### PR TITLE
feat: Object pooling system for phalanx-ecs

### DIFF
--- a/direct-strike-babylon-example/src/components/ProjectileComponent.ts
+++ b/direct-strike-babylon-example/src/components/ProjectileComponent.ts
@@ -34,7 +34,7 @@ export class ProjectileComponent implements IResettableComponent {
     remainingTicks?: number,
     sourceId?: number
   ) {
-    this.fpDirection = fpDirection ?? FPVector3.FromFloat(0, 0, 0);
+    this.fpDirection = fpDirection ?? FPVector3.Zero;
     this.fpSpeed = fpSpeed ?? FP._0;
     this.damage = damage ?? 0;
     this.remainingTicks = remainingTicks ?? 0;
@@ -43,7 +43,7 @@ export class ProjectileComponent implements IResettableComponent {
 
   /** IPoolable: reset to default state */
   reset(): void {
-    this.fpDirection = FPVector3.FromFloat(0, 0, 0);
+    this.fpDirection = FPVector3.Zero;
     this.fpSpeed = FP._0;
     this.damage = 0;
     this.remainingTicks = 0;

--- a/direct-strike-babylon-example/src/components/ProjectileComponent.ts
+++ b/direct-strike-babylon-example/src/components/ProjectileComponent.ts
@@ -1,39 +1,63 @@
-import type { IComponent } from './Component';
 import { ComponentType } from './Component';
+import type { IResettableComponent } from 'phalanx-ecs';
 import type { FPVector3 as FPVector3Type, FixedPoint } from 'phalanx-math';
+import { FP, FPVector3 } from 'phalanx-math';
 
 /**
  * ProjectileComponent - Data-only component for projectile state
  *
- * Stores all deterministic simulation state for a projectile entity.
- * Uses fixed-point math for direction and speed to ensure determinism.
- * Lifetime is tick-based (integer countdown) for exact cross-client synchronization.
+ * Implements IResettableComponent for pool support.
+ * Fields are mutable to allow reinitialize() without allocation.
  */
-export class ProjectileComponent implements IComponent {
+export class ProjectileComponent implements IResettableComponent {
   public readonly type = ComponentType.Projectile;
 
   /** Normalized direction of travel (fixed-point, deterministic) */
-  public readonly fpDirection: FPVector3Type;
+  public fpDirection: FPVector3Type;
 
   /** Movement speed per second (fixed-point, deterministic) */
-  public readonly fpSpeed: FixedPoint;
+  public fpSpeed: FixedPoint;
 
   /** Damage dealt on hit */
-  public readonly damage: number;
+  public damage: number;
 
   /** Remaining lifetime in simulation ticks (deterministic integer countdown) */
   public remainingTicks: number;
 
   /** Entity ID of the shooter (for friendly-fire prevention & event attribution) */
-  public readonly sourceId: number;
+  public sourceId: number;
 
   constructor(
+    fpDirection?: FPVector3Type,
+    fpSpeed?: FixedPoint,
+    damage?: number,
+    remainingTicks?: number,
+    sourceId?: number
+  ) {
+    this.fpDirection = fpDirection ?? FPVector3.FromFloat(0, 0, 0);
+    this.fpSpeed = fpSpeed ?? FP._0;
+    this.damage = damage ?? 0;
+    this.remainingTicks = remainingTicks ?? 0;
+    this.sourceId = sourceId ?? 0;
+  }
+
+  /** IPoolable: reset to default state */
+  reset(): void {
+    this.fpDirection = FPVector3.FromFloat(0, 0, 0);
+    this.fpSpeed = FP._0;
+    this.damage = 0;
+    this.remainingTicks = 0;
+    this.sourceId = 0;
+  }
+
+  /** IResettableComponent: reinitialize with new parameters */
+  reinitialize(
     fpDirection: FPVector3Type,
     fpSpeed: FixedPoint,
     damage: number,
     remainingTicks: number,
     sourceId: number
-  ) {
+  ): void {
     this.fpDirection = fpDirection;
     this.fpSpeed = fpSpeed;
     this.damage = damage;

--- a/direct-strike-babylon-example/src/components/TeamComponent.ts
+++ b/direct-strike-babylon-example/src/components/TeamComponent.ts
@@ -1,11 +1,13 @@
-import type { IComponent } from './Component';
 import { ComponentType } from './Component';
 import { TeamTag } from '../enums/TeamTag';
+import type { IResettableComponent } from 'phalanx-ecs';
 
 /**
  * TeamComponent - Defines team affiliation for an entity
+ *
+ * Implements IResettableComponent for pool support.
  */
-export class TeamComponent implements IComponent {
+export class TeamComponent implements IResettableComponent {
   public readonly type = ComponentType.Team;
 
   private _team: TeamTag;
@@ -19,6 +21,16 @@ export class TeamComponent implements IComponent {
   }
 
   public setTeam(team: TeamTag): void {
+    this._team = team;
+  }
+
+  /** IPoolable: reset to neutral */
+  public reset(): void {
+    this._team = TeamTag.Neutral;
+  }
+
+  /** IResettableComponent: reinitialize with new team */
+  public reinitialize(team: TeamTag): void {
     this._team = team;
   }
 

--- a/direct-strike-babylon-example/src/core/EntityCleanupService.ts
+++ b/direct-strike-babylon-example/src/core/EntityCleanupService.ts
@@ -1,4 +1,4 @@
-import type { EntityManager } from 'phalanx-ecs';
+import type { EntityManager, PoolManager } from 'phalanx-ecs';
 import type { EntityFactory } from './EntityFactory';
 
 /**
@@ -7,7 +7,7 @@ import type { EntityFactory } from './EntityFactory';
  * Responsible for:
  * - Removing destroyed entities from all systems
  * - Cleaning up ownership tracking
- * - Disposing entity resources
+ * - Releasing pooled entities back to pool or disposing non-pooled ones
  *
  * Note: HealthBarSystem and InterpolationSystem cleanup is automatic -
  * they query entities with their respective components and the components
@@ -16,27 +16,34 @@ import type { EntityFactory } from './EntityFactory';
 export class EntityCleanupService {
   private entityManager: EntityManager;
   private entityFactory: EntityFactory;
+  private pools: PoolManager | null;
 
   constructor(
     entityManager: EntityManager,
-    entityFactory: EntityFactory
+    entityFactory: EntityFactory,
+    pools: PoolManager | null = null
   ) {
     this.entityManager = entityManager;
     this.entityFactory = entityFactory;
+    this.pools = pools;
   }
 
   /**
-   * Remove destroyed entities from all systems
+   * Remove destroyed entities from all systems.
+   * Pooled entities (with _poolTypeKey) are released back to the pool.
+   * Non-pooled entities are disposed normally.
    */
   public cleanupDestroyedEntities(): void {
     const destroyed = this.entityManager.cleanupDestroyed();
 
     for (const entity of destroyed) {
       this.entityFactory.removeOwnership(entity.id);
-      // InterpolationComponent and HealthBarComponent cleanup is automatic -
-      // they are removed with the entity when disposed
 
-      entity.dispose();
+      if (entity._poolTypeKey && this.pools) {
+        this.pools.release(entity._poolTypeKey, entity);
+      } else {
+        entity.dispose();
+      }
     }
   }
 }

--- a/direct-strike-babylon-example/src/core/Game.ts
+++ b/direct-strike-babylon-example/src/core/Game.ts
@@ -1,6 +1,8 @@
 import { Engine, Scene } from '@babylonjs/core';
 import { GameWorld } from 'phalanx-ecs';
 import type { CommandsBatch } from 'phalanx-ecs';
+import { ProjectileEntity } from '../entities/ProjectileEntity';
+import { ProjectileComponent, TeamComponent } from '../components';
 import { LockstepManager } from './LockstepManager';
 import { EntityFactory } from './EntityFactory';
 import { UIManager } from './UIManager';
@@ -118,6 +120,18 @@ export class Game {
     this.world = new GameWorld({
       componentTypes: Object.values(ComponentType),
       tickFrameProvider: this.client,
+      pooling: {
+        entityTypes: {
+          'projectile': {
+            factory: () => new ProjectileEntity(),
+            pool: { initialSize: 50, maxSize: 200 },
+            components: [
+              { type: ComponentType.Projectile, factory: () => new ProjectileComponent() },
+              { type: ComponentType.Team, factory: () => new TeamComponent() },
+            ],
+          },
+        },
+      },
     });
 
     // Create scene manager (not a GameSystem, but needed by other systems)
@@ -178,6 +192,9 @@ export class Game {
 
     // Register systems and call init() on each
     this.world.registerSystems(tickSystems, frameSystems);
+
+    // Wire pool manager to ProjectileSystem
+    this.projectileSystem.setPoolManager(this.world.pools);
 
     this.setupResizeHandler();
   }
@@ -250,10 +267,11 @@ export class Game {
     // Phase 7: Create lockstep manager (needs all systems)
     this.lockstepManager = this.createLockstepManager();
 
-    // Phase 8: Create entity cleanup service
+    // Phase 8: Create entity cleanup service (pool-aware)
     this.entityCleanupService = new EntityCleanupService(
       this.world.entityManager,
-      this.entityFactory
+      this.entityFactory,
+      this.world.pools
     );
 
     // Phase 9: Create coordinators

--- a/direct-strike-babylon-example/src/entities/ProjectileEntity.ts
+++ b/direct-strike-babylon-example/src/entities/ProjectileEntity.ts
@@ -33,6 +33,9 @@ export class ProjectileEntity extends Entity implements IMeshEntity {
 
     if (!this.mesh) {
       this.mesh = this.createMesh(team);
+    } else {
+      // Update team colors on the existing material for reuse
+      this.applyTeamColors(this.mesh, team);
     }
 
     this.mesh.position.copyFrom(origin);
@@ -53,6 +56,15 @@ export class ProjectileEntity extends Entity implements IMeshEntity {
     );
 
     const material = new StandardMaterial('projectileMat', scene);
+    mesh.material = material;
+    this.applyTeamColors(mesh, team);
+
+    return mesh;
+  }
+
+  private applyTeamColors(mesh: Mesh, team: TeamTag): void {
+    const material = mesh.material as StandardMaterial;
+    if (!material) return;
     if (team === TeamTag.Team1) {
       material.diffuseColor = new Color3(0, 0.8, 1);
       material.emissiveColor = new Color3(0, 0.4, 0.5);
@@ -60,9 +72,6 @@ export class ProjectileEntity extends Entity implements IMeshEntity {
       material.diffuseColor = new Color3(1, 0.2, 0);
       material.emissiveColor = new Color3(0.5, 0.1, 0);
     }
-    mesh.material = material;
-
-    return mesh;
   }
 
   private orientToDirection(direction: Vector3): void {

--- a/direct-strike-babylon-example/src/entities/ProjectileEntity.ts
+++ b/direct-strike-babylon-example/src/entities/ProjectileEntity.ts
@@ -13,25 +13,35 @@ import type { IMeshEntity } from '../interfaces/IMeshEntity';
 /**
  * ProjectileEntity - ECS entity with laser beam mesh
  *
- * Extends Entity directly (not Unit) for lighter weight.
- * Implements IMeshEntity so InterpolationSystem can update its visual position.
- *
- * All simulation state lives in components (ProjectileComponent, TransformComponent, etc.).
- * This class only handles the visual mesh representation.
+ * Supports object pooling: no-arg constructor for pool factory,
+ * lazy mesh creation via initVisual(), reset() hides mesh but keeps it alive.
  */
 export class ProjectileEntity extends Entity implements IMeshEntity {
-  private scene: Scene;
-  private mesh: Mesh;
+  private scene: Scene | null = null;
+  private mesh: Mesh | null = null;
 
-  constructor(scene: Scene, origin: Vector3, direction: Vector3, team: TeamTag) {
+  constructor() {
     super();
+  }
+
+  /**
+   * Initialize or reposition the visual mesh.
+   * Creates mesh lazily on first call; repositions on subsequent calls.
+   */
+  public initVisual(scene: Scene, origin: Vector3, direction: Vector3, team: TeamTag): void {
     this.scene = scene;
-    this.mesh = this.createMesh(team);
+
+    if (!this.mesh) {
+      this.mesh = this.createMesh(team);
+    }
+
     this.mesh.position.copyFrom(origin);
     this.orientToDirection(direction);
+    this.mesh.setEnabled(true);
   }
 
   private createMesh(team: TeamTag): Mesh {
+    const scene = this.scene!;
     const mesh = MeshBuilder.CreateCylinder(
       'projectile',
       {
@@ -39,10 +49,10 @@ export class ProjectileEntity extends Entity implements IMeshEntity {
         diameter: 0.15,
         tessellation: 8,
       },
-      this.scene
+      scene
     );
 
-    const material = new StandardMaterial('projectileMat', this.scene);
+    const material = new StandardMaterial('projectileMat', scene);
     if (team === TeamTag.Team1) {
       material.diffuseColor = new Color3(0, 0.8, 1);
       material.emissiveColor = new Color3(0, 0.4, 0.5);
@@ -61,25 +71,43 @@ export class ProjectileEntity extends Entity implements IMeshEntity {
     const axis = Vector3.Cross(up, normalized);
 
     if (axis.length() > 0.001) {
-      this.mesh.rotationQuaternion = null;
-      this.mesh.rotation = Vector3.Zero();
+      this.mesh!.rotationQuaternion = null;
+      this.mesh!.rotation = Vector3.Zero();
 
-      const targetPos = this.mesh.position.add(normalized);
-      this.mesh.lookAt(targetPos);
-      this.mesh.rotation.x += Math.PI / 2;
+      const targetPos = this.mesh!.position.add(normalized);
+      this.mesh!.lookAt(targetPos);
+      this.mesh!.rotation.x += Math.PI / 2;
     }
   }
 
   public setVisualPosition(position: Vector3): void {
-    this.mesh.position.copyFrom(position);
+    if (this.mesh) {
+      this.mesh.position.copyFrom(position);
+    }
   }
 
   public getMesh(): Mesh | null {
     return this.mesh;
   }
 
+  /**
+   * Pool reset: hide mesh but don't dispose it.
+   */
+  public override reset(): void {
+    super.reset();
+    if (this.mesh) {
+      this.mesh.setEnabled(false);
+    }
+  }
+
+  /**
+   * Full disposal: dispose mesh and GPU resources.
+   */
   public override dispose(): void {
-    this.mesh.dispose();
+    if (this.mesh) {
+      this.mesh.dispose();
+      this.mesh = null;
+    }
     super.dispose();
   }
 }

--- a/direct-strike-babylon-example/src/systems/ProjectileSystem.ts
+++ b/direct-strike-babylon-example/src/systems/ProjectileSystem.ts
@@ -2,7 +2,7 @@ import { Vector3 } from '@babylonjs/core';
 import type { Scene } from '@babylonjs/core';
 import { ProjectileEntity } from '../entities/ProjectileEntity';
 import { ExplosionEffect } from '../effects/ExplosionEffect';
-import type { SystemContext, Entity } from 'phalanx-ecs';
+import type { SystemContext, Entity, PoolManager } from 'phalanx-ecs';
 import { GameSystem } from 'phalanx-ecs';
 import {
   ComponentType,
@@ -41,18 +41,13 @@ export interface ProjectileSpawnConfig {
 /**
  * ProjectileSystem - Manages all projectiles as ECS entities
  *
- * Projectiles are proper ECS entities with:
- * - ProjectileComponent: direction, speed, damage, lifetime, sourceId
- * - TeamComponent: team affiliation for collision filtering
- * - TransformComponent: authoritative fixed-point position (SoA-backed)
- * - InterpolationComponent: smooth visual movement between ticks
- *
- * Collision detection uses fixed-point squared distance for determinism.
- * Lifetime is tick-based (integer countdown) — fully deterministic.
- * Visual interpolation is handled automatically by InterpolationSystem.
+ * Supports object pooling: when world.pools has a 'projectile' pool registered,
+ * entities are acquired from the pool and template components are reinitialized
+ * instead of creating new instances.
  */
 export class ProjectileSystem extends GameSystem {
   private scene: Scene;
+  private pools: PoolManager | null = null;
 
   constructor(scene: Scene) {
     super();
@@ -62,6 +57,11 @@ export class ProjectileSystem extends GameSystem {
   public override init(context: SystemContext): void {
     super.init(context);
     this.setupEventListeners();
+  }
+
+  /** Set the pool manager reference (called by Game after world creation) */
+  public setPoolManager(pools: PoolManager | null): void {
+    this.pools = pools;
   }
 
   private setupEventListeners(): void {
@@ -90,19 +90,45 @@ export class ProjectileSystem extends GameSystem {
     const lifetimeSecs = config.lifetime ?? DEFAULT_PROJECTILE_LIFETIME_SECS;
     const remainingTicks = Math.round(lifetimeSecs * networkConfig.tickRate);
 
-    // Create entity with mesh
-    const entity = new ProjectileEntity(this.scene, origin, direction, config.team);
-
-    // Add components
     const fpDirection = FPVector3.Normalize(
       FPVector3.FromFloat(direction.x, direction.y, direction.z)
     );
     const fpSpeed = FP.FromFloat(speed);
-    entity.addComponent(
-      new ProjectileComponent(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId)
-    );
-    entity.addComponent(new TeamComponent(config.team));
 
+    let entity: ProjectileEntity;
+
+    if (this.pools) {
+      // Pool path: acquire from pool, reinitialize template components
+      entity = this.pools.acquire<ProjectileEntity>('projectile');
+      entity.initVisual(this.scene, origin, direction, config.team);
+
+      // Reinitialize template components (already attached during prewarm)
+      const projectileComp = entity.getComponent<ProjectileComponent>(ComponentType.Projectile);
+      if (projectileComp) {
+        projectileComp.reinitialize(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId);
+      } else {
+        entity.addComponent(
+          new ProjectileComponent(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId)
+        );
+      }
+
+      const teamComp = entity.getComponent<TeamComponent>(ComponentType.Team);
+      if (teamComp) {
+        teamComp.reinitialize(config.team);
+      } else {
+        entity.addComponent(new TeamComponent(config.team));
+      }
+    } else {
+      // Fallback: create new entity without pooling
+      entity = new ProjectileEntity();
+      entity.initVisual(this.scene, origin, direction, config.team);
+      entity.addComponent(
+        new ProjectileComponent(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId)
+      );
+      entity.addComponent(new TeamComponent(config.team));
+    }
+
+    // SoA components are always created new (data lives in typed arrays)
     const initialFpPos = FPVector3.FromFloat(origin.x, origin.y, origin.z);
     const transform = new TransformComponent(entity.id, initialFpPos);
     entity.addComponent(transform);

--- a/direct-strike-babylon-example/src/systems/ProjectileSystem.ts
+++ b/direct-strike-babylon-example/src/systems/ProjectileSystem.ts
@@ -102,22 +102,11 @@ export class ProjectileSystem extends GameSystem {
       entity = this.pools.acquire<ProjectileEntity>('projectile');
       entity.initVisual(this.scene, origin, direction, config.team);
 
-      // Reinitialize template components (already attached during prewarm)
-      const projectileComp = entity.getComponent<ProjectileComponent>(ComponentType.Projectile);
-      if (projectileComp) {
-        projectileComp.reinitialize(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId);
-      } else {
-        entity.addComponent(
-          new ProjectileComponent(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId)
-        );
-      }
-
-      const teamComp = entity.getComponent<TeamComponent>(ComponentType.Team);
-      if (teamComp) {
-        teamComp.reinitialize(config.team);
-      } else {
-        entity.addComponent(new TeamComponent(config.team));
-      }
+      // Template components are guaranteed to be attached after acquire
+      entity.getComponent<ProjectileComponent>(ComponentType.Projectile)!
+        .reinitialize(fpDirection, fpSpeed, config.damage, remainingTicks, config.sourceId);
+      entity.getComponent<TeamComponent>(ComponentType.Team)!
+        .reinitialize(config.team);
     } else {
       // Fallback: create new entity without pooling
       entity = new ProjectileEntity();

--- a/phalanx-ecs/src/Entity.ts
+++ b/phalanx-ecs/src/Entity.ts
@@ -1,4 +1,5 @@
 import type { IComponent } from './Component';
+import type { IPoolable } from './pool/IPoolable';
 
 let entityIdCounter = 0;
 
@@ -11,6 +12,14 @@ export function resetEntityIdCounter(): void {
 }
 
 /**
+ * Allocate and return the next sequential entity ID from the global counter.
+ * Used by EntityPool to assign fresh IDs on acquire.
+ */
+export function nextEntityId(): number {
+  return ++entityIdCounter;
+}
+
+/**
  * Base Entity class - Container for components
  * Uses composition over inheritance
  *
@@ -18,13 +27,46 @@ export function resetEntityIdCounter(): void {
  * Game-specific subclasses (e.g. Unit) can add mesh, position, and other
  * rendering-related properties.
  */
-export class Entity {
-  public readonly id: number;
+export class Entity implements IPoolable {
+  private _id: number;
   protected components: Map<symbol, IComponent> = new Map();
   private _isDestroyed: boolean = false;
 
+  /** Optional pool type key, set by PoolManager during acquire */
+  public _poolTypeKey?: string;
+
   constructor() {
-    this.id = ++entityIdCounter;
+    this._id = ++entityIdCounter;
+  }
+
+  /**
+   * Unique entity ID.
+   */
+  public get id(): number {
+    return this._id;
+  }
+
+  /**
+   * @internal Used by EntityPool to assign a new ID on acquire.
+   */
+  public _setId(id: number): void {
+    this._id = id;
+  }
+
+  /**
+   * @internal Used by EntityPool to clear destroyed flag on acquire.
+   */
+  public _revive(): void {
+    this._isDestroyed = false;
+  }
+
+  /**
+   * IPoolable: Reset entity to clean state for pool reuse.
+   * Clears destroyed flag and all components.
+   */
+  public reset(): void {
+    this._isDestroyed = false;
+    this.components.clear();
   }
 
   /**

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -61,6 +61,27 @@ export interface GameWorldHooks {
  *
  * Replaces the manual wiring of SystemRegistry + TickFrameManager + NetworkCoordinator
  * with a single entry point. Completely renderer-agnostic.
+ *
+ * Single-player usage:
+ * ```ts
+ * const world = new GameWorld({ componentTypes });
+ * world.registerSystems(tickSystems, frameSystems);
+ * world.start({
+ *   afterFrame(alpha, dt) { scene.render(); },
+ * });
+ * ```
+ *
+ * Multiplayer usage (with PhalanxClient as tickFrameProvider):
+ * ```ts
+ * const world = new GameWorld({ componentTypes, tickFrameProvider: client });
+ * world.registerSystems(tickSystems, frameSystems);
+ * world.start({
+ *   beforeTick(tick, commands) { lockstepManager.processTick(tick, commands); },
+ *   afterTick(tick) { interpolationSystem.captureCurrentPositions(); },
+ *   beforeFrame(alpha, dt) { cameraController.update(dt); },
+ *   afterFrame(alpha, dt) { interpolationSystem.interpolate(alpha); scene.render(); },
+ * });
+ * ```
  */
 export class GameWorld {
   private readonly systemRegistry: SystemRegistry;
@@ -123,13 +144,24 @@ export class GameWorld {
 
   /**
    * Pause the game world.
+   *
+   * If the provider implements requestPause (both TickFrameManager and
+   * PhalanxClient do), the request is forwarded to the provider. The world
+   * will actually freeze only when the provider fires the onPause callback —
+   * this ensures multiplayer clients all freeze at the same deterministic
+   * point after server confirmation, while single-player pauses immediately.
+   *
+   * If the provider does NOT implement requestPause, the world is paused
+   * directly as a fallback.
    */
   public pause(): void {
     if (this._paused) return;
 
     if (this.provider.requestPause) {
+      // Delegate to provider — _paused is set in the onPause callback
       this.provider.requestPause();
     } else {
+      // Fallback for providers that don't support pause
       this._paused = true;
       this.systemRegistry.eventBus.emit(GameWorldEvents.PAUSED, {});
     }
@@ -137,13 +169,18 @@ export class GameWorld {
 
   /**
    * Resume the game world after a pause.
+   *
+   * Same semantics as pause(): delegates to the provider when possible,
+   * and the actual resume happens in the onResume callback.
    */
   public resume(): void {
     if (!this._paused) return;
 
     if (this.provider.requestResume) {
+      // Delegate to provider — _paused is cleared in the onResume callback
       this.provider.requestResume();
     } else {
+      // Fallback for providers that don't support resume
       this._paused = false;
       this.systemRegistry.eventBus.emit(GameWorldEvents.RESUMED, {});
     }
@@ -217,6 +254,14 @@ export class GameWorld {
 
   /**
    * Start the tick/frame loop.
+   *
+   * The tick pipeline:  hooks.beforeTick → processAllTicks → hooks.afterTick
+   * The frame pipeline: hooks.beforeFrame → updateAll → hooks.afterFrame
+   *
+   * Rendering is NOT called automatically. The consumer should call their
+   * renderer (e.g. scene.render()) in the afterFrame hook.
+   *
+   * @param hooks - Optional lifecycle hooks to inject custom logic around the core steps.
    */
   public start(hooks?: GameWorldHooks): void {
     // Prewarm pools if configured

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -1,6 +1,8 @@
 import { SystemRegistry } from './SystemRegistry';
 import { TickFrameManager } from './TickFrameManager';
 import { SoAComponent } from './SoAComponent';
+import { PoolManager } from './pool/PoolManager';
+import type { PoolingConfig } from './pool/types';
 import type { ITickFrameProvider, Unsubscribe } from './ITickFrameProvider';
 import type { EventBus } from './EventBus';
 import type { EntityManager } from './EntityManager';
@@ -30,6 +32,8 @@ export interface GameWorldConfig {
   maxFrameTime?: number;
   /** External tick/frame provider (e.g. PhalanxClient for multiplayer). If omitted, an internal TickFrameManager is created. */
   tickFrameProvider?: ITickFrameProvider;
+  /** Object pooling configuration. If omitted, pooling is disabled. */
+  pooling?: PoolingConfig;
 }
 
 /**
@@ -57,32 +61,13 @@ export interface GameWorldHooks {
  *
  * Replaces the manual wiring of SystemRegistry + TickFrameManager + NetworkCoordinator
  * with a single entry point. Completely renderer-agnostic.
- *
- * Single-player usage:
- * ```ts
- * const world = new GameWorld({ componentTypes });
- * world.registerSystems(tickSystems, frameSystems);
- * world.start({
- *   afterFrame(alpha, dt) { scene.render(); },
- * });
- * ```
- *
- * Multiplayer usage (with PhalanxClient as tickFrameProvider):
- * ```ts
- * const world = new GameWorld({ componentTypes, tickFrameProvider: client });
- * world.registerSystems(tickSystems, frameSystems);
- * world.start({
- *   beforeTick(tick, commands) { lockstepManager.processTick(tick, commands); },
- *   afterTick(tick) { interpolationSystem.captureCurrentPositions(); },
- *   beforeFrame(alpha, dt) { cameraController.update(dt); },
- *   afterFrame(alpha, dt) { interpolationSystem.interpolate(alpha); scene.render(); },
- * });
- * ```
  */
 export class GameWorld {
   private readonly systemRegistry: SystemRegistry;
   private readonly provider: ITickFrameProvider;
   private readonly ownsProvider: boolean;
+  private readonly _pools: PoolManager | null;
+  private readonly _poolingConfig: PoolingConfig | undefined;
 
   // Unsubscribe handles for tick/frame
   private unsubscribeTick: Unsubscribe | null = null;
@@ -103,6 +88,18 @@ export class GameWorld {
 
     // Set SoAComponent context so SoA-backed components can resolve stores
     SoAComponent.useEntityManager(this.systemRegistry.entityManager);
+
+    // Setup pooling if configured
+    if (config.pooling) {
+      this._poolingConfig = config.pooling;
+      this._pools = new PoolManager();
+      for (const [typeKey, typeConfig] of Object.entries(config.pooling.entityTypes)) {
+        this._pools.registerEntityType(typeKey, typeConfig);
+      }
+    } else {
+      this._poolingConfig = undefined;
+      this._pools = null;
+    }
 
     // Use external provider or create internal TickFrameManager
     if (config.tickFrameProvider) {
@@ -126,24 +123,13 @@ export class GameWorld {
 
   /**
    * Pause the game world.
-   *
-   * If the provider implements requestPause (both TickFrameManager and
-   * PhalanxClient do), the request is forwarded to the provider. The world
-   * will actually freeze only when the provider fires the onPause callback —
-   * this ensures multiplayer clients all freeze at the same deterministic
-   * point after server confirmation, while single-player pauses immediately.
-   *
-   * If the provider does NOT implement requestPause, the world is paused
-   * directly as a fallback.
    */
   public pause(): void {
     if (this._paused) return;
 
     if (this.provider.requestPause) {
-      // Delegate to provider — _paused is set in the onPause callback
       this.provider.requestPause();
     } else {
-      // Fallback for providers that don't support pause
       this._paused = true;
       this.systemRegistry.eventBus.emit(GameWorldEvents.PAUSED, {});
     }
@@ -151,18 +137,13 @@ export class GameWorld {
 
   /**
    * Resume the game world after a pause.
-   *
-   * Same semantics as pause(): delegates to the provider when possible,
-   * and the actual resume happens in the onResume callback.
    */
   public resume(): void {
     if (!this._paused) return;
 
     if (this.provider.requestResume) {
-      // Delegate to provider — _paused is cleared in the onResume callback
       this.provider.requestResume();
     } else {
-      // Fallback for providers that don't support resume
       this._paused = false;
       this.systemRegistry.eventBus.emit(GameWorldEvents.RESUMED, {});
     }
@@ -178,6 +159,11 @@ export class GameWorld {
   /** Entity manager */
   public get entityManager(): EntityManager {
     return this.systemRegistry.entityManager;
+  }
+
+  /** Pool manager. null if pooling is not configured. */
+  public get pools(): PoolManager | null {
+    return this._pools;
   }
 
   /** System context (for advanced use) */
@@ -231,16 +217,13 @@ export class GameWorld {
 
   /**
    * Start the tick/frame loop.
-   *
-   * The tick pipeline:  hooks.beforeTick → processAllTicks → hooks.afterTick
-   * The frame pipeline: hooks.beforeFrame → updateAll → hooks.afterFrame
-   *
-   * Rendering is NOT called automatically. The consumer should call their
-   * renderer (e.g. scene.render()) in the afterFrame hook.
-   *
-   * @param hooks - Optional lifecycle hooks to inject custom logic around the core steps.
    */
   public start(hooks?: GameWorldHooks): void {
+    // Prewarm pools if configured
+    if (this._pools && this._poolingConfig?.autoPrewarm !== false) {
+      this._pools.prewarmAll();
+    }
+
     // Subscribe to provider pause/resume signals
     if (this.provider.onPause) {
       this.unsubscribePause = this.provider.onPause(() => {
@@ -304,10 +287,13 @@ export class GameWorld {
   }
 
   /**
-   * Full cleanup: stop loops then dispose all systems.
+   * Full cleanup: stop loops, drain pools, then dispose all systems.
    */
   public dispose(): void {
     this.stop();
+    if (this._pools) {
+      this._pools.drainAll();
+    }
     this.systemRegistry.dispose();
     SoAComponent.resetContext();
   }

--- a/phalanx-ecs/src/index.ts
+++ b/phalanx-ecs/src/index.ts
@@ -17,9 +17,26 @@ export { GameWorld, GameWorldEvents } from './GameWorld';
 export type { GameWorldConfig, GameWorldHooks } from './GameWorld';
 
 // Entity and Component
-export { Entity, resetEntityIdCounter } from './Entity';
+export { Entity, resetEntityIdCounter, nextEntityId } from './Entity';
 export { IComponent, createComponentTypeRegistry } from './Component';
 export type { IComponent as Component } from './Component';
+
+// Object Pooling
+export {
+  ObjectPool,
+  EntityPool,
+  PoolManager,
+} from './pool';
+export type {
+  IPoolable,
+  IResettableComponent,
+  PoolConfig,
+  PoolStats,
+  ComponentTemplate,
+  EntityPoolConfig,
+  EntityTypeConfig,
+  PoolingConfig,
+} from './pool';
 
 // SoA (Structure-of-Arrays) high-performance storage
 export { SoAComponentStore } from './SoAComponentStore';

--- a/phalanx-ecs/src/pool/EntityPool.ts
+++ b/phalanx-ecs/src/pool/EntityPool.ts
@@ -1,6 +1,7 @@
 import type { Entity } from '../Entity';
 import { nextEntityId } from '../Entity';
-import type { EntityPoolConfig, PoolStats, ComponentTemplate } from './types';
+import type { EntityPoolConfig, PoolStats, ComponentTemplate, ResolvedPoolConfig } from './types';
+import { resolvePoolConfig } from './types';
 
 /**
  * Entity-specific pool with component template support.
@@ -10,7 +11,7 @@ export class EntityPool<T extends Entity = Entity> {
   private readonly available: T[] = [];
   private readonly entityFactory: () => T;
   private readonly componentTemplates: ComponentTemplate[];
-  private readonly maxSize: number;
+  private readonly config: ResolvedPoolConfig;
 
   private _totalCreated: number = 0;
   private _acquireCount: number = 0;
@@ -20,7 +21,7 @@ export class EntityPool<T extends Entity = Entity> {
   constructor(entityFactory: () => T, config?: EntityPoolConfig) {
     this.entityFactory = entityFactory;
     this.componentTemplates = config?.componentTemplates ?? [];
-    this.maxSize = config?.maxSize ?? 0;
+    this.config = resolvePoolConfig(config);
   }
 
   /**
@@ -36,12 +37,36 @@ export class EntityPool<T extends Entity = Entity> {
       entity = this.available.pop()!;
     } else {
       this._missCount++;
-      entity = this.createEntity();
+
+      if (this.config.growthStrategy === 'grow') {
+        this.growBatch();
+      }
+
+      if (this.available.length > 0) {
+        entity = this.available.pop()!;
+      } else {
+        entity = this.createEntity();
+      }
     }
 
     // Assign new ID and revive
     entity._setId(nextEntityId());
     entity._revive();
+
+    // For pool hits: template components survived from release, reset them.
+    // For misses: template components were just created in createEntity(), also reset them.
+    for (const template of this.componentTemplates) {
+      let comp = entity.getComponent(template.type);
+      if (!comp) {
+        // Component was removed somehow - recreate from template
+        comp = template.factory();
+        entity.addComponent(comp);
+        this._totalCreated++;
+      }
+      if ('reset' in comp && typeof comp.reset === 'function') {
+        (comp as any).reset();
+      }
+    }
 
     return entity;
   }
@@ -49,18 +74,52 @@ export class EntityPool<T extends Entity = Entity> {
   /** Return an entity to the pool. Calls reset(). */
   release(entity: T): void {
     this._releaseCount++;
-    entity.reset();
 
-    if (this.maxSize === 0 || this.available.length < this.maxSize) {
-      this.available.push(entity);
+    if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) {
+      return; // Pool is full — discard
     }
+
+    // Save template components before reset clears the map
+    const saved: any[] = [];
+    for (const template of this.componentTemplates) {
+      const comp = entity.getComponent(template.type);
+      if (comp) saved.push(comp);
+    }
+
+    entity.reset(); // clears component map
+
+    // Re-attach template components (reset them too)
+    for (const comp of saved) {
+      if ('reset' in comp && typeof comp.reset === 'function') {
+        comp.reset();
+      }
+      entity.addComponent(comp);
+    }
+
+    this.available.push(entity);
   }
 
   /** Pre-allocate entities with template components. */
   prewarm(count: number): void {
     const toCreate = count - this.available.length;
     for (let i = 0; i < toCreate; i++) {
+      if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) {
+        break;
+      }
       const entity = this.createEntity();
+      entity.reset();
+      this.available.push(entity);
+    }
+  }
+
+  private growBatch(): void {
+    const batchSize = this.config.growthBatchSize;
+    for (let i = 0; i < batchSize; i++) {
+      if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) {
+        break;
+      }
+      const entity = this.createEntity();
+      entity.reset();
       this.available.push(entity);
     }
   }

--- a/phalanx-ecs/src/pool/EntityPool.ts
+++ b/phalanx-ecs/src/pool/EntityPool.ts
@@ -1,0 +1,98 @@
+import type { Entity } from '../Entity';
+import { nextEntityId } from '../Entity';
+import type { EntityPoolConfig, PoolStats, ComponentTemplate } from './types';
+
+/**
+ * Entity-specific pool with component template support.
+ * Manages entity lifecycle: ID assignment, revive, and component templates.
+ */
+export class EntityPool<T extends Entity = Entity> {
+  private readonly available: T[] = [];
+  private readonly entityFactory: () => T;
+  private readonly componentTemplates: ComponentTemplate[];
+  private readonly maxSize: number;
+
+  private _totalCreated: number = 0;
+  private _acquireCount: number = 0;
+  private _releaseCount: number = 0;
+  private _missCount: number = 0;
+
+  constructor(entityFactory: () => T, config?: EntityPoolConfig) {
+    this.entityFactory = entityFactory;
+    this.componentTemplates = config?.componentTemplates ?? [];
+    this.maxSize = config?.maxSize ?? 0;
+  }
+
+  /**
+   * Get an entity from the pool.
+   * Assigns a new ID, revives, and returns a ready-to-use entity.
+   */
+  acquire(): T {
+    this._acquireCount++;
+
+    let entity: T;
+
+    if (this.available.length > 0) {
+      entity = this.available.pop()!;
+    } else {
+      this._missCount++;
+      entity = this.createEntity();
+    }
+
+    // Assign new ID and revive
+    entity._setId(nextEntityId());
+    entity._revive();
+
+    return entity;
+  }
+
+  /** Return an entity to the pool. Calls reset(). */
+  release(entity: T): void {
+    this._releaseCount++;
+    entity.reset();
+
+    if (this.maxSize === 0 || this.available.length < this.maxSize) {
+      this.available.push(entity);
+    }
+  }
+
+  /** Pre-allocate entities with template components. */
+  prewarm(count: number): void {
+    const toCreate = count - this.available.length;
+    for (let i = 0; i < toCreate; i++) {
+      const entity = this.createEntity();
+      this.available.push(entity);
+    }
+  }
+
+  /** Clear all pooled entities. */
+  drain(): void {
+    this.available.length = 0;
+  }
+
+  get availableCount(): number {
+    return this.available.length;
+  }
+
+  get stats(): PoolStats {
+    return {
+      available: this.available.length,
+      totalCreated: this._totalCreated,
+      acquireCount: this._acquireCount,
+      releaseCount: this._releaseCount,
+      missCount: this._missCount,
+    };
+  }
+
+  private createEntity(): T {
+    const entity = this.entityFactory();
+    this._totalCreated++;
+
+    // Attach template components
+    for (const template of this.componentTemplates) {
+      entity.addComponent(template.factory());
+    }
+
+    return entity;
+  }
+}

--- a/phalanx-ecs/src/pool/EntityPool.ts
+++ b/phalanx-ecs/src/pool/EntityPool.ts
@@ -1,5 +1,7 @@
+import type { IComponent } from '../Component';
 import type { Entity } from '../Entity';
 import { nextEntityId } from '../Entity';
+import type { IPoolable } from './IPoolable';
 import type { EntityPoolConfig, PoolStats, ComponentTemplate, ResolvedPoolConfig } from './types';
 import { resolvePoolConfig } from './types';
 
@@ -32,9 +34,11 @@ export class EntityPool<T extends Entity = Entity> {
     this._acquireCount++;
 
     let entity: T;
+    let fromPool = false;
 
     if (this.available.length > 0) {
       entity = this.available.pop()!;
+      fromPool = true;
     } else {
       this._missCount++;
 
@@ -44,28 +48,28 @@ export class EntityPool<T extends Entity = Entity> {
 
       if (this.available.length > 0) {
         entity = this.available.pop()!;
+        fromPool = true;
       } else {
         entity = this.createEntity();
       }
     }
 
-    // Assign new ID and revive
-    entity._setId(nextEntityId());
-    entity._revive();
+    if (fromPool) {
+      // Reused entity — assign fresh ID and revive
+      entity._setId(nextEntityId());
+      entity._revive();
+    }
+    // For fresh entities: constructor already assigned ID, _isDestroyed is false
 
-    // For pool hits: template components survived from release, reset them.
-    // For misses: template components were just created in createEntity(), also reset them.
+    // Reset template components
     for (const template of this.componentTemplates) {
-      let comp = entity.getComponent(template.type);
-      if (!comp) {
-        // Component was removed somehow - recreate from template
-        comp = template.factory();
-        entity.addComponent(comp);
-        this._totalCreated++;
+      const comp = entity.getComponent(template.type);
+      if (comp) {
+        if ('reset' in comp && typeof (comp as IPoolable).reset === 'function') {
+          (comp as IPoolable).reset();
+        }
       }
-      if ('reset' in comp && typeof comp.reset === 'function') {
-        (comp as any).reset();
-      }
+      // No need to recreate — templates are preserved via prepareForPool/createEntity
     }
 
     return entity;
@@ -76,26 +80,11 @@ export class EntityPool<T extends Entity = Entity> {
     this._releaseCount++;
 
     if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) {
-      return; // Pool is full — discard
+      entity.dispose(); // Clean up resources for entities that won't be pooled
+      return;
     }
 
-    // Save template components before reset clears the map
-    const saved: any[] = [];
-    for (const template of this.componentTemplates) {
-      const comp = entity.getComponent(template.type);
-      if (comp) saved.push(comp);
-    }
-
-    entity.reset(); // clears component map
-
-    // Re-attach template components (reset them too)
-    for (const comp of saved) {
-      if ('reset' in comp && typeof comp.reset === 'function') {
-        comp.reset();
-      }
-      entity.addComponent(comp);
-    }
-
+    this.prepareForPool(entity);
     this.available.push(entity);
   }
 
@@ -107,7 +96,7 @@ export class EntityPool<T extends Entity = Entity> {
         break;
       }
       const entity = this.createEntity();
-      entity.reset();
+      this.prepareForPool(entity);
       this.available.push(entity);
     }
   }
@@ -119,8 +108,26 @@ export class EntityPool<T extends Entity = Entity> {
         break;
       }
       const entity = this.createEntity();
-      entity.reset();
+      this.prepareForPool(entity);
       this.available.push(entity);
+    }
+  }
+
+  /** Prepare an entity for storage in the pool — reset while preserving templates. */
+  private prepareForPool(entity: T): void {
+    const savedComps: IComponent[] = [];
+    for (const template of this.componentTemplates) {
+      const comp = entity.getComponent(template.type);
+      if (comp) savedComps.push(comp);
+    }
+
+    entity.reset();
+
+    for (const comp of savedComps) {
+      if ('reset' in comp && typeof (comp as IPoolable).reset === 'function') {
+        (comp as IPoolable).reset();
+      }
+      entity.addComponent(comp);
     }
   }
 

--- a/phalanx-ecs/src/pool/IPoolable.ts
+++ b/phalanx-ecs/src/pool/IPoolable.ts
@@ -1,3 +1,12 @@
+/**
+ * Contract for objects that support reuse via an object pool.
+ * Entity and Component classes implement this interface to enable pooling.
+ */
 export interface IPoolable {
+  /**
+   * Reset the object to a clean initial state.
+   * Called when returning the object to the pool and before handing it out.
+   * Must NOT allocate new objects — only reuse existing fields.
+   */
   reset(): void;
 }

--- a/phalanx-ecs/src/pool/IPoolable.ts
+++ b/phalanx-ecs/src/pool/IPoolable.ts
@@ -1,0 +1,3 @@
+export interface IPoolable {
+  reset(): void;
+}

--- a/phalanx-ecs/src/pool/IResettableComponent.ts
+++ b/phalanx-ecs/src/pool/IResettableComponent.ts
@@ -1,6 +1,14 @@
 import type { IComponent } from '../Component';
 import type { IPoolable } from './IPoolable';
 
+/**
+ * Extended contract for components that support pooling with re-initialization.
+ * Components implement this to allow reset + reinitialize without allocation.
+ */
 export interface IResettableComponent extends IComponent, IPoolable {
-  reinitialize(...args: any[]): void;
+  /**
+   * Reset and re-initialize the component with new parameter values.
+   * The argument types depend on the concrete component.
+   */
+  reinitialize(...args: unknown[]): void;
 }

--- a/phalanx-ecs/src/pool/IResettableComponent.ts
+++ b/phalanx-ecs/src/pool/IResettableComponent.ts
@@ -1,0 +1,6 @@
+import type { IComponent } from '../Component';
+import type { IPoolable } from './IPoolable';
+
+export interface IResettableComponent extends IComponent, IPoolable {
+  reinitialize(...args: any[]): void;
+}

--- a/phalanx-ecs/src/pool/ObjectPool.ts
+++ b/phalanx-ecs/src/pool/ObjectPool.ts
@@ -1,0 +1,94 @@
+import type { IPoolable } from './IPoolable';
+import type { PoolConfig, PoolStats } from './types';
+
+/**
+ * Generic object pool for any IPoolable type.
+ * Uses a LIFO stack for cache-friendly reuse.
+ */
+export class ObjectPool<T extends IPoolable> {
+  private readonly available: T[] = [];
+  private readonly factory: () => T;
+  private readonly config: Required<PoolConfig>;
+
+  private _totalCreated: number = 0;
+  private _acquireCount: number = 0;
+  private _releaseCount: number = 0;
+  private _missCount: number = 0;
+
+  constructor(factory: () => T, config?: PoolConfig) {
+    this.factory = factory;
+    this.config = {
+      initialSize: config?.initialSize ?? 0,
+      maxSize: config?.maxSize ?? 0,
+      growthStrategy: config?.growthStrategy ?? 'create',
+      growthBatchSize: config?.growthBatchSize ?? 8,
+    };
+  }
+
+  /** Take an object from the pool, or create a new one. */
+  acquire(): T {
+    this._acquireCount++;
+
+    if (this.available.length > 0) {
+      return this.available.pop()!;
+    }
+
+    // Pool miss
+    this._missCount++;
+
+    if (this.config.growthStrategy === 'grow') {
+      // Batch create, push all but one to available
+      const batch = this.config.growthBatchSize;
+      for (let i = 1; i < batch; i++) {
+        this.available.push(this.factory());
+        this._totalCreated++;
+      }
+    }
+
+    this._totalCreated++;
+    return this.factory();
+  }
+
+  /** Return an object to the pool. Calls reset(). */
+  release(obj: T): void {
+    this._releaseCount++;
+    obj.reset();
+
+    // Respect maxSize (0 = unlimited)
+    if (this.config.maxSize === 0 || this.available.length < this.config.maxSize) {
+      this.available.push(obj);
+    }
+  }
+
+  /** Pre-allocate objects into the pool. */
+  prewarm(count: number): void {
+    const toCreate = count - this.available.length;
+    for (let i = 0; i < toCreate; i++) {
+      this.available.push(this.factory());
+      this._totalCreated++;
+    }
+  }
+
+  /** Clear all pooled objects. */
+  drain(): void {
+    this.available.length = 0;
+  }
+
+  get availableCount(): number {
+    return this.available.length;
+  }
+
+  get totalCreated(): number {
+    return this._totalCreated;
+  }
+
+  get stats(): PoolStats {
+    return {
+      available: this.available.length,
+      totalCreated: this._totalCreated,
+      acquireCount: this._acquireCount,
+      releaseCount: this._releaseCount,
+      missCount: this._missCount,
+    };
+  }
+}

--- a/phalanx-ecs/src/pool/ObjectPool.ts
+++ b/phalanx-ecs/src/pool/ObjectPool.ts
@@ -25,24 +25,33 @@ export class ObjectPool<T extends IPoolable> {
   acquire(): T {
     this._acquireCount++;
 
-    if (this.available.length > 0) {
-      return this.available.pop()!;
-    }
+    if (this.available.length === 0) {
+      // Pool miss
+      this._missCount++;
 
-    // Pool miss
-    this._missCount++;
+      if (this.config.growthStrategy === 'grow') {
+        // Batch create with maxSize respect
+        const batch = this.config.growthBatchSize;
+        for (let i = 0; i < batch; i++) {
+          if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) break;
+          const obj = this.factory();
+          obj.reset();
+          this._totalCreated++;
+          this.available.push(obj);
+        }
+      }
 
-    if (this.config.growthStrategy === 'grow') {
-      // Batch create, push all but one to available
-      const batch = this.config.growthBatchSize;
-      for (let i = 1; i < batch; i++) {
-        this.available.push(this.factory());
+      if (this.available.length === 0) {
         this._totalCreated++;
+        const obj = this.factory();
+        obj.reset();
+        return obj;
       }
     }
 
-    this._totalCreated++;
-    return this.factory();
+    const obj = this.available.pop()!;
+    obj.reset();
+    return obj;
   }
 
   /** Return an object to the pool. Calls reset(). */
@@ -60,8 +69,11 @@ export class ObjectPool<T extends IPoolable> {
   prewarm(count: number): void {
     const toCreate = count - this.available.length;
     for (let i = 0; i < toCreate; i++) {
-      this.available.push(this.factory());
+      if (this.config.maxSize > 0 && this.available.length >= this.config.maxSize) break;
+      const obj = this.factory();
+      obj.reset();
       this._totalCreated++;
+      this.available.push(obj);
     }
   }
 

--- a/phalanx-ecs/src/pool/ObjectPool.ts
+++ b/phalanx-ecs/src/pool/ObjectPool.ts
@@ -1,5 +1,6 @@
 import type { IPoolable } from './IPoolable';
-import type { PoolConfig, PoolStats } from './types';
+import type { PoolConfig, PoolStats, ResolvedPoolConfig } from './types';
+import { resolvePoolConfig } from './types';
 
 /**
  * Generic object pool for any IPoolable type.
@@ -8,7 +9,7 @@ import type { PoolConfig, PoolStats } from './types';
 export class ObjectPool<T extends IPoolable> {
   private readonly available: T[] = [];
   private readonly factory: () => T;
-  private readonly config: Required<PoolConfig>;
+  private readonly config: ResolvedPoolConfig;
 
   private _totalCreated: number = 0;
   private _acquireCount: number = 0;
@@ -17,12 +18,7 @@ export class ObjectPool<T extends IPoolable> {
 
   constructor(factory: () => T, config?: PoolConfig) {
     this.factory = factory;
-    this.config = {
-      initialSize: config?.initialSize ?? 0,
-      maxSize: config?.maxSize ?? 0,
-      growthStrategy: config?.growthStrategy ?? 'create',
-      growthBatchSize: config?.growthBatchSize ?? 8,
-    };
+    this.config = resolvePoolConfig(config);
   }
 
   /** Take an object from the pool, or create a new one. */

--- a/phalanx-ecs/src/pool/PoolManager.ts
+++ b/phalanx-ecs/src/pool/PoolManager.ts
@@ -1,0 +1,99 @@
+import type { Entity } from '../Entity';
+import { EntityPool } from './EntityPool';
+import type { EntityTypeConfig, PoolStats } from './types';
+
+/**
+ * Central manager for entity pools.
+ * One PoolManager per GameWorld.
+ */
+export class PoolManager {
+  private readonly pools: Map<string, EntityPool<any>> = new Map();
+  private readonly initialSizes: Map<string, number> = new Map();
+
+  /**
+   * Register an entity type for pooling.
+   */
+  registerEntityType<T extends Entity>(
+    typeKey: string,
+    config: EntityTypeConfig<T>
+  ): void {
+    if (this.pools.has(typeKey)) {
+      throw new Error(`Pool '${typeKey}' is already registered`);
+    }
+
+    const pool = new EntityPool<T>(config.factory, {
+      ...config.pool,
+      componentTemplates: config.components,
+    });
+
+    this.pools.set(typeKey, pool);
+    this.initialSizes.set(typeKey, config.pool?.initialSize ?? 0);
+  }
+
+  /**
+   * Acquire an entity from the named pool.
+   * Sets _poolTypeKey on the entity for later release.
+   */
+  acquire<T extends Entity>(typeKey: string): T {
+    const pool = this.pools.get(typeKey);
+    if (!pool) {
+      throw new Error(`Pool '${typeKey}' is not registered`);
+    }
+
+    const entity = pool.acquire() as T;
+    entity._poolTypeKey = typeKey;
+    return entity;
+  }
+
+  /** Release an entity back to its pool. */
+  release(typeKey: string, entity: Entity): void {
+    const pool = this.pools.get(typeKey);
+    if (!pool) {
+      throw new Error(`Pool '${typeKey}' is not registered`);
+    }
+
+    pool.release(entity);
+  }
+
+  /** Prewarm all registered pools using their configured initialSize. */
+  prewarmAll(): void {
+    for (const [typeKey, initialSize] of this.initialSizes) {
+      if (initialSize > 0) {
+        const pool = this.pools.get(typeKey);
+        if (pool) {
+          pool.prewarm(initialSize);
+        }
+      }
+    }
+  }
+
+  /** Prewarm a specific pool to the given count. */
+  prewarm(typeKey: string, count: number): void {
+    const pool = this.pools.get(typeKey);
+    if (!pool) {
+      throw new Error(`Pool '${typeKey}' is not registered`);
+    }
+    pool.prewarm(count);
+  }
+
+  /** Drain all pools. */
+  drainAll(): void {
+    for (const pool of this.pools.values()) {
+      pool.drain();
+    }
+  }
+
+  /** Get stats for all pools. */
+  getStats(): Map<string, PoolStats> {
+    const result = new Map<string, PoolStats>();
+    for (const [key, pool] of this.pools) {
+      result.set(key, pool.stats);
+    }
+    return result;
+  }
+
+  /** Get stats for a specific pool. */
+  getPoolStats(typeKey: string): PoolStats | undefined {
+    return this.pools.get(typeKey)?.stats;
+  }
+}

--- a/phalanx-ecs/src/pool/PoolManager.ts
+++ b/phalanx-ecs/src/pool/PoolManager.ts
@@ -7,7 +7,7 @@ import type { EntityTypeConfig, PoolStats } from './types';
  * One PoolManager per GameWorld.
  */
 export class PoolManager {
-  private readonly pools: Map<string, EntityPool<any>> = new Map();
+  private readonly pools: Map<string, EntityPool<Entity>> = new Map();
   private readonly initialSizes: Map<string, number> = new Map();
 
   /**

--- a/phalanx-ecs/src/pool/index.ts
+++ b/phalanx-ecs/src/pool/index.ts
@@ -1,0 +1,13 @@
+export type { IPoolable } from './IPoolable';
+export type { IResettableComponent } from './IResettableComponent';
+export type {
+  PoolConfig,
+  PoolStats,
+  ComponentTemplate,
+  EntityPoolConfig,
+  EntityTypeConfig,
+  PoolingConfig,
+} from './types';
+export { ObjectPool } from './ObjectPool';
+export { EntityPool } from './EntityPool';
+export { PoolManager } from './PoolManager';

--- a/phalanx-ecs/src/pool/index.ts
+++ b/phalanx-ecs/src/pool/index.ts
@@ -7,7 +7,9 @@ export type {
   EntityPoolConfig,
   EntityTypeConfig,
   PoolingConfig,
+  ResolvedPoolConfig,
 } from './types';
+export { resolvePoolConfig } from './types';
 export { ObjectPool } from './ObjectPool';
 export { EntityPool } from './EntityPool';
 export { PoolManager } from './PoolManager';

--- a/phalanx-ecs/src/pool/types.ts
+++ b/phalanx-ecs/src/pool/types.ts
@@ -1,0 +1,42 @@
+import type { Entity } from '../Entity';
+import type { IResettableComponent } from './IResettableComponent';
+
+export interface PoolConfig {
+  /** Initial number of pre-allocated objects. Default: 0 */
+  initialSize?: number;
+  /** Maximum pool size. 0 = unlimited. Default: 0 */
+  maxSize?: number;
+  /** Growth strategy when pool is empty: 'create' (single) or 'grow' (batch). Default: 'create' */
+  growthStrategy?: 'create' | 'grow';
+  /** Number of objects to create in batch when growthStrategy = 'grow'. Default: 8 */
+  growthBatchSize?: number;
+}
+
+export interface PoolStats {
+  available: number;
+  totalCreated: number;
+  acquireCount: number;
+  releaseCount: number;
+  missCount: number;
+}
+
+export interface ComponentTemplate {
+  type: symbol;
+  factory: () => IResettableComponent;
+}
+
+export interface EntityPoolConfig extends PoolConfig {
+  componentTemplates?: ComponentTemplate[];
+}
+
+export interface EntityTypeConfig<T extends Entity = Entity> {
+  factory: () => T;
+  pool?: PoolConfig;
+  components?: ComponentTemplate[];
+}
+
+export interface PoolingConfig {
+  entityTypes: Record<string, EntityTypeConfig>;
+  /** Automatically prewarm all pools on start(). Default: true */
+  autoPrewarm?: boolean;
+}

--- a/phalanx-ecs/src/pool/types.ts
+++ b/phalanx-ecs/src/pool/types.ts
@@ -40,3 +40,19 @@ export interface PoolingConfig {
   /** Automatically prewarm all pools on start(). Default: true */
   autoPrewarm?: boolean;
 }
+
+export interface ResolvedPoolConfig {
+  initialSize: number;
+  maxSize: number;
+  growthStrategy: 'create' | 'grow';
+  growthBatchSize: number;
+}
+
+export function resolvePoolConfig(config?: PoolConfig): ResolvedPoolConfig {
+  return {
+    initialSize: config?.initialSize ?? 0,
+    maxSize: config?.maxSize ?? 0,
+    growthStrategy: config?.growthStrategy ?? 'create',
+    growthBatchSize: config?.growthBatchSize ?? 8,
+  };
+}

--- a/phalanx-ecs/tests/Entity.test.ts
+++ b/phalanx-ecs/tests/Entity.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Entity, resetEntityIdCounter, nextEntityId } from '../src/Entity';
+import type { IComponent } from '../src/Component';
+
+const TestType = Symbol('TestComponent');
+
+class TestComponent implements IComponent {
+  readonly type = TestType;
+  constructor(public value: number = 0) {}
+}
+
+describe('Entity pool support', () => {
+  beforeEach(() => {
+    resetEntityIdCounter();
+  });
+
+  it('nextEntityId returns sequential IDs', () => {
+    const id1 = nextEntityId();
+    const id2 = nextEntityId();
+    expect(id1).toBe(1);
+    expect(id2).toBe(2);
+  });
+
+  it('nextEntityId shares counter with Entity constructor', () => {
+    const entity = new Entity();
+    expect(entity.id).toBe(1);
+    expect(nextEntityId()).toBe(2);
+  });
+
+  it('_setId changes entity ID', () => {
+    const entity = new Entity();
+    expect(entity.id).toBe(1);
+    entity._setId(999);
+    expect(entity.id).toBe(999);
+  });
+
+  it('_revive clears destroyed flag', () => {
+    const entity = new Entity();
+    entity.destroy();
+    expect(entity.isDestroyed).toBe(true);
+    entity._revive();
+    expect(entity.isDestroyed).toBe(false);
+  });
+
+  it('reset clears components and destroyed flag', () => {
+    const entity = new Entity();
+    entity.addComponent(new TestComponent(42));
+    entity.destroy();
+
+    entity.reset();
+    expect(entity.isDestroyed).toBe(false);
+    expect(entity.hasComponent(TestType)).toBe(false);
+  });
+
+  it('_poolTypeKey is undefined by default', () => {
+    const entity = new Entity();
+    expect(entity._poolTypeKey).toBeUndefined();
+  });
+
+  it('_poolTypeKey can be set', () => {
+    const entity = new Entity();
+    entity._poolTypeKey = 'projectile';
+    expect(entity._poolTypeKey).toBe('projectile');
+  });
+
+  it('backward compat: dispose still works', () => {
+    const entity = new Entity();
+    entity.addComponent(new TestComponent());
+    entity.dispose();
+    expect(entity.isDestroyed).toBe(true);
+    expect(entity.hasComponent(TestType)).toBe(false);
+  });
+
+  it('resetEntityIdCounter resets the counter', () => {
+    new Entity(); // id 1
+    new Entity(); // id 2
+    resetEntityIdCounter();
+    const entity = new Entity();
+    expect(entity.id).toBe(1);
+  });
+});

--- a/phalanx-ecs/tests/EntityPool.test.ts
+++ b/phalanx-ecs/tests/EntityPool.test.ts
@@ -127,6 +127,30 @@ describe('EntityPool', () => {
     expect(pool.availableCount).toBe(0);
   });
 
+  it('preserves template components across release/acquire', () => {
+    const pool = new EntityPool(() => new Entity(), {
+      componentTemplates: [
+        { type: TestType, factory: () => new TestResettableComponent() },
+      ],
+    });
+
+    const entity = pool.acquire();
+    expect(entity.hasComponent(TestType)).toBe(true);
+
+    const comp = entity.getComponent<TestResettableComponent>(TestType)!;
+    comp.reinitialize(42);
+    expect(comp.value).toBe(42);
+
+    pool.release(entity);
+    const reused = pool.acquire();
+
+    expect(reused).toBe(entity); // same instance
+    expect(reused.hasComponent(TestType)).toBe(true);
+    const reusedComp = reused.getComponent<TestResettableComponent>(TestType)!;
+    expect(reusedComp).toBe(comp); // same component instance
+    expect(reusedComp.value).toBe(0); // was reset
+  });
+
   it('IDs are globally sequential', () => {
     const pool = new EntityPool(() => new Entity());
 

--- a/phalanx-ecs/tests/EntityPool.test.ts
+++ b/phalanx-ecs/tests/EntityPool.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Entity, resetEntityIdCounter } from '../src/Entity';
+import { EntityPool } from '../src/pool/EntityPool';
+import type { IComponent } from '../src/Component';
+import type { IResettableComponent } from '../src/pool/IResettableComponent';
+
+const TestType = Symbol('Test');
+
+class TestResettableComponent implements IResettableComponent {
+  readonly type = TestType;
+  public value: number = 0;
+
+  reset(): void {
+    this.value = 0;
+  }
+
+  reinitialize(value: number): void {
+    this.value = value;
+  }
+}
+
+describe('EntityPool', () => {
+  beforeEach(() => {
+    resetEntityIdCounter();
+  });
+
+  it('creates entities via factory', () => {
+    let factoryCalls = 0;
+    const pool = new EntityPool(() => {
+      factoryCalls++;
+      return new Entity();
+    });
+
+    const entity = pool.acquire();
+    expect(entity).toBeInstanceOf(Entity);
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('assigns new ID on acquire', () => {
+    const pool = new EntityPool(() => new Entity());
+
+    const e1 = pool.acquire();
+    const id1 = e1.id;
+
+    pool.release(e1);
+    const e2 = pool.acquire();
+
+    expect(e2).toBe(e1); // same instance
+    expect(e2.id).not.toBe(id1); // new ID
+    expect(e2.id).toBeGreaterThan(id1);
+  });
+
+  it('revives entity on acquire', () => {
+    const pool = new EntityPool(() => new Entity());
+
+    const entity = pool.acquire();
+    entity.destroy();
+    expect(entity.isDestroyed).toBe(true);
+
+    pool.release(entity);
+    const reused = pool.acquire();
+    expect(reused.isDestroyed).toBe(false);
+  });
+
+  it('clears components on release via reset()', () => {
+    const pool = new EntityPool(() => new Entity());
+
+    const entity = pool.acquire();
+    entity.addComponent(new TestResettableComponent());
+    expect(entity.hasComponent(TestType)).toBe(true);
+
+    pool.release(entity);
+
+    const reused = pool.acquire();
+    expect(reused.hasComponent(TestType)).toBe(false);
+  });
+
+  it('prewarm creates entities with template components', () => {
+    const pool = new EntityPool(() => new Entity(), {
+      componentTemplates: [
+        { type: TestType, factory: () => new TestResettableComponent() },
+      ],
+    });
+
+    pool.prewarm(5);
+    expect(pool.availableCount).toBe(5);
+    expect(pool.stats.totalCreated).toBe(5);
+
+    // Acquire and verify template component exists
+    const entity = pool.acquire();
+    expect(entity.hasComponent(TestType)).toBe(true);
+  });
+
+  it('tracks stats', () => {
+    const pool = new EntityPool(() => new Entity());
+
+    const e1 = pool.acquire();
+    expect(pool.stats.acquireCount).toBe(1);
+    expect(pool.stats.missCount).toBe(1);
+
+    pool.release(e1);
+    expect(pool.stats.releaseCount).toBe(1);
+
+    pool.acquire(); // from pool, no miss
+    expect(pool.stats.acquireCount).toBe(2);
+    expect(pool.stats.missCount).toBe(1);
+  });
+
+  it('respects maxSize', () => {
+    const pool = new EntityPool(() => new Entity(), { maxSize: 2 });
+
+    const a = pool.acquire();
+    const b = pool.acquire();
+    const c = pool.acquire();
+
+    pool.release(a);
+    pool.release(b);
+    pool.release(c); // should be discarded
+
+    expect(pool.availableCount).toBe(2);
+  });
+
+  it('drain clears all available', () => {
+    const pool = new EntityPool(() => new Entity());
+    pool.prewarm(10);
+    pool.drain();
+    expect(pool.availableCount).toBe(0);
+  });
+
+  it('IDs are globally sequential', () => {
+    const pool = new EntityPool(() => new Entity());
+
+    const e1 = pool.acquire();
+    const id1 = e1.id;
+
+    const regular = new Entity();
+    expect(regular.id).toBe(id1 + 1);
+
+    pool.release(e1);
+    const e2 = pool.acquire();
+    expect(e2.id).toBe(id1 + 2);
+  });
+});

--- a/phalanx-ecs/tests/ObjectPool.test.ts
+++ b/phalanx-ecs/tests/ObjectPool.test.ts
@@ -133,6 +133,18 @@ describe('ObjectPool', () => {
     expect(pool.totalCreated).toBe(4);
   });
 
+  it('uses LIFO order (stack)', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
+
+    const a = pool.acquire();
+    const b = pool.acquire();
+    pool.release(a);
+    pool.release(b);
+
+    expect(pool.acquire()).toBe(b); // last in, first out
+    expect(pool.acquire()).toBe(a);
+  });
+
   it('growth strategy "create" creates single object', () => {
     const pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), {
       growthStrategy: 'create',

--- a/phalanx-ecs/tests/ObjectPool.test.ts
+++ b/phalanx-ecs/tests/ObjectPool.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ObjectPool } from '../src/pool/ObjectPool';
+import type { IPoolable } from '../src/pool/IPoolable';
+
+class TestPoolable implements IPoolable {
+  public value: number = 0;
+  public resetCount: number = 0;
+
+  reset(): void {
+    this.value = 0;
+    this.resetCount++;
+  }
+}
+
+describe('ObjectPool', () => {
+  it('creates objects via factory when pool is empty', () => {
+    let factoryCalls = 0;
+    const pool = new ObjectPool<TestPoolable>(() => {
+      factoryCalls++;
+      return new TestPoolable();
+    });
+
+    const obj = pool.acquire();
+    expect(obj).toBeInstanceOf(TestPoolable);
+    expect(factoryCalls).toBe(1);
+    expect(pool.availableCount).toBe(0);
+  });
+
+  it('reuses objects after release (LIFO)', () => {
+    let factoryCalls = 0;
+    const pool = new ObjectPool<TestPoolable>(() => {
+      factoryCalls++;
+      return new TestPoolable();
+    });
+
+    const obj1 = pool.acquire();
+    obj1.value = 42;
+    pool.release(obj1);
+    expect(pool.availableCount).toBe(1);
+
+    const obj2 = pool.acquire();
+    expect(obj2).toBe(obj1);
+    expect(obj2.value).toBe(0); // reset was called
+    expect(factoryCalls).toBe(1);
+  });
+
+  it('calls reset() on release', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
+
+    const obj = pool.acquire();
+    obj.value = 100;
+    pool.release(obj);
+    expect(obj.value).toBe(0);
+    expect(obj.resetCount).toBe(1);
+  });
+
+  it('respects maxSize limit', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), {
+      maxSize: 2,
+    });
+
+    const a = pool.acquire();
+    const b = pool.acquire();
+    const c = pool.acquire();
+
+    pool.release(a);
+    pool.release(b);
+    pool.release(c); // should be discarded
+
+    expect(pool.availableCount).toBe(2);
+  });
+
+  it('maxSize 0 means unlimited', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), {
+      maxSize: 0,
+    });
+
+    const objects: TestPoolable[] = [];
+    for (let i = 0; i < 100; i++) {
+      objects.push(pool.acquire());
+    }
+    for (const obj of objects) {
+      pool.release(obj);
+    }
+    expect(pool.availableCount).toBe(100);
+  });
+
+  it('prewarm fills the pool', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
+
+    pool.prewarm(10);
+    expect(pool.availableCount).toBe(10);
+    expect(pool.totalCreated).toBe(10);
+
+    // prewarm to lower count does nothing
+    pool.prewarm(5);
+    expect(pool.availableCount).toBe(10);
+  });
+
+  it('drain clears the pool', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
+    pool.prewarm(10);
+    pool.drain();
+    expect(pool.availableCount).toBe(0);
+  });
+
+  it('tracks stats correctly', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
+
+    // First acquire = miss
+    const obj1 = pool.acquire();
+    expect(pool.stats.missCount).toBe(1);
+    expect(pool.stats.acquireCount).toBe(1);
+
+    pool.release(obj1);
+    expect(pool.stats.releaseCount).toBe(1);
+
+    // Second acquire = from pool, no miss
+    pool.acquire();
+    expect(pool.stats.missCount).toBe(1);
+    expect(pool.stats.acquireCount).toBe(2);
+  });
+
+  it('growth strategy "grow" creates batch', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), {
+      growthStrategy: 'grow',
+      growthBatchSize: 4,
+    });
+
+    // First acquire triggers batch creation (4 total: 3 in pool + 1 returned)
+    pool.acquire();
+    expect(pool.availableCount).toBe(3);
+    expect(pool.totalCreated).toBe(4);
+  });
+
+  it('growth strategy "create" creates single object', () => {
+    const pool = new ObjectPool<TestPoolable>(() => new TestPoolable(), {
+      growthStrategy: 'create',
+    });
+
+    pool.acquire();
+    expect(pool.availableCount).toBe(0);
+    expect(pool.totalCreated).toBe(1);
+  });
+});

--- a/phalanx-ecs/tests/ObjectPool.test.ts
+++ b/phalanx-ecs/tests/ObjectPool.test.ts
@@ -48,10 +48,13 @@ describe('ObjectPool', () => {
     const pool = new ObjectPool<TestPoolable>(() => new TestPoolable());
 
     const obj = pool.acquire();
+    // acquire() calls reset() once on the new object
+    expect(obj.resetCount).toBe(1);
     obj.value = 100;
     pool.release(obj);
     expect(obj.value).toBe(0);
-    expect(obj.resetCount).toBe(1);
+    // reset() called once on acquire + once on release = 2
+    expect(obj.resetCount).toBe(2);
   });
 
   it('respects maxSize limit', () => {

--- a/phalanx-ecs/tests/PoolManager.test.ts
+++ b/phalanx-ecs/tests/PoolManager.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Entity, resetEntityIdCounter } from '../src/Entity';
+import { PoolManager } from '../src/pool/PoolManager';
+import type { IResettableComponent } from '../src/pool/IResettableComponent';
+
+const TestType = Symbol('Test');
+
+class TestComponent implements IResettableComponent {
+  readonly type = TestType;
+  public value: number = 0;
+
+  reset(): void {
+    this.value = 0;
+  }
+
+  reinitialize(value: number): void {
+    this.value = value;
+  }
+}
+
+describe('PoolManager', () => {
+  let manager: PoolManager;
+
+  beforeEach(() => {
+    resetEntityIdCounter();
+    manager = new PoolManager();
+  });
+
+  it('registers and acquires from a named pool', () => {
+    manager.registerEntityType('test', {
+      factory: () => new Entity(),
+    });
+
+    const entity = manager.acquire('test');
+    expect(entity).toBeInstanceOf(Entity);
+    expect(entity._poolTypeKey).toBe('test');
+  });
+
+  it('throws on duplicate registration', () => {
+    manager.registerEntityType('test', { factory: () => new Entity() });
+    expect(() => {
+      manager.registerEntityType('test', { factory: () => new Entity() });
+    }).toThrow("Pool 'test' is already registered");
+  });
+
+  it('throws on acquire from unregistered pool', () => {
+    expect(() => manager.acquire('nope')).toThrow("Pool 'nope' is not registered");
+  });
+
+  it('throws on release to unregistered pool', () => {
+    expect(() => manager.release('nope', new Entity())).toThrow(
+      "Pool 'nope' is not registered"
+    );
+  });
+
+  it('release and reacquire reuses entity', () => {
+    manager.registerEntityType('test', { factory: () => new Entity() });
+
+    const entity = manager.acquire('test');
+    const firstId = entity.id;
+    manager.release('test', entity);
+
+    const reused = manager.acquire('test');
+    expect(reused).toBe(entity);
+    expect(reused.id).not.toBe(firstId);
+  });
+
+  it('prewarmAll uses initialSize', () => {
+    manager.registerEntityType('test', {
+      factory: () => new Entity(),
+      pool: { initialSize: 10 },
+    });
+
+    manager.prewarmAll();
+    const stats = manager.getPoolStats('test')!;
+    expect(stats.available).toBe(10);
+  });
+
+  it('prewarm specific pool', () => {
+    manager.registerEntityType('test', { factory: () => new Entity() });
+    manager.prewarm('test', 5);
+    expect(manager.getPoolStats('test')!.available).toBe(5);
+  });
+
+  it('prewarm throws for unregistered pool', () => {
+    expect(() => manager.prewarm('nope', 10)).toThrow(
+      "Pool 'nope' is not registered"
+    );
+  });
+
+  it('drainAll clears all pools', () => {
+    manager.registerEntityType('a', { factory: () => new Entity(), pool: { initialSize: 5 } });
+    manager.registerEntityType('b', { factory: () => new Entity(), pool: { initialSize: 3 } });
+    manager.prewarmAll();
+    manager.drainAll();
+
+    expect(manager.getPoolStats('a')!.available).toBe(0);
+    expect(manager.getPoolStats('b')!.available).toBe(0);
+  });
+
+  it('getStats returns all pool stats', () => {
+    manager.registerEntityType('a', { factory: () => new Entity() });
+    manager.registerEntityType('b', { factory: () => new Entity() });
+    manager.acquire('a');
+    manager.acquire('b');
+
+    const stats = manager.getStats();
+    expect(stats.size).toBe(2);
+    expect(stats.get('a')!.acquireCount).toBe(1);
+    expect(stats.get('b')!.acquireCount).toBe(1);
+  });
+
+  it('getPoolStats returns undefined for unknown pool', () => {
+    expect(manager.getPoolStats('nope')).toBeUndefined();
+  });
+
+  it('registers with component templates and prewarmed entities have them', () => {
+    manager.registerEntityType('test', {
+      factory: () => new Entity(),
+      pool: { initialSize: 3 },
+      components: [
+        { type: TestType, factory: () => new TestComponent() },
+      ],
+    });
+
+    manager.prewarmAll();
+    const entity = manager.acquire('test');
+    expect(entity.hasComponent(TestType)).toBe(true);
+
+    const comp = entity.getComponent<TestComponent>(TestType)!;
+    comp.reinitialize(42);
+    expect(comp.value).toBe(42);
+  });
+
+  it('multiple pools operate independently', () => {
+    manager.registerEntityType('alpha', {
+      factory: () => new Entity(),
+      pool: { initialSize: 3 },
+    });
+    manager.registerEntityType('beta', {
+      factory: () => new Entity(),
+      pool: { initialSize: 5 },
+    });
+
+    manager.prewarmAll();
+
+    expect(manager.getPoolStats('alpha')!.available).toBe(3);
+    expect(manager.getPoolStats('beta')!.available).toBe(5);
+
+    const a = manager.acquire('alpha');
+    const b = manager.acquire('beta');
+    expect(a._poolTypeKey).toBe('alpha');
+    expect(b._poolTypeKey).toBe('beta');
+  });
+});


### PR DESCRIPTION
## Summary

- **ObjectPool\<T\>**: Generic object pool with factory/reset pattern, pre-warming, configurable max size, and LIFO reuse strategy
- **EntityPool\<T\>**: Entity-specific pool with component template support — preserves template components across reset cycles via `prepareForPool()`, assigns fresh IDs on acquire, and properly disposes overflow entities
- **PoolManager**: Central registry that maps named pools to entity lifecycle — handles acquire/release with automatic pool type tracking
- **GameWorld.pools**: Exposes the PoolManager on the GameWorld facade for easy access from systems

### Breaking Changes

- `Entity.id` changed from `public readonly id: number` (field) to `public get id(): number` (getter). This is source-compatible for all reads but allows EntityPool to reassign IDs on reuse via `_setId()`.
- `nextEntityId()` function exported from Entity module for ID allocation outside the constructor.

## New API Surface

### ObjectPool\<T extends IPoolable\>

| Method / Property | Description |
|---|---|
| `new ObjectPool(factory, config?)` | Create a pool with factory function, optional initialSize, maxSize, growthStrategy |
| `acquire(): T` | Get an object from pool (or create new via factory). Calls `reset()` before returning. |
| `release(obj: T)` | Return object to pool. Calls `reset()`. Discarded if at `maxSize`. |
| `prewarm(count)` | Pre-create objects up to `count` available (respects maxSize) |
| `availableCount` / `totalCreated` / `stats` | Pool statistics |
| `drain()` | Clear the pool |

### EntityPool\<T extends Entity\>

| Method / Property | Description |
|---|---|
| `new EntityPool(factory, config?)` | Create a pool with entity factory and optional component templates |
| `acquire(): T` | Get entity from pool — assigns fresh ID via `nextEntityId()`, revives, resets template components |
| `release(entity: T)` | Return entity to pool via `prepareForPool()`. Calls `dispose()` on overflow entities. |
| `prewarm(count)` | Pre-create entities with templates (respects maxSize) |
| `availableCount` / `stats` | Pool statistics |
| `drain()` | Clear the pool |

### PoolManager

| Method | Description |
|---|---|
| `registerEntityType(typeKey, config)` | Register a named pool with factory/pool config/component templates |
| `acquire<T>(typeKey)` | Acquire from named pool, set `_poolTypeKey` on entity |
| `release(typeKey, entity)` | Release to named pool |
| `prewarmAll()` / `prewarm(typeKey, count)` | Pre-warm pools |
| `getStats()` / `getPoolStats(typeKey)` | Pool diagnostics |
| `drainAll()` | Clear all pools |

## Usage Example

### Configuring a pool for projectiles

```typescript
import { Entity, GameWorld } from 'phalanx-ecs';
import { ProjectileComponent } from './components';

world.pools.registerEntityType('projectile', {
  factory: () => new ProjectileEntity(),
  pool: { initialSize: 50, maxSize: 200 },
  components: [
    { type: ComponentType.Projectile, factory: () => new ProjectileComponent() },
    { type: ComponentType.Transform, factory: () => new TransformComponent() },
  ],
});

world.pools.prewarmAll();
```

### How ProjectileSystem would use the pool

```typescript
class ProjectileSystem extends GameSystem {
  spawnProjectile(origin: Vector3, direction: Vector3, config: ProjectileConfig) {
    const entity = this.context.pools
      ? this.context.pools.acquire<ProjectileEntity>('projectile')
      : new ProjectileEntity();

    entity.initVisual(this.scene, origin, direction, config.team);
    this.entityManager.addEntity(entity);
  }

  destroyProjectile(entity: Entity) {
    const pools = this.context.pools;
    if (pools && entity._poolTypeKey) {
      pools.release(entity._poolTypeKey, entity);
      return;
    }
    entity.destroy();
  }
}
```

## Test Coverage

**60 tests** across 5 test suites (all passing):

| Suite | Tests | Covers |
|---|---|---|
| ObjectPool | 11 | Factory creation, reuse after release, reset on acquire/release, maxSize, prewarm with maxSize, batch growth with maxSize, stats, LIFO |
| EntityPool | 10 | Template component preservation via prepareForPool, ID assignment (no double increment), component template reset, maxSize bounds, dispose on overflow |
| PoolManager | 13 | Register/acquire/release, duplicate name error, unregistered pool errors, pool type tracking, prewarmAll, stats |
| Entity | 9 | Core entity operations |
| SoAComponent | 17 | SoA component operations |

**Total: 60 tests passing**

---
Generated with [Claude Code](https://claude.com/claude-code)