### PR TITLE
feat: client-ready handshake to prevent desync on slow-loading clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,34 @@ This repository contains the following packages:
 - **Fixed-Point Math**: Platform-independent fixed-point arithmetic via `phalanx-math` ensures identical calculations across all clients
 - **Matchmaking**: Built-in support for various game modes (1v1, 2v2, 3v3, 4v4, FFA)
 - **Tick System**: Configurable tick rate with command batching
+- **Game Start Synchronization**: Ready handshake ensures all clients finish loading before the tick loop begins
 - **Reconnection Support**: Players can rejoin matches after disconnection
 - **TypeScript**: Full TypeScript support with exported types
+
+## Game Start Synchronization
+
+Phalanx uses a **ready handshake** protocol to ensure all clients are fully initialized before the simulation begins. This prevents desync caused by clients with different asset download speeds missing early ticks.
+
+### How it works
+
+1. Server emits `game-start` after the countdown completes and enters a `waiting-for-ready` state
+2. Each client receives `game-start`, loads assets, sets up the game world, and initializes all systems
+3. Each client calls `client.sendReady()` to emit `client-ready` to the server
+4. Server receives `client-ready` from **all** connected players, then starts the tick loop
+5. All clients are guaranteed to be subscribed to tick events before tick 0
+
+If any client fails to send `client-ready` within 30 seconds, the match ends with reason `'ready-timeout'`.
+
+### Usage
+
+Clients **must** call `sendReady()` after initialization:
+
+```typescript
+client.on('gameStart', async () => {
+  await game.initialize(); // Load assets, set up ECS, etc.
+  client.sendReady();      // Tell the server we're ready
+});
+```
 
 ## Quick Start
 

--- a/direct-strike-babylon-example/src/main.ts
+++ b/direct-strike-babylon-example/src/main.ts
@@ -27,7 +27,7 @@ function returnToLobby(): void {
 
 // Handle game start
 lobbyScene.setOnGameStart(
-  (client: PhalanxClient, matchData: MatchFoundEvent) => {
+  async (client: PhalanxClient, matchData: MatchFoundEvent) => {
     console.warn('Game starting!', matchData);
 
     const canvas = document.getElementById('app') as HTMLCanvasElement;
@@ -40,7 +40,8 @@ lobbyScene.setOnGameStart(
     game = new Game(canvas, client, matchData);
     game.setOnExit(returnToLobby);
 
-    void game.initialize();
+    await game.initialize(); // Wait for asset loading + setup
+    client.sendReady(); // Tell server we're ready for ticks
   }
 );
 

--- a/direct-strike-babylon-example/src/scenes/LobbyScene.ts
+++ b/direct-strike-babylon-example/src/scenes/LobbyScene.ts
@@ -284,7 +284,19 @@ export class LobbyScene {
     this.gameContainer.style.display = 'block';
 
     if (this.onGameStart && this.matchData) {
-      this.onGameStart(this.client, this.matchData);
+      const result = this.onGameStart(this.client, this.matchData);
+      if (result instanceof Promise) {
+        result.catch((error) => {
+          console.error('[LobbyScene] Game initialization failed:', error);
+          this.gameContainer.style.display = 'none';
+          this.lobbyElement.style.display = 'flex';
+          this.setStatus(
+            `Failed to initialize game: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            'error'
+          );
+          this.connectButton.disabled = false;
+        });
+      }
     }
   }
 

--- a/direct-strike-babylon-example/src/scenes/LobbyScene.ts
+++ b/direct-strike-babylon-example/src/scenes/LobbyScene.ts
@@ -25,7 +25,7 @@ export class LobbyScene {
 
   // Callbacks
   private onGameStart:
-    | ((client: PhalanxClient, matchData: MatchFoundEvent) => void)
+    | ((client: PhalanxClient, matchData: MatchFoundEvent) => void | Promise<void>)
     | null = null;
 
   // Network event unsubscribers (to clean up when returning to lobby)
@@ -155,7 +155,7 @@ export class LobbyScene {
    * Set callback for game start
    */
   setOnGameStart(
-    callback: (client: PhalanxClient, matchData: MatchFoundEvent) => void
+    callback: (client: PhalanxClient, matchData: MatchFoundEvent) => void | Promise<void>
   ): void {
     this.onGameStart = callback;
   }

--- a/phalanx-client/README.md
+++ b/phalanx-client/README.md
@@ -138,6 +138,24 @@ await client.waitForCountdown((event) => {
 
 // Wait for game start
 const gameStart = await client.waitForGameStart();
+
+// After loading assets and initializing game systems, report ready.
+// The server will not start the tick loop until ALL clients call sendReady().
+await loadAssets();
+initializeGameWorld();
+client.sendReady();
+```
+
+#### sendReady(): void
+
+Notify the server that this client has finished loading and is ready to receive ticks. **Must** be called after assets are loaded and game systems are initialized. The server will not start the tick loop until all clients report ready.
+
+```typescript
+// Example: in your game-start handler
+client.on('gameStart', async () => {
+  await game.initialize(); // downloads assets, sets up ECS
+  client.sendReady();       // signals server to start tick loop
+});
 ```
 
 ### Commands
@@ -441,6 +459,7 @@ client.on('commands', (event) => {});
 // Player events
 client.on('playerDisconnected', (event) => {});
 client.on('playerReconnected', (event) => {});
+client.on('playerReady', (event) => {});  // Another player reported ready
 
 // Reconnection events
 client.on('reconnectState', (event) => {});

--- a/phalanx-client/README.md
+++ b/phalanx-client/README.md
@@ -459,7 +459,7 @@ client.on('commands', (event) => {});
 // Player events
 client.on('playerDisconnected', (event) => {});
 client.on('playerReconnected', (event) => {});
-client.on('playerReady', (event) => {});  // Another player reported ready
+client.on('playerReady', (event) => {});  // A player reported ready (local or remote)
 
 // Reconnection events
 client.on('reconnectState', (event) => {});

--- a/phalanx-client/src/PhalanxClient.ts
+++ b/phalanx-client/src/PhalanxClient.ts
@@ -162,6 +162,7 @@ export class PhalanxClient extends EventEmitter<PhalanxClientEvents> {
         // Player events
         onPlayerDisconnected: (data) => this.emit('playerDisconnected', data),
         onPlayerReconnected: (data) => this.emit('playerReconnected', data),
+        onPlayerReady: (data) => this.emit('playerReady', data),
 
         // Reconnection events
         onReconnectState: (data) => {
@@ -509,6 +510,16 @@ export class PhalanxClient extends EventEmitter<PhalanxClientEvents> {
   resumeGame(): void {
     this.ensureConnected();
     this.socketManager.sendResumeGame();
+  }
+
+  /**
+   * Notify the server that this client has finished loading and is ready to receive ticks.
+   * Must be called after assets are loaded and game systems are initialized.
+   * The server will not start the tick loop until all clients report ready.
+   */
+  sendReady(): void {
+    this.ensureConnected();
+    this.socketManager.sendReady();
   }
 
   /**

--- a/phalanx-client/src/SocketManager.ts
+++ b/phalanx-client/src/SocketManager.ts
@@ -18,6 +18,7 @@ import type {
   QueueStatusEvent,
   PlayerDisconnectedEvent,
   PlayerReconnectedEvent,
+  PlayerReadyEvent,
   ReconnectStateEvent,
   ReconnectStatusEvent,
   SubmitCommandsAck,
@@ -78,6 +79,7 @@ export interface SocketManagerCallbacks {
   // Player events
   onPlayerDisconnected: (data: PlayerDisconnectedEvent) => void;
   onPlayerReconnected: (data: PlayerReconnectedEvent) => void;
+  onPlayerReady: (data: PlayerReadyEvent) => void;
 
   // Reconnection events
   onReconnectState: (data: ReconnectStateEvent) => void;
@@ -342,6 +344,14 @@ export class SocketManager {
     this.socket!.emit('resume-game');
   }
 
+  /**
+   * Notify the server that this client has finished loading and is ready to receive ticks.
+   */
+  sendReady(): void {
+    this.ensureConnected();
+    this.socket!.emit('client-ready');
+  }
+
   // ============================================
   // RECONNECTION
   // ============================================
@@ -454,6 +464,10 @@ export class SocketManager {
 
     this.socket.on('player-reconnected', (data: PlayerReconnectedEvent) => {
       this.callbacks.onPlayerReconnected(data);
+    });
+
+    this.socket.on('player-ready', (data: PlayerReadyEvent) => {
+      this.callbacks.onPlayerReady(data);
     });
 
     // Match end

--- a/phalanx-client/src/index.ts
+++ b/phalanx-client/src/index.ts
@@ -161,6 +161,7 @@ export type {
   // Player events
   PlayerDisconnectedEvent,
   PlayerReconnectedEvent,
+  PlayerReadyEvent,
 
   // Reconnection
   ReconnectStateEvent,

--- a/phalanx-client/src/types.ts
+++ b/phalanx-client/src/types.ts
@@ -228,7 +228,7 @@ export interface PlayerReconnectedEvent {
 }
 
 /**
- * Event received when another player reports ready during the loading phase
+ * Event received when a player reports ready during the loading phase
  */
 export interface PlayerReadyEvent {
   playerId: string;

--- a/phalanx-client/src/types.ts
+++ b/phalanx-client/src/types.ts
@@ -228,12 +228,19 @@ export interface PlayerReconnectedEvent {
 }
 
 /**
+ * Event received when another player reports ready during the loading phase
+ */
+export interface PlayerReadyEvent {
+  playerId: string;
+}
+
+/**
  * State received when reconnecting to a match
  */
 export interface ReconnectStateEvent {
   matchId: string;
   currentTick: number;
-  state: 'countdown' | 'playing' | 'paused' | 'finished';
+  state: 'countdown' | 'waiting-for-ready' | 'playing' | 'paused' | 'finished';
   recentCommands: TickCommandsHistory[];
 }
 
@@ -413,6 +420,7 @@ export interface PhalanxClientEvents {
   // Player events
   playerDisconnected: (event: PlayerDisconnectedEvent) => void;
   playerReconnected: (event: PlayerReconnectedEvent) => void;
+  playerReady: (event: PlayerReadyEvent) => void;
 
   // Reconnection events
   reconnectState: (event: ReconnectStateEvent) => void;

--- a/phalanx-server/README.md
+++ b/phalanx-server/README.md
@@ -136,7 +136,7 @@ class Phalanx {
 | `match-found`         |      | ✅      | Match created, countdown starting |
 | `game-start`          |      | ✅      | Countdown finished, load assets   |
 | `client-ready`        | ✅   |         | Client finished loading, ready for ticks |
-| `player-ready`        |      | ✅      | Another player reported ready     |
+| `player-ready`        |      | ✅      | A player reported ready           |
 | `match-end`           |      | ✅      | Match has ended                   |
 | `submit-commands`     | ✅   |         | Send game commands                |
 | `submit-commands-ack` |      | ✅      | Command acknowledgment            |

--- a/phalanx-server/README.md
+++ b/phalanx-server/README.md
@@ -134,7 +134,9 @@ class Phalanx {
 | `queue-leave`         | ✅   |         | Leave matchmaking queue           |
 | `queue-status`        |      | ✅      | Queue join/leave confirmation     |
 | `match-found`         |      | ✅      | Match created, countdown starting |
-| `game-start`          |      | ✅      | Match gameplay begins             |
+| `game-start`          |      | ✅      | Countdown finished, load assets   |
+| `client-ready`        | ✅   |         | Client finished loading, ready for ticks |
+| `player-ready`        |      | ✅      | Another player reported ready     |
 | `match-end`           |      | ✅      | Match has ended                   |
 | `submit-commands`     | ✅   |         | Send game commands                |
 | `submit-commands-ack` |      | ✅      | Command acknowledgment            |
@@ -146,6 +148,12 @@ class Phalanx {
 | `reconnect-state`     |      | ✅      | Game state for reconnection       |
 | `player-disconnected` |      | ✅      | Another player disconnected       |
 | `player-reconnected`  |      | ✅      | Another player reconnected        |
+
+### Game Start Synchronization
+
+After the countdown completes, the server emits `game-start` and enters a `waiting-for-ready` state. The tick loop does **not** start until all connected clients send `client-ready`. This prevents desync caused by clients with different asset loading times missing early ticks.
+
+If a client does not send `client-ready` within 30 seconds, the match ends with reason `'ready-timeout'`.
 
 ## Game Modes
 

--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -534,6 +534,17 @@ export class Phalanx extends EventEmitter {
         }
       });
 
+      // Handle client-ready (ready handshake after asset loading)
+      socket.on('client-ready', () => {
+        if (!playerId) return;
+        const matchId = (socket.data as SocketData).matchId;
+        if (!matchId) return;
+        const gameRoom = this.matchmaking!.getMatch(matchId);
+        if (gameRoom) {
+          gameRoom.handlePlayerReady(playerId);
+        }
+      });
+
       // Handle reconnection
       socket.on(
         'reconnect-match',

--- a/phalanx-server/src/config/defaults.ts
+++ b/phalanx-server/src/config/defaults.ts
@@ -49,6 +49,9 @@ export const DEFAULT_CONFIG: PhalanxConfig = {
   enableStateHashing: false,
   stateHashInterval: 60, // 3 seconds at 20 TPS
 
+  // Ready Handshake
+  readyTimeoutMs: 30000,
+
   // Desync Detection Behavior
   desync: {
     enabled: true,

--- a/phalanx-server/src/services/GameRoom.ts
+++ b/phalanx-server/src/services/GameRoom.ts
@@ -50,7 +50,7 @@ export class GameRoom {
   // Ready handshake: tracks which players have reported ready after asset loading
   private readyPlayers: Set<string> = new Set();
   private readyTimeout: NodeJS.Timeout | null = null;
-  private readonly readyTimeoutMs: number = 30000;
+  private readonly readyTimeoutMs: number;
 
   // Command buffer for lockstep: Map<tick, { playerId: commands[] }>
   private commandBuffer: Map<number, TickCommands> = new Map();
@@ -95,6 +95,9 @@ export class GameRoom {
     this.createdAt = new Date();
     // Generate deterministic random seed for this match (32-bit unsigned integer)
     this.randomSeed = randomBytes(4).readUInt32BE();
+
+    // Resolve ready timeout from config
+    this.readyTimeoutMs = config.readyTimeoutMs ?? 30000;
 
     // Resolve desync config with defaults
     this.desyncConfig = {

--- a/phalanx-server/src/services/GameRoom.ts
+++ b/phalanx-server/src/services/GameRoom.ts
@@ -40,12 +40,17 @@ export class GameRoom {
   ) => boolean | void;
 
   private currentTick: number = 0;
-  private state: 'countdown' | 'playing' | 'paused' | 'finished' = 'countdown';
+  private state: 'countdown' | 'waiting-for-ready' | 'playing' | 'paused' | 'finished' = 'countdown';
   private createdAt: Date;
   private tickInterval: NodeJS.Timeout | null = null;
   private countdownTimer: NodeJS.Timeout | null = null;
   private countdownInterval: NodeJS.Timeout | null = null;
   private pendingCommands: Map<number, PlayerCommand[]> = new Map();
+
+  // Ready handshake: tracks which players have reported ready after asset loading
+  private readyPlayers: Set<string> = new Set();
+  private readyTimeout: NodeJS.Timeout | null = null;
+  private readonly readyTimeoutMs: number = 30000;
 
   // Command buffer for lockstep: Map<tick, { playerId: commands[] }>
   private commandBuffer: Map<number, TickCommands> = new Map();
@@ -184,7 +189,13 @@ export class GameRoom {
           matchId: this.id,
           randomSeed: this.randomSeed,
         });
-        this.startGame();
+        // Enter waiting-for-ready state instead of starting immediately.
+        // The tick loop will not begin until all clients send 'client-ready'.
+        this.state = 'waiting-for-ready';
+        this.readyPlayers.clear();
+        this.readyTimeout = setTimeout(() => {
+          this.endMatchDueToReadyTimeout();
+        }, this.readyTimeoutMs);
       }
     }, 1000);
   }
@@ -226,6 +237,54 @@ export class GameRoom {
         }
       });
     });
+  }
+
+  /**
+   * Handle a player reporting ready after asset loading.
+   * When all connected players are ready, the tick loop starts.
+   * @param playerId - The player reporting ready
+   */
+  handlePlayerReady(playerId: string): void {
+    const player = this.players.get(playerId);
+    if (!player || !player.connected) {
+      return;
+    }
+
+    if (this.state !== 'waiting-for-ready') {
+      return;
+    }
+
+    this.readyPlayers.add(playerId);
+
+    // Broadcast player-ready to the room so clients can update loading screens
+    this.io.to(this.roomId).emit('player-ready', { playerId });
+
+    // Check if all connected players are ready
+    const allReady = Array.from(this.players.entries()).every(
+      ([id, info]) => !info.connected || this.readyPlayers.has(id)
+    );
+
+    if (allReady) {
+      if (this.readyTimeout) {
+        clearTimeout(this.readyTimeout);
+        this.readyTimeout = null;
+      }
+      this.startGame();
+    }
+  }
+
+  /**
+   * End the match because not all clients reported ready within the timeout.
+   */
+  private endMatchDueToReadyTimeout(): void {
+    this.readyTimeout = null;
+    this.stop(true);
+
+    this.io.to(this.roomId).emit('match-end', {
+      reason: 'ready-timeout',
+    });
+
+    this.eventEmitter('match-ended', this.id, 'ready-timeout');
   }
 
   /**
@@ -690,6 +749,10 @@ export class GameRoom {
       clearInterval(this.countdownInterval);
       this.countdownInterval = null;
     }
+    if (this.readyTimeout) {
+      clearTimeout(this.readyTimeout);
+      this.readyTimeout = null;
+    }
     this.state = 'finished';
 
     if (!skipNotify) {
@@ -723,6 +786,22 @@ export class GameRoom {
         matchId: this.id,
         gracePeriodMs: this.config.reconnectGracePeriodMs,
       });
+
+      // If we're waiting for ready, re-check whether all remaining connected
+      // players are now ready (the disconnected player no longer blocks).
+      if (this.state === 'waiting-for-ready') {
+        const allReady = Array.from(this.players.entries()).every(
+          ([id, info]) => !info.connected || this.readyPlayers.has(id)
+        );
+
+        if (allReady) {
+          if (this.readyTimeout) {
+            clearTimeout(this.readyTimeout);
+            this.readyTimeout = null;
+          }
+          this.startGame();
+        }
+      }
     }
   }
 
@@ -775,6 +854,12 @@ export class GameRoom {
 
       // Notify other players
       socket.to(this.roomId).emit('player-reconnected', { playerId });
+    }
+
+    // If reconnecting during waiting-for-ready, clear their previous ready
+    // status so they must send client-ready again after re-loading.
+    if (this.state === 'waiting-for-ready') {
+      this.readyPlayers.delete(playerId);
     }
 
     return true;

--- a/phalanx-server/src/services/GameRoom.ts
+++ b/phalanx-server/src/services/GameRoom.ts
@@ -172,6 +172,16 @@ export class GameRoom {
    * Emits countdown events (5, 4, 3, 2, 1, 0) every second, then game-start
    */
   private startGameCountdown(): void {
+    if (this.config.countdownSeconds <= 0) {
+      // Skip countdown entirely — go straight to waiting-for-ready
+      this.io.to(this.roomId).emit('game-start', {
+        matchId: this.id,
+        randomSeed: this.randomSeed,
+      });
+      this.enterWaitingForReady();
+      return;
+    }
+
     let countdown = this.config.countdownSeconds;
 
     // Emit initial countdown
@@ -192,15 +202,21 @@ export class GameRoom {
           matchId: this.id,
           randomSeed: this.randomSeed,
         });
-        // Enter waiting-for-ready state instead of starting immediately.
-        // The tick loop will not begin until all clients send 'client-ready'.
-        this.state = 'waiting-for-ready';
-        this.readyPlayers.clear();
-        this.readyTimeout = setTimeout(() => {
-          this.endMatchDueToReadyTimeout();
-        }, this.readyTimeoutMs);
+        this.enterWaitingForReady();
       }
     }, 1000);
+  }
+
+  /**
+   * Transition to waiting-for-ready state.
+   * The tick loop will not begin until all clients send 'client-ready'.
+   */
+  private enterWaitingForReady(): void {
+    this.state = 'waiting-for-ready';
+    this.readyPlayers.clear();
+    this.readyTimeout = setTimeout(() => {
+      this.endMatchDueToReadyTimeout();
+    }, this.readyTimeoutMs);
   }
 
   /**
@@ -254,6 +270,11 @@ export class GameRoom {
     }
 
     if (this.state !== 'waiting-for-ready') {
+      return;
+    }
+
+    // Ignore duplicate ready signals
+    if (this.readyPlayers.has(playerId)) {
       return;
     }
 

--- a/phalanx-server/src/types/index.ts
+++ b/phalanx-server/src/types/index.ts
@@ -195,6 +195,10 @@ export interface PhalanxConfig {
   /** Desync detection behavior configuration */
   desync?: Partial<DesyncConfig>;
 
+  // === Ready Handshake ===
+  /** Timeout in milliseconds for all clients to report ready after game-start (default: 30000) */
+  readyTimeoutMs?: number;
+
   // === Pause/Resume Settings ===
   /** Pause/resume behavior configuration */
   pause?: Partial<PauseConfig>;

--- a/phalanx-server/src/types/index.ts
+++ b/phalanx-server/src/types/index.ts
@@ -229,7 +229,7 @@ export interface MatchInfo {
   id: string;
   players: PlayerInfo[];
   currentTick: number;
-  state: 'countdown' | 'playing' | 'paused' | 'finished';
+  state: 'countdown' | 'waiting-for-ready' | 'playing' | 'paused' | 'finished';
   createdAt: Date;
 }
 

--- a/phalanx-server/tests/match-10.test.ts
+++ b/phalanx-server/tests/match-10.test.ts
@@ -37,6 +37,12 @@ describe('NET-1: Server Validates Incoming Player Commands', () => {
       new Promise<void>((resolve) => socket2.on('connect', resolve)),
     ]);
 
+    // Set up game-start listeners before joining queue (with countdownSeconds: 0, game-start fires immediately)
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { socket1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { socket2.once('game-start', () => resolve()); }),
+    ]);
+
     // Join queue and wait for match
     const matchPromise = new Promise<void>((resolve) => {
       socket1.once('match-found', () => resolve());
@@ -47,10 +53,8 @@ describe('NET-1: Server Validates Incoming Player Commands', () => {
 
     await matchPromise;
 
-    // Wait for game to start
-    await new Promise<void>((resolve) => {
-      socket1.once('game-start', () => resolve());
-    });
+    // Wait for game to start on both sockets
+    await gameStartPromise;
 
     // Send client-ready from both clients to start tick loop
     socket1.emit('client-ready');

--- a/phalanx-server/tests/match-10.test.ts
+++ b/phalanx-server/tests/match-10.test.ts
@@ -52,6 +52,10 @@ describe('NET-1: Server Validates Incoming Player Commands', () => {
       socket1.once('game-start', () => resolve());
     });
 
+    // Send client-ready from both clients to start tick loop
+    socket1.emit('client-ready');
+    socket2.emit('client-ready');
+
     // Wait a tick
     await new Promise<void>((resolve) => {
       socket1.once('tick-sync', () => resolve());

--- a/phalanx-server/tests/match-11.test.ts
+++ b/phalanx-server/tests/match-11.test.ts
@@ -38,6 +38,12 @@ describe('LOCKSTEP-5: Server Detects Unresponsive Players via Activity Tracking'
       new Promise<void>((resolve) => socket2.on('connect', resolve)),
     ]);
 
+    // Set up game-start listeners before joining queue (with countdownSeconds: 0, game-start fires immediately)
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { socket1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { socket2.once('game-start', () => resolve()); }),
+    ]);
+
     // Join queue and wait for match
     const matchPromise = new Promise<void>((resolve) => {
       socket1.once('match-found', () => resolve());
@@ -48,10 +54,8 @@ describe('LOCKSTEP-5: Server Detects Unresponsive Players via Activity Tracking'
 
     await matchPromise;
 
-    // Wait for game to start
-    await new Promise<void>((resolve) => {
-      socket1.once('game-start', () => resolve());
-    });
+    // Wait for game to start on both sockets
+    await gameStartPromise;
 
     // Send client-ready from both clients to start tick loop
     socket1.emit('client-ready');

--- a/phalanx-server/tests/match-11.test.ts
+++ b/phalanx-server/tests/match-11.test.ts
@@ -52,6 +52,15 @@ describe('LOCKSTEP-5: Server Detects Unresponsive Players via Activity Tracking'
     await new Promise<void>((resolve) => {
       socket1.once('game-start', () => resolve());
     });
+
+    // Send client-ready from both clients to start tick loop
+    socket1.emit('client-ready');
+    socket2.emit('client-ready');
+
+    // Wait a tick to ensure game is running
+    await new Promise<void>((resolve) => {
+      socket1.once('tick-sync', () => resolve());
+    });
   });
 
   afterEach(async () => {

--- a/phalanx-server/tests/match-12.test.ts
+++ b/phalanx-server/tests/match-12.test.ts
@@ -39,6 +39,12 @@ describe('NET-2: Server Handles Player Reconnection', () => {
       new Promise<void>((resolve) => socket2.on('connect', resolve)),
     ]);
 
+    // Set up game-start listeners before joining queue (with countdownSeconds: 0, game-start fires immediately)
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { socket1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { socket2.once('game-start', () => resolve()); }),
+    ]);
+
     // Join queue and wait for match
     const matchPromise = new Promise<string>((resolve) => {
       socket1.once('match-found', (data: MatchFoundEvent) => {
@@ -52,10 +58,8 @@ describe('NET-2: Server Handles Player Reconnection', () => {
 
     matchId = await matchPromise;
 
-    // Wait for game to start
-    await new Promise<void>((resolve) => {
-      socket1.once('game-start', () => resolve());
-    });
+    // Wait for game to start on both sockets
+    await gameStartPromise;
 
     // Send client-ready from both clients to start tick loop
     socket1.emit('client-ready');

--- a/phalanx-server/tests/match-12.test.ts
+++ b/phalanx-server/tests/match-12.test.ts
@@ -57,6 +57,10 @@ describe('NET-2: Server Handles Player Reconnection', () => {
       socket1.once('game-start', () => resolve());
     });
 
+    // Send client-ready from both clients to start tick loop
+    socket1.emit('client-ready');
+    socket2.emit('client-ready');
+
     // Wait a tick
     await new Promise<void>((resolve) => {
       socket1.once('tick-sync', () => resolve());

--- a/phalanx-server/tests/match-7.test.ts
+++ b/phalanx-server/tests/match-7.test.ts
@@ -71,6 +71,11 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
     await gameStartPromise;
+
+    // Send client-ready from both clients to start tick loop
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
     const firstTick = await firstTickPromise;
 
     // First tick should be 0
@@ -89,11 +94,17 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push(data);
     });
 
+    const gameStartPromise = waitForGameStart(client1);
+
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
-    // Wait for countdown (1s) + some ticks (~500ms = 10 ticks at 20 TPS)
-    await new Promise((resolve) => setTimeout(resolve, 1800));
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for some ticks (~500ms = 10 ticks at 20 TPS)
+    await new Promise((resolve) => setTimeout(resolve, 800));
 
     // Should have received multiple tick events
     expect(tickEvents.length).toBeGreaterThanOrEqual(5);
@@ -118,11 +129,17 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push({ tick: data.tick, receivedAt: Date.now() });
     });
 
+    const gameStartPromise = waitForGameStart(client1);
+
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
-    // Wait for countdown + 1 second of ticks (20 ticks)
-    await new Promise((resolve) => setTimeout(resolve, 2200));
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for 1 second of ticks (20 ticks)
+    await new Promise((resolve) => setTimeout(resolve, 1200));
 
     // Should have ~20 ticks in 1 second
     const ticksAfterFirst = tickEvents.filter(
@@ -152,11 +169,17 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents2.push(data);
     });
 
+    const gameStartPromise = waitForGameStart(client1);
+
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
-    // Wait for countdown + some ticks
-    await new Promise((resolve) => setTimeout(resolve, 1800));
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for some ticks
+    await new Promise((resolve) => setTimeout(resolve, 800));
 
     // Both players should receive same ticks
     expect(tickEvents1.length).toBeGreaterThanOrEqual(5);
@@ -174,12 +197,17 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
     await connectClient(client1);
     await connectClient(client2);
 
+    const gameStartPromise = waitForGameStart(client1);
     const tickPromise = new Promise<TickSyncEvent>((resolve) => {
       client1.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
+
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
 
     const tickEvent = await tickPromise;
 
@@ -201,11 +229,17 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push(data);
     });
 
+    const gameStartPromise = waitForGameStart(client1);
+
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
     // Wait for 2 seconds of gameplay
-    await new Promise((resolve) => setTimeout(resolve, 3200));
+    await new Promise((resolve) => setTimeout(resolve, 2200));
 
     // Should have ~40 ticks in 2 seconds at 20 TPS
     expect(tickEvents.length).toBeGreaterThanOrEqual(30);
@@ -278,20 +312,36 @@ describe('LOCKSTEP-1: Independent Tick Counters Per Match', () => {
       client1.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
 
+    const match1GameStart = new Promise<void>((resolve) => {
+      client1.once('game-start', () => resolve());
+    });
+
     // Start first match
     client1.emit('queue-join', { playerId: 'p1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'p2', username: 'bob' });
 
-    // Wait for first match to start and progress
-    await new Promise((resolve) => setTimeout(resolve, 2000));
+    await match1GameStart;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for first match to progress
+    await new Promise((resolve) => setTimeout(resolve, 1000));
 
     const match2FirstTick = new Promise<TickSyncEvent>((resolve) => {
       client3.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
 
+    const match2GameStart = new Promise<void>((resolve) => {
+      client3.once('game-start', () => resolve());
+    });
+
     // Start second match (delayed)
     client3.emit('queue-join', { playerId: 'p3', username: 'carol' });
     client4.emit('queue-join', { playerId: 'p4', username: 'dave' });
+
+    await match2GameStart;
+    client3.emit('client-ready');
+    client4.emit('client-ready');
 
     const firstTickMatch1 = await match1FirstTick;
     const firstTickMatch2 = await match2FirstTick;
@@ -358,11 +408,19 @@ describe('LOCKSTEP-1: Configurable Tick Rate', () => {
       tickEvents.push(data);
     });
 
+    const gameStartPromise = new Promise<void>((resolve) => {
+      client1.once('game-start', () => resolve());
+    });
+
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
 
-    // Wait for countdown + 1 second
-    await new Promise((resolve) => setTimeout(resolve, 2200));
+    await gameStartPromise;
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for 1 second of ticks
+    await new Promise((resolve) => setTimeout(resolve, 1200));
 
     // At 10 TPS, should have ~10 ticks in 1 second
     const ticksInOneSecond = tickEvents.filter(

--- a/phalanx-server/tests/match-7.test.ts
+++ b/phalanx-server/tests/match-7.test.ts
@@ -62,7 +62,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
     await connectClient(client1);
     await connectClient(client2);
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
     const firstTickPromise = new Promise<TickSyncEvent>((resolve) => {
       client1.on('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
@@ -94,7 +97,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push(data);
     });
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
@@ -129,7 +135,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push({ tick: data.tick, receivedAt: Date.now() });
     });
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
@@ -169,7 +178,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents2.push(data);
     });
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
@@ -197,7 +209,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
     await connectClient(client1);
     await connectClient(client2);
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
     const tickPromise = new Promise<TickSyncEvent>((resolve) => {
       client1.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
@@ -229,7 +244,10 @@ describe('LOCKSTEP-1: Server Initializes Tick Clock and Synchronizes All Clients
       tickEvents.push(data);
     });
 
-    const gameStartPromise = waitForGameStart(client1);
+    const gameStartPromise = Promise.all([
+      waitForGameStart(client1),
+      waitForGameStart(client2),
+    ]);
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
@@ -312,9 +330,10 @@ describe('LOCKSTEP-1: Independent Tick Counters Per Match', () => {
       client1.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
 
-    const match1GameStart = new Promise<void>((resolve) => {
-      client1.once('game-start', () => resolve());
-    });
+    const match1GameStart = Promise.all([
+      new Promise<void>((resolve) => { client1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { client2.once('game-start', () => resolve()); }),
+    ]);
 
     // Start first match
     client1.emit('queue-join', { playerId: 'p1', username: 'alice' });
@@ -331,9 +350,10 @@ describe('LOCKSTEP-1: Independent Tick Counters Per Match', () => {
       client3.once('tick-sync', (data: TickSyncEvent) => resolve(data));
     });
 
-    const match2GameStart = new Promise<void>((resolve) => {
-      client3.once('game-start', () => resolve());
-    });
+    const match2GameStart = Promise.all([
+      new Promise<void>((resolve) => { client3.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { client4.once('game-start', () => resolve()); }),
+    ]);
 
     // Start second match (delayed)
     client3.emit('queue-join', { playerId: 'p3', username: 'carol' });
@@ -408,9 +428,10 @@ describe('LOCKSTEP-1: Configurable Tick Rate', () => {
       tickEvents.push(data);
     });
 
-    const gameStartPromise = new Promise<void>((resolve) => {
-      client1.once('game-start', () => resolve());
-    });
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { client1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { client2.once('game-start', () => resolve()); }),
+    ]);
 
     client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
     client2.emit('queue-join', { playerId: 'player2', username: 'bob' });

--- a/phalanx-server/tests/match-8.test.ts
+++ b/phalanx-server/tests/match-8.test.ts
@@ -60,6 +60,10 @@ describe('LOCKSTEP-2: Server Collects Commands from All Players for Each Tick', 
       socket1.once('game-start', () => resolve());
     });
 
+    // Send client-ready from both clients to start tick loop
+    socket1.emit('client-ready');
+    socket2.emit('client-ready');
+
     // Wait a tick to ensure game is running
     await new Promise<void>((resolve) => {
       socket1.once('tick-sync', () => resolve());

--- a/phalanx-server/tests/match-8.test.ts
+++ b/phalanx-server/tests/match-8.test.ts
@@ -43,6 +43,12 @@ describe('LOCKSTEP-2: Server Collects Commands from All Players for Each Tick', 
       new Promise<void>((resolve) => socket2.on('connect', resolve)),
     ]);
 
+    // Set up game-start listeners before joining queue (with countdownSeconds: 0, game-start fires immediately)
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { socket1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { socket2.once('game-start', () => resolve()); }),
+    ]);
+
     // Join queue and wait for match
     const matchPromise = new Promise<string>((resolve) => {
       socket1.once('match-found', (data: MatchFoundEvent) => {
@@ -55,10 +61,8 @@ describe('LOCKSTEP-2: Server Collects Commands from All Players for Each Tick', 
 
     await matchPromise;
 
-    // Wait for game to start
-    await new Promise<void>((resolve) => {
-      socket1.once('game-start', () => resolve());
-    });
+    // Wait for game to start on both sockets
+    await gameStartPromise;
 
     // Send client-ready from both clients to start tick loop
     socket1.emit('client-ready');

--- a/phalanx-server/tests/match-9.test.ts
+++ b/phalanx-server/tests/match-9.test.ts
@@ -59,6 +59,15 @@ describe('LOCKSTEP-3: Server Broadcasts Tick Commands on Timer', () => {
     await new Promise<void>((resolve) => {
       socket1.once('game-start', () => resolve());
     });
+
+    // Send client-ready from both clients to start tick loop
+    socket1.emit('client-ready');
+    socket2.emit('client-ready');
+
+    // Wait a tick to ensure game is running
+    await new Promise<void>((resolve) => {
+      socket1.once('tick-sync', () => resolve());
+    });
   });
 
   afterEach(async () => {

--- a/phalanx-server/tests/match-9.test.ts
+++ b/phalanx-server/tests/match-9.test.ts
@@ -43,6 +43,12 @@ describe('LOCKSTEP-3: Server Broadcasts Tick Commands on Timer', () => {
       new Promise<void>((resolve) => socket2.on('connect', resolve)),
     ]);
 
+    // Set up game-start listeners before joining queue (with countdownSeconds: 0, game-start fires immediately)
+    const gameStartPromise = Promise.all([
+      new Promise<void>((resolve) => { socket1.once('game-start', () => resolve()); }),
+      new Promise<void>((resolve) => { socket2.once('game-start', () => resolve()); }),
+    ]);
+
     // Join queue and wait for match
     const matchPromise = new Promise<string>((resolve) => {
       socket1.once('match-found', (data: MatchFoundEvent) => {
@@ -55,10 +61,8 @@ describe('LOCKSTEP-3: Server Broadcasts Tick Commands on Timer', () => {
 
     await matchPromise;
 
-    // Wait for game to start
-    await new Promise<void>((resolve) => {
-      socket1.once('game-start', () => resolve());
-    });
+    // Wait for game to start on both sockets
+    await gameStartPromise;
 
     // Send client-ready from both clients to start tick loop
     socket1.emit('client-ready');

--- a/phalanx-server/tests/pause.test.ts
+++ b/phalanx-server/tests/pause.test.ts
@@ -83,6 +83,15 @@ describe('Game Pause Functionality', () => {
     // Wait for game to start
     await Promise.all([gameStartPromise1, gameStartPromise2]);
 
+    // Send client-ready from both clients to start tick loop
+    client1.emit('client-ready');
+    client2.emit('client-ready');
+
+    // Wait for tick loop to start
+    await new Promise<void>((resolve) => {
+      client1.once('tick-sync', () => resolve());
+    });
+
     return { client1, client2, matchId: matchFound1.matchId };
   }
 

--- a/phalanx-server/tests/ready-handshake.test.ts
+++ b/phalanx-server/tests/ready-handshake.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { io, Socket } from 'socket.io-client';
+import { Phalanx } from '../src/Phalanx.js';
+import type { MatchFoundEvent } from '../src/types/index.js';
+
+/**
+ * Tests for the client-ready handshake protocol.
+ * Ensures the server waits for all clients to report ready before starting
+ * the tick loop, preventing desync from asymmetric asset loading times.
+ */
+describe('Ready Handshake Protocol', () => {
+  let server: Phalanx;
+  let clients: Socket[] = [];
+  const TEST_PORT = 3360;
+
+  function createClient(): Socket {
+    const client = io(`http://localhost:${TEST_PORT}`, {
+      autoConnect: false,
+      forceNew: true,
+    });
+    clients.push(client);
+    return client;
+  }
+
+  async function connectClient(client: Socket): Promise<void> {
+    return new Promise((resolve) => {
+      client.on('connect', () => resolve());
+      client.connect();
+    });
+  }
+
+  async function cleanupServer(): Promise<void> {
+    for (const client of clients) {
+      if (client.connected) {
+        client.disconnect();
+      }
+    }
+    clients = [];
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    if (server) {
+      await server.stop();
+    }
+  }
+
+  /**
+   * Set up a two-player match that reaches the game-start event
+   * but does NOT send client-ready (so the tick loop should not start).
+   */
+  async function setupTwoPlayerMatch(): Promise<{
+    client1: Socket;
+    client2: Socket;
+    matchId: string;
+  }> {
+    server = new Phalanx({
+      port: TEST_PORT,
+      countdownSeconds: 0,
+    });
+    await server.start();
+
+    const client1 = createClient();
+    const client2 = createClient();
+    await connectClient(client1);
+    await connectClient(client2);
+
+    const matchPromise1 = new Promise<MatchFoundEvent>((resolve) => {
+      client1.on('match-found', (data: MatchFoundEvent) => resolve(data));
+    });
+    const matchPromise2 = new Promise<MatchFoundEvent>((resolve) => {
+      client2.on('match-found', (data: MatchFoundEvent) => resolve(data));
+    });
+
+    // Wait for game-start events (server enters waiting-for-ready)
+    const gameStartPromise1 = new Promise<void>((resolve) => {
+      client1.on('game-start', () => resolve());
+    });
+    const gameStartPromise2 = new Promise<void>((resolve) => {
+      client2.on('game-start', () => resolve());
+    });
+
+    client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
+    client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
+
+    const [matchFound1] = await Promise.all([matchPromise1, matchPromise2]);
+    await Promise.all([gameStartPromise1, gameStartPromise2]);
+
+    return { client1, client2, matchId: matchFound1.matchId };
+  }
+
+  describe('Basic Ready Handshake', () => {
+    beforeEach(() => {
+      clients = [];
+    });
+
+    afterEach(async () => {
+      await cleanupServer();
+    });
+
+    it('should NOT start tick loop until all clients send client-ready', async () => {
+      const { client1 } = await setupTwoPlayerMatch();
+
+      // Listen for tick-sync events (indicates tick loop has started)
+      const tickReceived = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(false), 500);
+        client1.on('tick-sync', () => {
+          clearTimeout(timeout);
+          resolve(true);
+        });
+      });
+
+      // Do NOT send client-ready — tick loop should not start
+      const didReceiveTick = await tickReceived;
+      expect(didReceiveTick).toBe(false);
+    });
+
+    it('should start tick loop after all clients send client-ready', async () => {
+      const { client1, client2 } = await setupTwoPlayerMatch();
+
+      // Listen for tick-sync events
+      const tickPromise = new Promise<{ tick: number }>((resolve) => {
+        client1.on('tick-sync', (data: { tick: number }) => resolve(data));
+      });
+
+      // Both clients report ready
+      client1.emit('client-ready');
+      client2.emit('client-ready');
+
+      const tickData = await tickPromise;
+      expect(tickData.tick).toBe(0);
+    });
+
+    it('should NOT start tick loop if only one client reports ready', async () => {
+      const { client1 } = await setupTwoPlayerMatch();
+
+      // Only client1 reports ready
+      client1.emit('client-ready');
+
+      // Listen for tick-sync
+      const tickReceived = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(false), 500);
+        client1.on('tick-sync', () => {
+          clearTimeout(timeout);
+          resolve(true);
+        });
+      });
+
+      const didReceiveTick = await tickReceived;
+      expect(didReceiveTick).toBe(false);
+    });
+
+    it('should broadcast player-ready event to all clients when a player reports ready', async () => {
+      const { client1, client2 } = await setupTwoPlayerMatch();
+
+      const readyPromise = new Promise<{ playerId: string }>((resolve) => {
+        client2.on('player-ready', (data: { playerId: string }) => resolve(data));
+      });
+
+      client1.emit('client-ready');
+
+      const readyEvent = await readyPromise;
+      expect(readyEvent.playerId).toBe('player1');
+    });
+  });
+
+  describe('Ready Timeout', () => {
+    beforeEach(() => {
+      clients = [];
+    });
+
+    afterEach(async () => {
+      await cleanupServer();
+    });
+
+    it('should end match with ready-timeout if not all clients report ready in time', async () => {
+      // Use a very short timeout for testing
+      server = new Phalanx({
+        port: TEST_PORT,
+        countdownSeconds: 0,
+      });
+      await server.start();
+
+      const client1 = createClient();
+      const client2 = createClient();
+      await connectClient(client1);
+      await connectClient(client2);
+
+      const matchPromise1 = new Promise<MatchFoundEvent>((resolve) => {
+        client1.on('match-found', (data: MatchFoundEvent) => resolve(data));
+      });
+      const matchPromise2 = new Promise<MatchFoundEvent>((resolve) => {
+        client2.on('match-found', (data: MatchFoundEvent) => resolve(data));
+      });
+
+      const gameStartPromise1 = new Promise<void>((resolve) => {
+        client1.on('game-start', () => resolve());
+      });
+      const gameStartPromise2 = new Promise<void>((resolve) => {
+        client2.on('game-start', () => resolve());
+      });
+
+      client1.emit('queue-join', { playerId: 'player1', username: 'alice' });
+      client2.emit('queue-join', { playerId: 'player2', username: 'bob' });
+
+      await Promise.all([matchPromise1, matchPromise2]);
+      await Promise.all([gameStartPromise1, gameStartPromise2]);
+
+      // Listen for match-end with ready-timeout reason
+      const matchEndPromise = new Promise<{ reason: string }>((resolve) => {
+        client1.on('match-end', (data: { reason: string }) => resolve(data));
+      });
+
+      // Only client1 reports ready; client2 does not.
+      client1.emit('client-ready');
+      // Don't send client2 ready — wait for timeout
+
+      // The default timeout is 30s which is too long for tests.
+      // Instead, we verify the match state shows waiting-for-ready
+      // and that no ticks arrive. The full timeout test would require
+      // lowering the timeout constant.
+
+      // Verify no ticks arrive within a short window
+      const tickReceived = new Promise<boolean>((resolve) => {
+        const timeout = setTimeout(() => resolve(false), 500);
+        client1.on('tick-sync', () => {
+          clearTimeout(timeout);
+          resolve(true);
+        });
+      });
+
+      const didReceiveTick = await tickReceived;
+      expect(didReceiveTick).toBe(false);
+    });
+  });
+
+  describe('Disconnect During Waiting-for-Ready', () => {
+    beforeEach(() => {
+      clients = [];
+    });
+
+    afterEach(async () => {
+      await cleanupServer();
+    });
+
+    it('should start game if disconnected player is no longer blocking ready check', async () => {
+      const { client1, client2 } = await setupTwoPlayerMatch();
+
+      // Client1 reports ready
+      client1.emit('client-ready');
+
+      // Listen for tick-sync on client1
+      const tickPromise = new Promise<{ tick: number }>((resolve) => {
+        client1.on('tick-sync', (data: { tick: number }) => resolve(data));
+      });
+
+      // Client2 disconnects instead of reporting ready
+      // Since client2 is disconnected, the only connected+not-ready players are gone
+      client2.disconnect();
+
+      // Wait a bit for disconnect to process
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const tickData = await tickPromise;
+      expect(tickData.tick).toBe(0);
+    });
+  });
+
+  describe('Duplicate and Invalid Ready', () => {
+    beforeEach(() => {
+      clients = [];
+    });
+
+    afterEach(async () => {
+      await cleanupServer();
+    });
+
+    it('should handle duplicate client-ready from same player gracefully', async () => {
+      const { client1, client2 } = await setupTwoPlayerMatch();
+
+      // Listen for tick-sync
+      const tickPromise = new Promise<{ tick: number }>((resolve) => {
+        client1.on('tick-sync', (data: { tick: number }) => resolve(data));
+      });
+
+      // Client1 sends ready twice
+      client1.emit('client-ready');
+      client1.emit('client-ready');
+
+      // Client2 sends ready
+      client2.emit('client-ready');
+
+      const tickData = await tickPromise;
+      expect(tickData.tick).toBe(0);
+    });
+
+    it('should ignore client-ready when game is already playing', async () => {
+      const { client1, client2 } = await setupTwoPlayerMatch();
+
+      // Both clients report ready
+      const tickPromise = new Promise<void>((resolve) => {
+        client1.on('tick-sync', () => resolve());
+      });
+
+      client1.emit('client-ready');
+      client2.emit('client-ready');
+      await tickPromise;
+
+      // Game is now playing - sending client-ready again should be harmless
+      // Just verify no errors
+      client1.emit('client-ready');
+      client2.emit('client-ready');
+
+      // Wait briefly to ensure no errors
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+  });
+});

--- a/phalanx-server/tests/ready-handshake.test.ts
+++ b/phalanx-server/tests/ready-handshake.test.ts
@@ -175,6 +175,7 @@ describe('Ready Handshake Protocol', () => {
       server = new Phalanx({
         port: TEST_PORT,
         countdownSeconds: 0,
+        readyTimeoutMs: 200,
       });
       await server.start();
 
@@ -212,22 +213,8 @@ describe('Ready Handshake Protocol', () => {
       client1.emit('client-ready');
       // Don't send client2 ready — wait for timeout
 
-      // The default timeout is 30s which is too long for tests.
-      // Instead, we verify the match state shows waiting-for-ready
-      // and that no ticks arrive. The full timeout test would require
-      // lowering the timeout constant.
-
-      // Verify no ticks arrive within a short window
-      const tickReceived = new Promise<boolean>((resolve) => {
-        const timeout = setTimeout(() => resolve(false), 500);
-        client1.on('tick-sync', () => {
-          clearTimeout(timeout);
-          resolve(true);
-        });
-      });
-
-      const didReceiveTick = await tickReceived;
-      expect(didReceiveTick).toBe(false);
+      const matchEnd = await matchEndPromise;
+      expect(matchEnd.reason).toBe('ready-timeout');
     });
   });
 


### PR DESCRIPTION
## Summary

- Implements a **ready handshake protocol** so the server waits for all clients to finish loading before starting the tick loop. This prevents desync caused by clients with different asset download speeds missing early ticks.
- After the countdown completes, the server enters a `waiting-for-ready` state instead of immediately starting the tick loop. Each client calls `client.sendReady()` after assets are loaded, and the server starts the game only once all connected players have reported ready.
- Includes a 30-second timeout: if not all clients report ready, the match ends with reason `'ready-timeout'`.

### Changes across packages

**phalanx-server:**
- `GameRoom.ts`: New `waiting-for-ready` state, `handlePlayerReady()`, ready timeout, edge cases for disconnect/reconnect during wait
- `Phalanx.ts`: Added `client-ready` socket event handler
- `types/index.ts`: Added `'waiting-for-ready'` to `MatchInfo.state`

**phalanx-client:**
- `PhalanxClient.ts`: Added `sendReady()` public method
- `SocketManager.ts`: Added `sendReady()` and `player-ready` event listener
- `types.ts`: Added `PlayerReadyEvent`, `playerReady` event, updated `ReconnectStateEvent`
- `index.ts`: Exported `PlayerReadyEvent`

**direct-strike-babylon-example:**
- `main.ts`: Calls `sendReady()` after `game.initialize()` completes
- `LobbyScene.ts`: Updated callback type to support async

**Documentation:**
- Root README, server README, client README all updated with ready handshake docs

## Test plan

- [x] Added `ready-handshake.test.ts` with 8 tests covering:
  - Server does NOT start tick loop until all clients send `client-ready`
  - Server starts tick loop after all clients send `client-ready`
  - Server does NOT start if only one client reports ready
  - Server broadcasts `player-ready` event to all clients
  - Disconnect during `waiting-for-ready` allows game to proceed
  - Duplicate `client-ready` is handled gracefully
  - `client-ready` is ignored when game is already `playing`
- [x] Updated 7 existing test files (match-7 through match-12, pause.test.ts) to emit `client-ready` after `game-start`
- [x] All 112 existing tests pass (1 pre-existing TLS self-signed cert failure unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)