### PR TITLE
feat(debug): add DebugDataProvider and debug accessors (Iteration 1)

### DIFF
--- a/phalanx-ecs/src/Entity.ts
+++ b/phalanx-ecs/src/Entity.ts
@@ -107,6 +107,22 @@ export class Entity implements IPoolable {
   }
 
   /**
+   * Get all component type symbols attached to this entity.
+   * Useful for debugging and introspection.
+   */
+  public getComponentTypes(): symbol[] {
+    return Array.from(this.components.keys());
+  }
+
+  /**
+   * Get a read-only view of all components attached to this entity.
+   * Useful for debugging and introspection.
+   */
+  public getComponents(): ReadonlyMap<symbol, IComponent> {
+    return this.components;
+  }
+
+  /**
    * Check if entity is destroyed
    */
   public get isDestroyed(): boolean {

--- a/phalanx-ecs/src/EntityManager.ts
+++ b/phalanx-ecs/src/EntityManager.ts
@@ -382,6 +382,30 @@ export class EntityManager {
     }
   }
 
+  // ============ Debug / Introspection ============
+
+  /**
+   * Get a read-only view of all registered SoA component stores.
+   * Useful for debugging and introspection tools.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public getAllSoAStores(): ReadonlyMap<symbol, SoAComponentStore<any>> {
+    return this.soaStores;
+  }
+
+  /**
+   * Get entity counts per registered component type.
+   * Returns a map of component type symbol → number of entities with that component.
+   * Useful for debugging and introspection tools.
+   */
+  public getComponentTypeStats(): Map<symbol, number> {
+    const stats = new Map<symbol, number>();
+    for (const [type, index] of this.componentIndices) {
+      stats.set(type, index.length);
+    }
+    return stats;
+  }
+
   /**
    * Clear all entities
    */

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -2,6 +2,8 @@ import { SystemRegistry } from './SystemRegistry';
 import { TickFrameManager } from './TickFrameManager';
 import { SoAComponent } from './SoAComponent';
 import { PoolManager } from './pool/PoolManager';
+import { DebugDataProvider } from './debug/DebugDataProvider';
+import type { DebugDataProviderConfig } from './debug/types';
 import type { PoolingConfig } from './pool/types';
 import type { ITickFrameProvider, Unsubscribe } from './ITickFrameProvider';
 import type { EventBus } from './EventBus';
@@ -34,6 +36,10 @@ export interface GameWorldConfig {
   tickFrameProvider?: ITickFrameProvider;
   /** Object pooling configuration. If omitted, pooling is disabled. */
   pooling?: PoolingConfig;
+  /** Enable debug data collection. When true, a DebugDataProvider is created. Default: false */
+  debug?: boolean;
+  /** Configuration for the debug data provider (update interval, etc.). Only used when debug is true. */
+  debugConfig?: DebugDataProviderConfig;
 }
 
 /**
@@ -89,6 +95,7 @@ export class GameWorld {
   private readonly ownsProvider: boolean;
   private readonly _pools: PoolManager | null;
   private readonly _poolingConfig: PoolingConfig | undefined;
+  private readonly _debugProvider: DebugDataProvider | null;
 
   // Unsubscribe handles for tick/frame
   private unsubscribeTick: Unsubscribe | null = null;
@@ -132,6 +139,17 @@ export class GameWorld {
         maxFrameTime: config.maxFrameTime,
       });
       this.ownsProvider = true;
+    }
+
+    // Setup debug data provider if configured
+    if (config.debug) {
+      this._debugProvider = new DebugDataProvider(
+        this.systemRegistry.entityManager,
+        this._pools,
+        config.debugConfig,
+      );
+    } else {
+      this._debugProvider = null;
     }
   }
 
@@ -201,6 +219,24 @@ export class GameWorld {
   /** Pool manager. null if pooling is not configured. */
   public get pools(): PoolManager | null {
     return this._pools;
+  }
+
+  /**
+   * Debug data provider. null if debug mode is not enabled.
+   *
+   * Use this to subscribe to periodic debug snapshots or pull
+   * snapshots on demand for custom debug tooling.
+   *
+   * @example
+   * ```ts
+   * const world = new GameWorld({ debug: true });
+   * const unsub = world.debugProvider!.subscribe((snap) => {
+   *   console.log('Entities:', snap.world.entityCount);
+   * });
+   * ```
+   */
+  public get debugProvider(): DebugDataProvider | null {
+    return this._debugProvider;
   }
 
   /** System context (for advanced use) */
@@ -273,12 +309,14 @@ export class GameWorld {
     if (this.provider.onPause) {
       this.unsubscribePause = this.provider.onPause(() => {
         this._paused = true;
+        if (this._debugProvider) this._debugProvider.paused = true;
         this.systemRegistry.eventBus.emit(GameWorldEvents.PAUSED, {});
       });
     }
     if (this.provider.onResume) {
       this.unsubscribeResume = this.provider.onResume(() => {
         this._paused = false;
+        if (this._debugProvider) this._debugProvider.paused = false;
         this.systemRegistry.eventBus.emit(GameWorldEvents.RESUMED, {});
       });
     }
@@ -302,6 +340,11 @@ export class GameWorld {
     // Start internal TickFrameManager if we own it
     if (this.ownsProvider && this.provider instanceof TickFrameManager) {
       (this.provider as TickFrameManager).start();
+    }
+
+    // Start debug data provider if configured
+    if (this._debugProvider) {
+      this._debugProvider.start();
     }
   }
 
@@ -329,6 +372,11 @@ export class GameWorld {
     if (this.ownsProvider && this.provider instanceof TickFrameManager) {
       (this.provider as TickFrameManager).stop();
     }
+
+    // Stop debug data provider
+    if (this._debugProvider) {
+      this._debugProvider.stop();
+    }
   }
 
   /**
@@ -336,6 +384,9 @@ export class GameWorld {
    */
   public dispose(): void {
     this.stop();
+    if (this._debugProvider) {
+      this._debugProvider.dispose();
+    }
     if (this._pools) {
       this._pools.drainAll();
     }

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -181,6 +181,7 @@ export class GameWorld {
     } else {
       // Fallback for providers that don't support pause
       this._paused = true;
+      if (this._debugProvider) this._debugProvider.paused = true;
       this.systemRegistry.eventBus.emit(GameWorldEvents.PAUSED, {});
     }
   }
@@ -200,6 +201,7 @@ export class GameWorld {
     } else {
       // Fallback for providers that don't support resume
       this._paused = false;
+      if (this._debugProvider) this._debugProvider.paused = false;
       this.systemRegistry.eventBus.emit(GameWorldEvents.RESUMED, {});
     }
   }

--- a/phalanx-ecs/src/debug/DebugDataProvider.ts
+++ b/phalanx-ecs/src/debug/DebugDataProvider.ts
@@ -62,7 +62,7 @@ export class DebugDataProvider {
     this.updateInterval = config?.updateInterval ?? DEFAULT_UPDATE_INTERVAL;
   }
 
-  // ── Observable API ──────────────────────────────────────────────
+  // ── Observable API ──────────────────────────────────────────────────
 
   /**
    * Subscribe to periodic snapshot updates.
@@ -75,7 +75,7 @@ export class DebugDataProvider {
     };
   }
 
-  // ── Pull API ──────────────────────────────────────────────────
+  // ── Pull API ────────────────────────────────────────────────────────
 
   /**
    * Collect and return a snapshot immediately (no timer dependency).
@@ -84,7 +84,7 @@ export class DebugDataProvider {
     return this.collectSnapshot();
   }
 
-  // ── Lifecycle ─────────────────────────────────────────────────
+  // ── Lifecycle ───────────────────────────────────────────────────────
 
   /**
    * Start the automatic push interval.
@@ -117,7 +117,7 @@ export class DebugDataProvider {
     this.subscribers.clear();
   }
 
-  // ── Internals ─────────────────────────────────────────────────
+  // ── Internals ───────────────────────────────────────────────────────
 
   private push(): void {
     if (this.subscribers.size === 0) return;
@@ -128,15 +128,16 @@ export class DebugDataProvider {
   }
 
   private collectSnapshot(): DebugSnapshot {
+    const soaStores = this.collectSoAStores();
     return {
       timestamp: Date.now(),
       world: {
         entityCount: this.entityManager.count,
-        soaStoreCount: this.entityManager.getAllSoAStores().size,
+        soaStoreCount: soaStores.length,
         paused: this._paused,
       },
       entities: this.collectEntities(),
-      soaStores: this.collectSoAStores(),
+      soaStores,
       pools: this.collectPools(),
     };
   }

--- a/phalanx-ecs/src/debug/DebugDataProvider.ts
+++ b/phalanx-ecs/src/debug/DebugDataProvider.ts
@@ -1,0 +1,217 @@
+import type { EntityManager } from '../EntityManager';
+import type { PoolManager } from '../pool/PoolManager';
+import { calculateSchemaByteSize } from '../SoASchema';
+import type {
+  DebugSnapshot,
+  DebugEntitySnapshot,
+  DebugComponentSnapshot,
+  DebugSoAStoreSnapshot,
+  DebugPoolSnapshot,
+  DebugDataProviderConfig,
+} from './types';
+
+/** Default push interval in milliseconds */
+const DEFAULT_UPDATE_INTERVAL = 500;
+
+type SnapshotCallback = (snapshot: DebugSnapshot) => void;
+
+/**
+ * DebugDataProvider — centralised observable that collects ECS debug snapshots.
+ *
+ * Owns the single update interval. Subscribers receive `DebugSnapshot` objects
+ * on each interval tick. Also exposes `getSnapshot()` for on-demand pull
+ * without subscribing to the timer.
+ *
+ * Usage:
+ * ```ts
+ * const provider = new DebugDataProvider(entityManager, poolManager);
+ * provider.start();
+ *
+ * // Observable pattern
+ * const unsub = provider.subscribe((snap) => console.log(snap.world.entityCount));
+ *
+ * // On-demand pull
+ * const snap = provider.getSnapshot();
+ *
+ * // Cleanup
+ * unsub();
+ * provider.dispose();
+ * ```
+ */
+export class DebugDataProvider {
+  private readonly entityManager: EntityManager;
+  private readonly pools: PoolManager | null;
+  private readonly updateInterval: number;
+
+  private subscribers: Set<SnapshotCallback> = new Set();
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private _paused: boolean = false;
+
+  /** Externally settable — GameWorld updates this so the snapshot reflects pause state */
+  public set paused(value: boolean) {
+    this._paused = value;
+  }
+
+  constructor(
+    entityManager: EntityManager,
+    pools: PoolManager | null,
+    config?: DebugDataProviderConfig,
+  ) {
+    this.entityManager = entityManager;
+    this.pools = pools;
+    this.updateInterval = config?.updateInterval ?? DEFAULT_UPDATE_INTERVAL;
+  }
+
+  // ── Observable API ──────────────────────────────────────────────
+
+  /**
+   * Subscribe to periodic snapshot updates.
+   * @returns Unsubscribe function.
+   */
+  public subscribe(callback: SnapshotCallback): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  // ── Pull API ──────────────────────────────────────────────────
+
+  /**
+   * Collect and return a snapshot immediately (no timer dependency).
+   */
+  public getSnapshot(): DebugSnapshot {
+    return this.collectSnapshot();
+  }
+
+  // ── Lifecycle ─────────────────────────────────────────────────
+
+  /**
+   * Start the automatic push interval.
+   * If updateInterval is 0, no interval is created (pull-only mode).
+   */
+  public start(): void {
+    if (this.intervalId !== null) return; // already running
+    if (this.updateInterval <= 0) return; // pull-only mode
+
+    this.intervalId = setInterval(() => {
+      this.push();
+    }, this.updateInterval);
+  }
+
+  /**
+   * Stop the automatic push interval. Subscribers remain registered.
+   */
+  public stop(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  /**
+   * Stop the interval and remove all subscribers.
+   */
+  public dispose(): void {
+    this.stop();
+    this.subscribers.clear();
+  }
+
+  // ── Internals ─────────────────────────────────────────────────
+
+  private push(): void {
+    if (this.subscribers.size === 0) return;
+    const snapshot = this.collectSnapshot();
+    for (const cb of this.subscribers) {
+      cb(snapshot);
+    }
+  }
+
+  private collectSnapshot(): DebugSnapshot {
+    return {
+      timestamp: Date.now(),
+      world: {
+        entityCount: this.entityManager.count,
+        soaStoreCount: this.entityManager.getAllSoAStores().size,
+        paused: this._paused,
+      },
+      entities: this.collectEntities(),
+      soaStores: this.collectSoAStores(),
+      pools: this.collectPools(),
+    };
+  }
+
+  private collectEntities(): DebugEntitySnapshot[] {
+    const entities = this.entityManager.getAllEntities();
+    const result: DebugEntitySnapshot[] = [];
+
+    for (const entity of entities) {
+      const components: DebugComponentSnapshot[] = [];
+
+      for (const [typeSymbol, component] of entity.getComponents()) {
+        const data: Record<string, unknown> = {};
+        // Shallow-copy own enumerable properties, skip the `type` symbol key
+        for (const key of Object.keys(component)) {
+          if (key === 'type') continue;
+          data[key] = (component as unknown as Record<string, unknown>)[key];
+        }
+
+        components.push({
+          typeName: typeSymbol.description ?? 'unknown',
+          typeSymbol,
+          data,
+        });
+      }
+
+      result.push({
+        id: entity.id,
+        destroyed: entity.isDestroyed,
+        components,
+      });
+    }
+
+    return result;
+  }
+
+  private collectSoAStores(): DebugSoAStoreSnapshot[] {
+    const stores = this.entityManager.getAllSoAStores();
+    const result: DebugSoAStoreSnapshot[] = [];
+
+    for (const store of stores.values()) {
+      const schema = store.schema;
+
+      const entities: DebugSoAStoreSnapshot['entities'] = [];
+      for (const entityId of store.entityIds()) {
+        const fields = store.get(entityId);
+        if (fields) {
+          entities.push({ entityId, fields: fields as Record<string, number | bigint> });
+        }
+      }
+
+      result.push({
+        name: schema.type.description ?? 'unknown',
+        fieldNames: [...schema.fieldNames],
+        fieldTypes: { ...schema.fieldTypes },
+        count: store.count,
+        capacity: store.capacity,
+        bytesPerEntity: calculateSchemaByteSize(schema),
+        entities,
+      });
+    }
+
+    return result;
+  }
+
+  private collectPools(): DebugPoolSnapshot[] {
+    if (!this.pools) return [];
+
+    const result: DebugPoolSnapshot[] = [];
+    const stats = this.pools.getStats();
+
+    for (const [typeKey, poolStats] of stats) {
+      result.push({ typeKey, stats: { ...poolStats } });
+    }
+
+    return result;
+  }
+}

--- a/phalanx-ecs/src/debug/index.ts
+++ b/phalanx-ecs/src/debug/index.ts
@@ -1,0 +1,9 @@
+export { DebugDataProvider } from './DebugDataProvider';
+export type {
+  DebugSnapshot,
+  DebugEntitySnapshot,
+  DebugComponentSnapshot,
+  DebugSoAStoreSnapshot,
+  DebugPoolSnapshot,
+  DebugDataProviderConfig,
+} from './types';

--- a/phalanx-ecs/src/debug/types.ts
+++ b/phalanx-ecs/src/debug/types.ts
@@ -1,0 +1,96 @@
+import type { PoolStats } from '../pool/types';
+import type { SoAFieldType } from '../SoASchema';
+
+/**
+ * Serialised snapshot of a single IComponent attached to an entity.
+ */
+export interface DebugComponentSnapshot {
+  /** Human-readable name derived from symbol.description */
+  typeName: string;
+  /** Original component type symbol */
+  typeSymbol: symbol;
+  /** Shallow copy of the component's own enumerable properties (excluding `type`) */
+  data: Record<string, unknown>;
+}
+
+/**
+ * Serialised snapshot of a single entity and its standard (non-SoA) components.
+ */
+export interface DebugEntitySnapshot {
+  id: number;
+  destroyed: boolean;
+  components: DebugComponentSnapshot[];
+}
+
+/**
+ * Serialised snapshot of one SoA component store.
+ */
+export interface DebugSoAStoreSnapshot {
+  /** Human-readable schema name from symbol.description */
+  name: string;
+  /** Ordered field names from the schema */
+  fieldNames: string[];
+  /** Field name → SoA type string (e.g. 'f64', 'i64', 'u8') */
+  fieldTypes: Record<string, SoAFieldType>;
+  /** Current number of entities in the store */
+  count: number;
+  /** Current allocated capacity */
+  capacity: number;
+  /** Bytes consumed per entity (sum of field byte sizes) */
+  bytesPerEntity: number;
+  /** Per-entity field values */
+  entities: {
+    entityId: number;
+    fields: Record<string, number | bigint>;
+  }[];
+}
+
+/**
+ * Serialised snapshot of one entity pool's stats.
+ */
+export interface DebugPoolSnapshot {
+  /** Pool registration key */
+  typeKey: string;
+  /** Pool statistics */
+  stats: PoolStats;
+}
+
+/**
+ * Complete debug snapshot of the GameWorld state.
+ *
+ * Produced by `DebugDataProvider` on a configurable interval or on demand
+ * via `getSnapshot()`. Designed to be consumed by the built-in DebugPanel
+ * or any custom visualisation tool.
+ */
+export interface DebugSnapshot {
+  /** Timestamp (ms) when this snapshot was collected */
+  timestamp: number;
+
+  /** World-level summary */
+  world: {
+    entityCount: number;
+    soaStoreCount: number;
+    paused: boolean;
+  };
+
+  /** Per-entity data for standard IComponent entities */
+  entities: DebugEntitySnapshot[];
+
+  /** SoA store snapshots */
+  soaStores: DebugSoAStoreSnapshot[];
+
+  /** Pool statistics */
+  pools: DebugPoolSnapshot[];
+}
+
+/**
+ * Configuration for DebugDataProvider.
+ */
+export interface DebugDataProviderConfig {
+  /**
+   * Interval in milliseconds between automatic snapshot pushes.
+   * Set to 0 to disable automatic pushes (pull-only via getSnapshot()).
+   * Default: 500
+   */
+  updateInterval?: number;
+}

--- a/phalanx-ecs/src/index.ts
+++ b/phalanx-ecs/src/index.ts
@@ -58,6 +58,17 @@ export type {
   TypedArrayLike,
 } from './SoASchema';
 
+// Debug / Introspection
+export { DebugDataProvider } from './debug';
+export type {
+  DebugSnapshot,
+  DebugEntitySnapshot,
+  DebugComponentSnapshot,
+  DebugSoAStoreSnapshot,
+  DebugPoolSnapshot,
+  DebugDataProviderConfig,
+} from './debug';
+
 // Tick/Frame Management
 export { TickFrameManager } from './TickFrameManager';
 export type { TickFrameManagerConfig } from './TickFrameManager';

--- a/phalanx-ecs/tests/debug/DebugAccessors.test.ts
+++ b/phalanx-ecs/tests/debug/DebugAccessors.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Entity, resetEntityIdCounter } from '../../src/Entity';
+import { EntityManager } from '../../src/EntityManager';
+import { SoAComponent } from '../../src/SoAComponent';
+import { defineSoASchema } from '../../src/SoASchema';
+import type { IComponent } from '../../src/Component';
+
+// ── Test fixtures ──────────────────────────────────────────────────
+
+const HealthType = Symbol('Health');
+const ArmorType = Symbol('Armor');
+
+class HealthComponent implements IComponent {
+  readonly type = HealthType;
+  constructor(public hp: number = 100) {}
+}
+
+class ArmorComponent implements IComponent {
+  readonly type = ArmorType;
+  constructor(public armor: number = 10) {}
+}
+
+const TestSoASchema = defineSoASchema(
+  { posX: 'f64', posY: 'f64', flags: 'u8' },
+  'TestTransform',
+);
+
+class TestSoAComponent extends SoAComponent<typeof TestSoASchema.definition> {
+  public readonly type = Symbol('TestSoA');
+  static readonly soaSchema = TestSoASchema;
+
+  constructor(entityId: number) {
+    super(TestSoASchema, entityId, { posX: 0, posY: 0, flags: 0 });
+  }
+}
+
+// ── Entity accessor tests ──────────────────────────────────────────
+
+describe('Entity debug accessors', () => {
+  beforeEach(() => {
+    resetEntityIdCounter();
+  });
+
+  it('getComponentTypes returns empty array for entity with no components', () => {
+    const entity = new Entity();
+    expect(entity.getComponentTypes()).toEqual([]);
+  });
+
+  it('getComponentTypes returns all attached component type symbols', () => {
+    const entity = new Entity();
+    entity.addComponent(new HealthComponent());
+    entity.addComponent(new ArmorComponent());
+
+    const types = entity.getComponentTypes();
+    expect(types).toHaveLength(2);
+    expect(types).toContain(HealthType);
+    expect(types).toContain(ArmorType);
+  });
+
+  it('getComponents returns a read-only map of all components', () => {
+    const entity = new Entity();
+    const health = new HealthComponent(75);
+    entity.addComponent(health);
+
+    const components = entity.getComponents();
+    expect(components.size).toBe(1);
+    expect(components.get(HealthType)).toBe(health);
+  });
+
+  it('getComponents reflects additions and removals', () => {
+    const entity = new Entity();
+    entity.addComponent(new HealthComponent());
+    expect(entity.getComponents().size).toBe(1);
+
+    entity.addComponent(new ArmorComponent());
+    expect(entity.getComponents().size).toBe(2);
+
+    entity.removeComponent(HealthType);
+    expect(entity.getComponents().size).toBe(1);
+    expect(entity.getComponents().has(ArmorType)).toBe(true);
+  });
+});
+
+// ── EntityManager accessor tests ───────────────────────────────────
+
+describe('EntityManager debug accessors', () => {
+  let em: EntityManager;
+
+  beforeEach(() => {
+    resetEntityIdCounter();
+    em = new EntityManager();
+    em.registerComponentTypes([HealthType, ArmorType]);
+    SoAComponent.useEntityManager(em);
+  });
+
+  it('getAllSoAStores returns empty map when no SoA stores exist', () => {
+    const stores = em.getAllSoAStores();
+    expect(stores.size).toBe(0);
+  });
+
+  it('getAllSoAStores returns registered SoA stores', () => {
+    const entity = new Entity();
+    em.addEntity(entity);
+
+    // Creating a SoAComponent triggers store creation
+    new TestSoAComponent(entity.id);
+
+    const stores = em.getAllSoAStores();
+    expect(stores.size).toBe(1);
+
+    const store = stores.get(TestSoASchema.type);
+    expect(store).toBeDefined();
+    expect(store!.count).toBe(1);
+  });
+
+  it('getComponentTypeStats returns correct counts', () => {
+    const e1 = new Entity();
+    e1.addComponent(new HealthComponent());
+    e1.addComponent(new ArmorComponent());
+    em.addEntity(e1);
+
+    const e2 = new Entity();
+    e2.addComponent(new HealthComponent());
+    em.addEntity(e2);
+
+    const stats = em.getComponentTypeStats();
+    expect(stats.get(HealthType)).toBe(2);
+    expect(stats.get(ArmorType)).toBe(1);
+  });
+
+  it('getComponentTypeStats returns zero for unused types', () => {
+    const stats = em.getComponentTypeStats();
+    expect(stats.get(HealthType)).toBe(0);
+    expect(stats.get(ArmorType)).toBe(0);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+});

--- a/phalanx-ecs/tests/debug/DebugDataProvider.test.ts
+++ b/phalanx-ecs/tests/debug/DebugDataProvider.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Entity, resetEntityIdCounter } from '../../src/Entity';
+import { EntityManager } from '../../src/EntityManager';
+import { SoAComponent } from '../../src/SoAComponent';
+import { defineSoASchema } from '../../src/SoASchema';
+import { PoolManager } from '../../src/pool/PoolManager';
+import { DebugDataProvider } from '../../src/debug/DebugDataProvider';
+import type { IComponent } from '../../src/Component';
+import type { DebugSnapshot } from '../../src/debug/types';
+
+// ── Test fixtures ──────────────────────────────────────────────────
+
+const HealthType = Symbol('Health');
+const ArmorType = Symbol('Armor');
+
+class HealthComponent implements IComponent {
+  readonly type = HealthType;
+  constructor(public hp: number = 100) {}
+}
+
+class ArmorComponent implements IComponent {
+  readonly type = ArmorType;
+  constructor(public armor: number = 10) {}
+}
+
+const PhysicsSoASchema = defineSoASchema(
+  { velocityX: 'i64', velocityY: 'i64', radius: 'f64', isStatic: 'u8' },
+  'PhysicsBody',
+);
+
+class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.definition> {
+  public readonly type = Symbol('PhysicsBody');
+  static readonly soaSchema = PhysicsSoASchema;
+
+  constructor(entityId: number, radius: number = 1.0) {
+    super(PhysicsSoASchema, entityId, {
+      velocityX: 0n,
+      velocityY: 0n,
+      radius,
+      isStatic: 0,
+    });
+  }
+}
+
+// ── Helper ─────────────────────────────────────────────────────
+
+function createProvider(
+  em: EntityManager,
+  pools: PoolManager | null = null,
+  interval = 0,
+): DebugDataProvider {
+  return new DebugDataProvider(em, pools, { updateInterval: interval });
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('DebugDataProvider', () => {
+  let em: EntityManager;
+
+  beforeEach(() => {
+    resetEntityIdCounter();
+    em = new EntityManager();
+    em.registerComponentTypes([HealthType, ArmorType]);
+    SoAComponent.useEntityManager(em);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  // ── Snapshot content ────────────────────────────────────────────
+
+  describe('getSnapshot()', () => {
+    it('returns correct world summary', () => {
+      const e1 = new Entity();
+      em.addEntity(e1);
+      const e2 = new Entity();
+      em.addEntity(e2);
+
+      const provider = createProvider(em);
+      const snap = provider.getSnapshot();
+
+      expect(snap.world.entityCount).toBe(2);
+      expect(snap.world.paused).toBe(false);
+      expect(snap.timestamp).toBeGreaterThan(0);
+    });
+
+    it('reflects paused state', () => {
+      const provider = createProvider(em);
+      provider.paused = true;
+      expect(provider.getSnapshot().world.paused).toBe(true);
+
+      provider.paused = false;
+      expect(provider.getSnapshot().world.paused).toBe(false);
+    });
+
+    it('collects standard entity components', () => {
+      const entity = new Entity();
+      entity.addComponent(new HealthComponent(75));
+      entity.addComponent(new ArmorComponent(20));
+      em.addEntity(entity);
+
+      const snap = createProvider(em).getSnapshot();
+
+      expect(snap.entities).toHaveLength(1);
+      expect(snap.entities[0].id).toBe(entity.id);
+      expect(snap.entities[0].destroyed).toBe(false);
+      expect(snap.entities[0].components).toHaveLength(2);
+
+      const healthSnap = snap.entities[0].components.find(
+        (c) => c.typeName === 'Health',
+      );
+      expect(healthSnap).toBeDefined();
+      expect(healthSnap!.data.hp).toBe(75);
+
+      const armorSnap = snap.entities[0].components.find(
+        (c) => c.typeName === 'Armor',
+      );
+      expect(armorSnap).toBeDefined();
+      expect(armorSnap!.data.armor).toBe(20);
+    });
+
+    it('collects SoA store data with correct field types', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+      new PhysicsBodyComponent(entity.id, 2.5);
+
+      const snap = createProvider(em).getSnapshot();
+
+      expect(snap.soaStores).toHaveLength(1);
+      const store = snap.soaStores[0];
+      expect(store.name).toBe('PhysicsBody');
+      expect(store.fieldNames).toEqual(['velocityX', 'velocityY', 'radius', 'isStatic']);
+      expect(store.fieldTypes.velocityX).toBe('i64');
+      expect(store.fieldTypes.radius).toBe('f64');
+      expect(store.fieldTypes.isStatic).toBe('u8');
+      expect(store.count).toBe(1);
+      expect(store.capacity).toBeGreaterThan(0);
+      expect(store.bytesPerEntity).toBe(8 + 8 + 8 + 1); // i64 + i64 + f64 + u8 = 25
+    });
+
+    it('includes per-entity SoA field values with bigint preserved', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+      new PhysicsBodyComponent(entity.id, 3.14);
+
+      const snap = createProvider(em).getSnapshot();
+      const storeSnap = snap.soaStores[0];
+
+      expect(storeSnap.entities).toHaveLength(1);
+      expect(storeSnap.entities[0].entityId).toBe(entity.id);
+      expect(storeSnap.entities[0].fields.velocityX).toBe(0n);
+      expect(storeSnap.entities[0].fields.radius).toBeCloseTo(3.14);
+      expect(storeSnap.entities[0].fields.isStatic).toBe(0);
+    });
+
+    it('reports soaStoreCount in world summary', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+      new PhysicsBodyComponent(entity.id);
+
+      const snap = createProvider(em).getSnapshot();
+      expect(snap.world.soaStoreCount).toBe(1);
+    });
+
+    it('collects pool stats when PoolManager is provided', () => {
+      const pools = new PoolManager();
+      pools.registerEntityType('projectile', {
+        factory: () => new Entity(),
+        pool: { initialSize: 10 },
+      });
+      pools.prewarmAll();
+
+      const snap = createProvider(em, pools).getSnapshot();
+
+      expect(snap.pools).toHaveLength(1);
+      expect(snap.pools[0].typeKey).toBe('projectile');
+      expect(snap.pools[0].stats.available).toBe(10);
+      expect(snap.pools[0].stats.totalCreated).toBe(10);
+    });
+
+    it('returns empty pools array when no PoolManager', () => {
+      const snap = createProvider(em, null).getSnapshot();
+      expect(snap.pools).toEqual([]);
+    });
+
+    it('returns empty entities array for empty world', () => {
+      const snap = createProvider(em).getSnapshot();
+      expect(snap.entities).toEqual([]);
+      expect(snap.soaStores).toEqual([]);
+      expect(snap.world.entityCount).toBe(0);
+    });
+  });
+
+  // ── Observable pattern ──────────────────────────────────────────
+
+  describe('subscribe / push', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('delivers snapshots to subscribers on interval', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const snapshots: DebugSnapshot[] = [];
+      provider.subscribe((snap) => snapshots.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(350);
+
+      expect(snapshots.length).toBe(3);
+      expect(snapshots[0].world.entityCount).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('does not push when there are no subscribers', () => {
+      // This mainly tests that no errors are thrown
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      provider.start();
+      vi.advanceTimersByTime(500);
+      provider.dispose();
+    });
+
+    it('unsubscribe stops delivery to that callback', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const snapshots: DebugSnapshot[] = [];
+      const unsub = provider.subscribe((snap) => snapshots.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(150); // 1 push
+      expect(snapshots.length).toBe(1);
+
+      unsub();
+      vi.advanceTimersByTime(300); // 3 more intervals, but unsubscribed
+      expect(snapshots.length).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('supports multiple subscribers', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const a: DebugSnapshot[] = [];
+      const b: DebugSnapshot[] = [];
+      provider.subscribe((snap) => a.push(snap));
+      provider.subscribe((snap) => b.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(150);
+      expect(a.length).toBe(1);
+      expect(b.length).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('stop halts pushes but keeps subscribers', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const snapshots: DebugSnapshot[] = [];
+      provider.subscribe((snap) => snapshots.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(150);
+      expect(snapshots.length).toBe(1);
+
+      provider.stop();
+      vi.advanceTimersByTime(500);
+      expect(snapshots.length).toBe(1);
+
+      // Re-start still works because subscribers were kept
+      provider.start();
+      vi.advanceTimersByTime(150);
+      expect(snapshots.length).toBe(2);
+
+      provider.dispose();
+    });
+
+    it('dispose stops interval and clears subscribers', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const snapshots: DebugSnapshot[] = [];
+      provider.subscribe((snap) => snapshots.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(150);
+      expect(snapshots.length).toBe(1);
+
+      provider.dispose();
+      vi.advanceTimersByTime(500);
+      expect(snapshots.length).toBe(1);
+
+      // Re-start after dispose: no subscribers, so no pushes
+      provider.start();
+      vi.advanceTimersByTime(300);
+      expect(snapshots.length).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('does not create interval when updateInterval is 0 (pull-only)', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 0 });
+      const snapshots: DebugSnapshot[] = [];
+      provider.subscribe((snap) => snapshots.push(snap));
+      provider.start();
+
+      vi.advanceTimersByTime(2000);
+      expect(snapshots.length).toBe(0);
+
+      // But getSnapshot still works
+      const snap = provider.getSnapshot();
+      expect(snap.world.entityCount).toBe(0);
+
+      provider.dispose();
+    });
+
+    it('start is idempotent (does not create duplicate intervals)', () => {
+      const provider = new DebugDataProvider(em, null, { updateInterval: 100 });
+      const snapshots: DebugSnapshot[] = [];
+      provider.subscribe((snap) => snapshots.push(snap));
+
+      provider.start();
+      provider.start(); // should be no-op
+      provider.start(); // should be no-op
+
+      vi.advanceTimersByTime(150);
+      expect(snapshots.length).toBe(1); // not 3
+
+      provider.dispose();
+    });
+  });
+
+  // ── GameWorld integration ───────────────────────────────────────
+
+  describe('GameWorld integration', () => {
+    // We test this by importing GameWorld directly
+    it('GameWorld creates provider when debug is true', async () => {
+      // Dynamic import to avoid circular issues in test setup
+      const { GameWorld } = await import('../../src/GameWorld');
+
+      const world = new GameWorld({
+        componentTypes: [HealthType],
+        debug: true,
+        debugConfig: { updateInterval: 0 },
+      });
+
+      expect(world.debugProvider).not.toBeNull();
+      expect(world.debugProvider).toBeInstanceOf(DebugDataProvider);
+
+      // Snapshot works
+      const snap = world.debugProvider!.getSnapshot();
+      expect(snap.world.entityCount).toBe(0);
+
+      world.dispose();
+    });
+
+    it('GameWorld does not create provider when debug is false', async () => {
+      const { GameWorld } = await import('../../src/GameWorld');
+
+      const world = new GameWorld({ componentTypes: [HealthType] });
+      expect(world.debugProvider).toBeNull();
+
+      world.dispose();
+    });
+
+    it('GameWorld provider reflects entities added to the world', async () => {
+      const { GameWorld } = await import('../../src/GameWorld');
+
+      const world = new GameWorld({
+        componentTypes: [HealthType],
+        debug: true,
+        debugConfig: { updateInterval: 0 },
+      });
+
+      const entity = new Entity();
+      entity.addComponent(new HealthComponent(50));
+      world.entityManager.addEntity(entity);
+
+      const snap = world.debugProvider!.getSnapshot();
+      expect(snap.world.entityCount).toBe(1);
+      expect(snap.entities[0].components[0].data.hp).toBe(50);
+
+      world.dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Iteration 1 of the debug panel feature: introduces the **data layer** — debug accessors, snapshot types, and a centralised `DebugDataProvider` with observable pattern.

This provides the foundation for Iteration 2 (DOM-based DebugPanel with drag, collapse, and all visual sections).

## Changes

### New files
- `phalanx-ecs/src/debug/types.ts` — `DebugSnapshot`, `DebugEntitySnapshot`, `DebugComponentSnapshot`, `DebugSoAStoreSnapshot`, `DebugPoolSnapshot`, `DebugDataProviderConfig` interfaces
- `phalanx-ecs/src/debug/DebugDataProvider.ts` — Observable provider: `subscribe()`, `getSnapshot()`, `start()/stop()/dispose()`, single `setInterval` owner
- `phalanx-ecs/src/debug/index.ts` — Barrel exports
- `phalanx-ecs/tests/debug/DebugAccessors.test.ts` — 8 tests for Entity/EntityManager accessors
- `phalanx-ecs/tests/debug/DebugDataProvider.test.ts` — 20 tests for snapshot content, observable pattern, GameWorld integration

### Modified files
- `phalanx-ecs/src/Entity.ts` — Added `getComponentTypes(): symbol[]` and `getComponents(): ReadonlyMap<symbol, IComponent>`
- `phalanx-ecs/src/EntityManager.ts` — Added `getAllSoAStores()` and `getComponentTypeStats()`
- `phalanx-ecs/src/GameWorld.ts` — Added `debug?: boolean` and `debugConfig?: DebugDataProviderConfig` to config; creates/starts/stops/disposes `DebugDataProvider`; syncs pause state
- `phalanx-ecs/src/index.ts` — Added debug module exports

## Architecture

```
Layer 1: Debug Accessors (Entity + EntityManager)
  ↓ pure data access, no allocations on hot path
Layer 2: DebugDataProvider (this PR)
  ↓ single interval, observable pattern, pull API
Layer 3: DebugPanel (Iteration 2, future PR)
  ↓ DOM renderer, draggable, collapsible
```

### Key design decisions
- **Single interval owner**: `DebugDataProvider` owns the only `setInterval` — no scattered timers
- **Observable + pull**: `subscribe()` for push, `getSnapshot()` for on-demand pull
- **Config-gated**: Enabled via `GameWorld({ debug: true })`, zero overhead when disabled
- **SoA-aware**: Snapshots include typed array field types, byte sizes, capacity, and per-entity field values with bigint preserved for `i64`/`u64` fields
- **Pool-aware**: Snapshots include pool stats (available, in-use, total created, peak, etc.)

## Test results

```
✓ tests/debug/DebugDataProvider.test.ts  (20 tests)
✓ tests/debug/DebugAccessors.test.ts     (8 tests)
✓ tests/SoAComponent.test.ts             (17 tests)
✓ tests/PoolManager.test.ts              (13 tests)
✓ tests/EntityPool.test.ts               (10 tests)
✓ tests/ObjectPool.test.ts               (11 tests)
✓ tests/Entity.test.ts                   (9 tests)

Test Files  7 passed (7)
     Tests  88 passed (88)
```

All 60 existing tests continue to pass. 28 new tests added. TypeScript compiles cleanly (`tsc --noEmit`).