### PR TITLE
feat(debug): add DebugPanel DOM renderer (Iteration 2)

### DIFF
--- a/phalanx-ecs/package.json
+++ b/phalanx-ecs/package.json
@@ -17,8 +17,8 @@
     "rebuild": "npm run clean && npm run build",
     "test": "vitest run"
   },
-  "dependencies": {},
   "devDependencies": {
+    "happy-dom": "^20.8.4",
     "typescript": "~5.9.3"
   },
   "keywords": [

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -3,7 +3,8 @@ import { TickFrameManager } from './TickFrameManager';
 import { SoAComponent } from './SoAComponent';
 import { PoolManager } from './pool/PoolManager';
 import { DebugDataProvider } from './debug/DebugDataProvider';
-import type { DebugDataProviderConfig } from './debug/types';
+import { DebugPanel } from './debug/DebugPanel';
+import type { DebugDataProviderConfig, DebugPanelConfig } from './debug/types';
 import type { PoolingConfig } from './pool/types';
 import type { ITickFrameProvider, Unsubscribe } from './ITickFrameProvider';
 import type { EventBus } from './EventBus';
@@ -40,6 +41,8 @@ export interface GameWorldConfig {
   debug?: boolean;
   /** Configuration for the debug data provider (update interval, etc.). Only used when debug is true. */
   debugConfig?: DebugDataProviderConfig;
+  /** Configuration for the debug panel UI. Only used when debug is true. */
+  debugPanelConfig?: DebugPanelConfig;
 }
 
 /**
@@ -96,6 +99,8 @@ export class GameWorld {
   private readonly _pools: PoolManager | null;
   private readonly _poolingConfig: PoolingConfig | undefined;
   private readonly _debugProvider: DebugDataProvider | null;
+  private readonly _debugPanelConfig: DebugPanelConfig | undefined;
+  private _debugPanel: DebugPanel | null = null;
 
   // Unsubscribe handles for tick/frame
   private unsubscribeTick: Unsubscribe | null = null;
@@ -148,8 +153,10 @@ export class GameWorld {
         this._pools,
         config.debugConfig,
       );
+      this._debugPanelConfig = config.debugPanelConfig;
     } else {
       this._debugProvider = null;
+      this._debugPanelConfig = undefined;
     }
   }
 
@@ -239,6 +246,11 @@ export class GameWorld {
    */
   public get debugProvider(): DebugDataProvider | null {
     return this._debugProvider;
+  }
+
+  /** Debug panel DOM renderer. null if debug mode is not enabled or panel not yet created. */
+  public get debugPanel(): DebugPanel | null {
+    return this._debugPanel;
   }
 
   /** System context (for advanced use) */
@@ -347,6 +359,11 @@ export class GameWorld {
     // Start debug data provider if configured
     if (this._debugProvider) {
       this._debugProvider.start();
+
+      // Auto-create panel if DOM is available
+      if (typeof document !== 'undefined') {
+        this._debugPanel = new DebugPanel(this._debugProvider, this._debugPanelConfig);
+      }
     }
   }
 
@@ -373,6 +390,12 @@ export class GameWorld {
 
     if (this.ownsProvider && this.provider instanceof TickFrameManager) {
       (this.provider as TickFrameManager).stop();
+    }
+
+    // Destroy debug panel
+    if (this._debugPanel) {
+      this._debugPanel.destroy();
+      this._debugPanel = null;
     }
 
     // Stop debug data provider

--- a/phalanx-ecs/src/GameWorld.ts
+++ b/phalanx-ecs/src/GameWorld.ts
@@ -41,7 +41,14 @@ export interface GameWorldConfig {
   debug?: boolean;
   /** Configuration for the debug data provider (update interval, etc.). Only used when debug is true. */
   debugConfig?: DebugDataProviderConfig;
-  /** Configuration for the debug panel UI. Only used when debug is true. */
+  /**
+   * Configuration for the built-in DebugPanel DOM overlay.
+   * Only used when `debug` is true.
+   *
+   * When provided (even as `{}`), a DebugPanel is auto-created in `start()`
+   * if a DOM environment is detected. Omit to use DebugDataProvider without
+   * the built-in panel (e.g. for custom tooling or headless environments).
+   */
   debugPanelConfig?: DebugPanelConfig;
 }
 
@@ -360,8 +367,11 @@ export class GameWorld {
     if (this._debugProvider) {
       this._debugProvider.start();
 
-      // Auto-create panel if DOM is available
-      if (typeof document !== 'undefined') {
+      // Auto-create panel only when debugPanelConfig was explicitly provided
+      // and a DOM environment is available. This keeps the overlay opt-in so
+      // consumers who only need DebugDataProvider aren't surprised by DOM
+      // side effects.
+      if (this._debugPanelConfig !== undefined && typeof document !== 'undefined') {
         this._debugPanel = new DebugPanel(this._debugProvider, this._debugPanelConfig);
       }
     }

--- a/phalanx-ecs/src/debug/DebugPanel.ts
+++ b/phalanx-ecs/src/debug/DebugPanel.ts
@@ -1,0 +1,637 @@
+import type { DebugDataProvider } from './DebugDataProvider';
+import type {
+  DebugSnapshot,
+  DebugEntitySnapshot,
+  DebugSoAStoreSnapshot,
+  DebugPoolSnapshot,
+  DebugPanelConfig,
+} from './types';
+
+const FONT_MONO = "'Consolas', 'Monaco', 'Courier New', monospace";
+const COLOR_BG = 'rgba(15, 15, 20, 0.92)';
+const COLOR_TEXT = '#c8ccd0';
+const COLOR_ACCENT = '#4fc3f7';
+const COLOR_WARNING = '#ffb74d';
+
+/**
+ * DebugPanel — Pure DOM renderer that subscribes to DebugDataProvider
+ * and renders an overlay panel with ECS debug information.
+ *
+ * All styles are inline. No CSS files. Works in any browser environment
+ * with a `document` global.
+ */
+export class DebugPanel {
+  private readonly provider: DebugDataProvider;
+  private readonly toggleKey: string;
+  private readonly unsubscribe: () => void;
+  private readonly keydownHandler: (e: KeyboardEvent) => void;
+  private readonly mouseMoveHandler: (e: MouseEvent) => void;
+  private readonly mouseUpHandler: () => void;
+
+  // Root DOM
+  private readonly root: HTMLDivElement;
+  private readonly titleBar: HTMLDivElement;
+  private readonly titleText: HTMLSpanElement;
+  private readonly toggleBtn: HTMLSpanElement;
+  private readonly body: HTMLDivElement;
+
+  // Sections
+  private readonly worldSection: HTMLDivElement;
+  private readonly entityCountEl: HTMLSpanElement;
+  private readonly soaCountEl: HTMLSpanElement;
+  private readonly pausedEl: HTMLSpanElement;
+
+  private readonly entitiesSection: HTMLDivElement;
+  private readonly entitiesHeader: HTMLDivElement;
+  private readonly entitiesBody: HTMLDivElement;
+  private readonly entitiesSummary: HTMLSpanElement;
+
+  private readonly soaSection: HTMLDivElement;
+  private readonly soaHeader: HTMLDivElement;
+  private readonly soaBody: HTMLDivElement;
+  private readonly soaSummary: HTMLSpanElement;
+
+  private readonly poolSection: HTMLDivElement;
+  private readonly poolHeader: HTMLDivElement;
+  private readonly poolBody: HTMLDivElement;
+  private readonly poolSummary: HTMLSpanElement;
+
+  // State
+  private collapsed: boolean;
+  private entitiesSectionCollapsed = false;
+  private soaSectionCollapsed = false;
+  private poolSectionCollapsed = false;
+  private expandedEntities: Set<number> = new Set();
+
+  // Drag state
+  private dragging = false;
+  private dragOffsetX = 0;
+  private dragOffsetY = 0;
+
+  constructor(provider: DebugDataProvider, config?: DebugPanelConfig) {
+    this.provider = provider;
+    this.toggleKey = config?.toggleKey ?? '`';
+    this.collapsed = config?.startCollapsed ?? false;
+
+    // Build DOM
+    this.root = document.createElement('div');
+    this.applyRootStyles();
+
+    // Title bar
+    this.titleBar = document.createElement('div');
+    this.applyTitleBarStyles();
+
+    this.titleText = document.createElement('span');
+    this.titleText.textContent = '\u2699 Phalanx Debug';
+
+    this.toggleBtn = document.createElement('span');
+    this.applyToggleBtnStyles();
+    this.updateToggleBtn();
+
+    this.titleBar.appendChild(this.titleText);
+    this.titleBar.appendChild(this.toggleBtn);
+    this.root.appendChild(this.titleBar);
+
+    // Body container
+    this.body = document.createElement('div');
+    this.body.style.padding = '6px 8px';
+    this.body.style.maxHeight = '80vh';
+    this.body.style.overflowY = 'auto';
+    this.body.style.display = this.collapsed ? 'none' : 'block';
+    this.root.appendChild(this.body);
+
+    // World overview (always visible)
+    this.worldSection = document.createElement('div');
+    this.worldSection.style.marginBottom = '6px';
+    this.worldSection.style.paddingBottom = '4px';
+    this.worldSection.style.borderBottom = '1px solid rgba(255,255,255,0.1)';
+
+    const worldLabel = document.createElement('div');
+    worldLabel.style.fontSize = '12px';
+    worldLabel.style.fontWeight = 'bold';
+    worldLabel.style.color = COLOR_ACCENT;
+    worldLabel.style.marginBottom = '2px';
+    worldLabel.textContent = 'World Overview';
+    this.worldSection.appendChild(worldLabel);
+
+    const worldDataRow = document.createElement('div');
+    worldDataRow.style.fontSize = '11px';
+
+    this.entityCountEl = document.createElement('span');
+    this.soaCountEl = document.createElement('span');
+    this.pausedEl = document.createElement('span');
+
+    worldDataRow.appendChild(this.createLabel('Entities: '));
+    worldDataRow.appendChild(this.entityCountEl);
+    worldDataRow.appendChild(this.createSeparator());
+    worldDataRow.appendChild(this.createLabel('SoA Stores: '));
+    worldDataRow.appendChild(this.soaCountEl);
+    worldDataRow.appendChild(this.createSeparator());
+    worldDataRow.appendChild(this.pausedEl);
+
+    this.worldSection.appendChild(worldDataRow);
+    this.body.appendChild(this.worldSection);
+
+    // Entities section
+    const entitiesResult = this.buildCollapsibleSection('Entities');
+    this.entitiesSection = entitiesResult.section;
+    this.entitiesHeader = entitiesResult.header;
+    this.entitiesBody = entitiesResult.body;
+    this.entitiesSummary = entitiesResult.summary;
+    this.body.appendChild(this.entitiesSection);
+
+    // SoA Stores section
+    const soaResult = this.buildCollapsibleSection('SoA Stores');
+    this.soaSection = soaResult.section;
+    this.soaHeader = soaResult.header;
+    this.soaBody = soaResult.body;
+    this.soaSummary = soaResult.summary;
+    this.body.appendChild(this.soaSection);
+
+    // Pool Stats section
+    const poolResult = this.buildCollapsibleSection('Pool Stats');
+    this.poolSection = poolResult.section;
+    this.poolHeader = poolResult.header;
+    this.poolBody = poolResult.body;
+    this.poolSummary = poolResult.summary;
+    this.body.appendChild(this.poolSection);
+
+    // Attach to DOM
+    document.body.appendChild(this.root);
+
+    // Subscribe to provider
+    this.unsubscribe = this.provider.subscribe((snapshot) => {
+      this.renderSnapshot(snapshot);
+    });
+
+    // Render initial snapshot
+    this.renderSnapshot(this.provider.getSnapshot());
+
+    // Drag handling
+    this.titleBar.addEventListener('mousedown', (e: MouseEvent) => {
+      e.preventDefault();
+      this.dragging = true;
+      this.dragOffsetX = e.clientX - this.root.offsetLeft;
+      this.dragOffsetY = e.clientY - this.root.offsetTop;
+    });
+
+    this.mouseMoveHandler = (e: MouseEvent) => {
+      if (!this.dragging) return;
+      this.root.style.left = (e.clientX - this.dragOffsetX) + 'px';
+      this.root.style.top = (e.clientY - this.dragOffsetY) + 'px';
+      this.root.style.right = 'auto';
+    };
+
+    this.mouseUpHandler = () => {
+      this.dragging = false;
+    };
+
+    document.addEventListener('mousemove', this.mouseMoveHandler);
+    document.addEventListener('mouseup', this.mouseUpHandler);
+
+    // Keyboard shortcut
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (this.toggleKey === '') return;
+      if (e.key !== this.toggleKey) return;
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+      this.toggleCollapse();
+    };
+    document.addEventListener('keydown', this.keydownHandler);
+
+    // Toggle button click
+    this.toggleBtn.addEventListener('click', (e: MouseEvent) => {
+      e.stopPropagation();
+      this.toggleCollapse();
+    });
+
+    // Section collapse handlers
+    this.entitiesHeader.addEventListener('click', () => {
+      this.entitiesSectionCollapsed = !this.entitiesSectionCollapsed;
+      this.applySectionCollapse(this.entitiesHeader, this.entitiesBody, this.entitiesSectionCollapsed);
+    });
+    this.soaHeader.addEventListener('click', () => {
+      this.soaSectionCollapsed = !this.soaSectionCollapsed;
+      this.applySectionCollapse(this.soaHeader, this.soaBody, this.soaSectionCollapsed);
+    });
+    this.poolHeader.addEventListener('click', () => {
+      this.poolSectionCollapsed = !this.poolSectionCollapsed;
+      this.applySectionCollapse(this.poolHeader, this.poolBody, this.poolSectionCollapsed);
+    });
+  }
+
+  /**
+   * Clean up: unsubscribe from provider, remove DOM, detach listeners.
+   */
+  public destroy(): void {
+    this.unsubscribe();
+    document.removeEventListener('keydown', this.keydownHandler);
+    document.removeEventListener('mousemove', this.mouseMoveHandler);
+    document.removeEventListener('mouseup', this.mouseUpHandler);
+    if (this.root.parentNode) {
+      this.root.parentNode.removeChild(this.root);
+    }
+  }
+
+  /**
+   * The root DOM element of the panel.
+   */
+  public get element(): HTMLDivElement {
+    return this.root;
+  }
+
+  // ── Rendering ──────────────────────────────────────────────────────
+
+  private renderSnapshot(snapshot: DebugSnapshot): void {
+    // World overview — always update
+    this.entityCountEl.textContent = String(snapshot.world.entityCount);
+    this.soaCountEl.textContent = String(snapshot.world.soaStoreCount);
+
+    if (snapshot.world.paused) {
+      this.pausedEl.textContent = 'PAUSED';
+      this.pausedEl.style.color = COLOR_WARNING;
+      this.pausedEl.style.fontWeight = 'bold';
+    } else {
+      this.pausedEl.textContent = 'Running';
+      this.pausedEl.style.color = COLOR_TEXT;
+      this.pausedEl.style.fontWeight = 'normal';
+    }
+
+    // Section summaries
+    this.entitiesSummary.textContent = `(${snapshot.entities.length} entities)`;
+    this.soaSummary.textContent = `(${snapshot.soaStores.length} stores)`;
+    this.poolSummary.textContent = `(${snapshot.pools.length} pools)`;
+
+    // Entities
+    if (!this.entitiesSectionCollapsed) {
+      this.renderEntities(snapshot.entities);
+    }
+
+    // SoA Stores
+    if (!this.soaSectionCollapsed) {
+      this.renderSoAStores(snapshot.soaStores);
+    }
+
+    // Pool Stats
+    if (!this.poolSectionCollapsed) {
+      this.renderPoolStats(snapshot.pools);
+    }
+  }
+
+  private renderEntities(entities: DebugEntitySnapshot[]): void {
+    this.entitiesBody.innerHTML = '';
+
+    for (const entity of entities) {
+      const row = document.createElement('div');
+      row.style.cursor = 'pointer';
+      row.style.padding = '2px 0';
+      row.style.fontSize = '11px';
+      row.style.borderBottom = '1px solid rgba(255,255,255,0.05)';
+
+      const componentNames = entity.components.map((c) => c.typeName).join(', ');
+      const label = document.createElement('span');
+      label.textContent = `[ID: ${entity.id}] ${componentNames}`;
+      row.appendChild(label);
+
+      const isExpanded = this.expandedEntities.has(entity.id);
+
+      row.addEventListener('click', () => {
+        if (this.expandedEntities.has(entity.id)) {
+          this.expandedEntities.delete(entity.id);
+        } else {
+          this.expandedEntities.add(entity.id);
+        }
+        // Re-render entities from last snapshot — trigger a fresh snapshot
+        this.renderEntities(this.provider.getSnapshot().entities);
+      });
+
+      this.entitiesBody.appendChild(row);
+
+      if (isExpanded) {
+        const detail = document.createElement('div');
+        detail.style.paddingLeft = '12px';
+        detail.style.fontSize = '11px';
+        detail.style.color = '#a0a4a8';
+        detail.style.marginBottom = '4px';
+
+        for (const comp of entity.components) {
+          const compHeader = document.createElement('div');
+          compHeader.style.color = COLOR_ACCENT;
+          compHeader.style.marginTop = '2px';
+          compHeader.textContent = comp.typeName;
+          detail.appendChild(compHeader);
+
+          for (const [key, value] of Object.entries(comp.data)) {
+            const kvRow = document.createElement('div');
+            kvRow.style.paddingLeft = '8px';
+
+            const keySpan = document.createElement('span');
+            keySpan.style.color = '#888';
+            keySpan.textContent = `${key}: `;
+
+            const valSpan = document.createElement('span');
+            valSpan.textContent = this.formatValue(value);
+
+            kvRow.appendChild(keySpan);
+            kvRow.appendChild(valSpan);
+            detail.appendChild(kvRow);
+          }
+        }
+
+        this.entitiesBody.appendChild(detail);
+      }
+    }
+  }
+
+  private renderSoAStores(stores: DebugSoAStoreSnapshot[]): void {
+    this.soaBody.innerHTML = '';
+
+    for (const store of stores) {
+      const storeDiv = document.createElement('div');
+      storeDiv.style.marginBottom = '6px';
+      storeDiv.style.paddingBottom = '4px';
+      storeDiv.style.borderBottom = '1px solid rgba(255,255,255,0.05)';
+
+      // Store name
+      const nameEl = document.createElement('div');
+      nameEl.style.color = COLOR_ACCENT;
+      nameEl.style.fontSize = '11px';
+      nameEl.style.fontWeight = 'bold';
+      nameEl.textContent = store.name;
+      storeDiv.appendChild(nameEl);
+
+      // Field layout
+      const layoutEl = document.createElement('div');
+      layoutEl.style.fontSize = '11px';
+      layoutEl.style.color = '#888';
+      const fieldDesc = store.fieldNames
+        .map((n) => `${n}: ${store.fieldTypes[n]}`)
+        .join(', ');
+      layoutEl.textContent = `Fields: ${fieldDesc}`;
+      storeDiv.appendChild(layoutEl);
+
+      // Count/capacity with utilisation
+      const utilPct = store.capacity > 0
+        ? ((store.count / store.capacity) * 100).toFixed(0)
+        : '0';
+      const capacityEl = document.createElement('div');
+      capacityEl.style.fontSize = '11px';
+      capacityEl.textContent = `Count: ${store.count}/${store.capacity} (${utilPct}% utilised)`;
+      storeDiv.appendChild(capacityEl);
+
+      // Per-entity field data
+      if (store.entities.length > 0) {
+        const gridEl = document.createElement('div');
+        gridEl.style.fontSize = '11px';
+        gridEl.style.marginTop = '2px';
+        gridEl.style.overflowX = 'auto';
+
+        // Header row
+        const headerRow = document.createElement('div');
+        headerRow.style.display = 'flex';
+        headerRow.style.gap = '8px';
+        headerRow.style.color = '#888';
+        headerRow.style.borderBottom = '1px solid rgba(255,255,255,0.1)';
+        headerRow.style.paddingBottom = '1px';
+        headerRow.style.marginBottom = '1px';
+
+        const idHeader = document.createElement('span');
+        idHeader.style.minWidth = '40px';
+        idHeader.textContent = 'ID';
+        headerRow.appendChild(idHeader);
+
+        for (const fieldName of store.fieldNames) {
+          const fh = document.createElement('span');
+          fh.style.minWidth = '60px';
+          fh.textContent = fieldName;
+          headerRow.appendChild(fh);
+        }
+        gridEl.appendChild(headerRow);
+
+        // Data rows
+        for (const entityData of store.entities) {
+          const dataRow = document.createElement('div');
+          dataRow.style.display = 'flex';
+          dataRow.style.gap = '8px';
+
+          const idCell = document.createElement('span');
+          idCell.style.minWidth = '40px';
+          idCell.textContent = String(entityData.entityId);
+          dataRow.appendChild(idCell);
+
+          for (const fieldName of store.fieldNames) {
+            const cell = document.createElement('span');
+            cell.style.minWidth = '60px';
+            cell.textContent = this.formatValue(entityData.fields[fieldName]);
+            dataRow.appendChild(cell);
+          }
+          gridEl.appendChild(dataRow);
+        }
+
+        storeDiv.appendChild(gridEl);
+      }
+
+      this.soaBody.appendChild(storeDiv);
+    }
+  }
+
+  private renderPoolStats(pools: DebugPoolSnapshot[]): void {
+    this.poolBody.innerHTML = '';
+
+    if (pools.length === 0) {
+      const emptyEl = document.createElement('div');
+      emptyEl.style.fontSize = '11px';
+      emptyEl.style.color = '#888';
+      emptyEl.textContent = 'No pools registered';
+      this.poolBody.appendChild(emptyEl);
+      return;
+    }
+
+    // Table
+    const table = document.createElement('table');
+    table.style.width = '100%';
+    table.style.fontSize = '11px';
+    table.style.borderCollapse = 'collapse';
+
+    // Header
+    const thead = document.createElement('thead');
+    const headerRow = document.createElement('tr');
+    const columns = ['typeKey', 'available', 'totalCreated', 'acquireCount', 'releaseCount', 'missCount'];
+    for (const col of columns) {
+      const th = document.createElement('th');
+      th.style.textAlign = 'left';
+      th.style.padding = '2px 4px';
+      th.style.borderBottom = '1px solid rgba(255,255,255,0.15)';
+      th.style.color = '#888';
+      th.style.fontWeight = 'normal';
+      th.textContent = col;
+      headerRow.appendChild(th);
+    }
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    // Body
+    const tbody = document.createElement('tbody');
+    for (const pool of pools) {
+      const tr = document.createElement('tr');
+
+      const tdKey = document.createElement('td');
+      tdKey.style.padding = '2px 4px';
+      tdKey.textContent = pool.typeKey;
+      tr.appendChild(tdKey);
+
+      const statValues = [
+        pool.stats.available,
+        pool.stats.totalCreated,
+        pool.stats.acquireCount,
+        pool.stats.releaseCount,
+        pool.stats.missCount,
+      ];
+      for (const val of statValues) {
+        const td = document.createElement('td');
+        td.style.padding = '2px 4px';
+        td.textContent = String(val);
+        tr.appendChild(td);
+      }
+
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    this.poolBody.appendChild(table);
+  }
+
+  // ── Collapse ───────────────────────────────────────────────────────
+
+  private toggleCollapse(): void {
+    this.collapsed = !this.collapsed;
+    this.body.style.display = this.collapsed ? 'none' : 'block';
+    this.updateToggleBtn();
+  }
+
+  private updateToggleBtn(): void {
+    this.toggleBtn.textContent = this.collapsed ? '[+]' : '[\u2212]';
+  }
+
+  private applySectionCollapse(
+    header: HTMLDivElement,
+    body: HTMLDivElement,
+    isCollapsed: boolean,
+  ): void {
+    body.style.display = isCollapsed ? 'none' : 'block';
+    const arrow = header.querySelector('[data-role="arrow"]') as HTMLSpanElement | null;
+    if (arrow) {
+      arrow.textContent = isCollapsed ? '\u25B6' : '\u25BC';
+    }
+  }
+
+  // ── DOM helpers ────────────────────────────────────────────────────
+
+  private buildCollapsibleSection(title: string): {
+    section: HTMLDivElement;
+    header: HTMLDivElement;
+    body: HTMLDivElement;
+    summary: HTMLSpanElement;
+  } {
+    const section = document.createElement('div');
+    section.style.marginBottom = '4px';
+
+    const header = document.createElement('div');
+    header.style.cursor = 'pointer';
+    header.style.fontSize = '12px';
+    header.style.fontWeight = 'bold';
+    header.style.color = COLOR_ACCENT;
+    header.style.padding = '2px 0';
+    header.style.userSelect = 'none';
+
+    const arrow = document.createElement('span');
+    arrow.setAttribute('data-role', 'arrow');
+    arrow.textContent = '\u25BC';
+    arrow.style.marginRight = '4px';
+    arrow.style.fontSize = '10px';
+
+    const titleSpan = document.createElement('span');
+    titleSpan.textContent = title;
+
+    const summary = document.createElement('span');
+    summary.style.fontWeight = 'normal';
+    summary.style.fontSize = '11px';
+    summary.style.color = '#888';
+    summary.style.marginLeft = '6px';
+
+    header.appendChild(arrow);
+    header.appendChild(titleSpan);
+    header.appendChild(summary);
+
+    const body = document.createElement('div');
+    body.style.paddingLeft = '4px';
+
+    section.appendChild(header);
+    section.appendChild(body);
+
+    return { section, header, body, summary };
+  }
+
+  private createLabel(text: string): HTMLSpanElement {
+    const el = document.createElement('span');
+    el.style.color = '#888';
+    el.textContent = text;
+    return el;
+  }
+
+  private createSeparator(): HTMLSpanElement {
+    const el = document.createElement('span');
+    el.style.margin = '0 6px';
+    el.style.color = '#555';
+    el.textContent = '|';
+    return el;
+  }
+
+  private formatValue(value: unknown): string {
+    if (typeof value === 'bigint') {
+      return `${value}n`;
+    }
+    return String(value);
+  }
+
+  // ── Styles ─────────────────────────────────────────────────────────
+
+  private applyRootStyles(): void {
+    const s = this.root.style;
+    s.position = 'fixed';
+    s.top = '8px';
+    s.right = '8px';
+    s.width = '360px';
+    s.backgroundColor = COLOR_BG;
+    s.color = COLOR_TEXT;
+    s.fontFamily = FONT_MONO;
+    s.fontSize = '11px';
+    s.zIndex = '99999';
+    s.borderRadius = '4px';
+    s.border = '1px solid rgba(255,255,255,0.1)';
+    s.boxShadow = '0 2px 12px rgba(0,0,0,0.5)';
+    s.overflow = 'hidden';
+  }
+
+  private applyTitleBarStyles(): void {
+    const s = this.titleBar.style;
+    s.backgroundColor = 'rgba(30, 30, 40, 0.95)';
+    s.padding = '4px 8px';
+    s.cursor = 'move';
+    s.userSelect = 'none';
+    s.display = 'flex';
+    s.justifyContent = 'space-between';
+    s.alignItems = 'center';
+    s.fontSize = '12px';
+    s.fontWeight = 'bold';
+    s.color = COLOR_ACCENT;
+    s.minHeight = '20px';
+  }
+
+  private applyToggleBtnStyles(): void {
+    const s = this.toggleBtn.style;
+    s.cursor = 'pointer';
+    s.fontSize = '12px';
+    s.color = COLOR_TEXT;
+    s.marginLeft = '8px';
+  }
+}

--- a/phalanx-ecs/src/debug/DebugPanel.ts
+++ b/phalanx-ecs/src/debug/DebugPanel.ts
@@ -199,7 +199,11 @@ export class DebugPanel {
     };
     document.addEventListener('keydown', this.keydownHandler);
 
-    // Toggle button click
+    // Toggle button – stop mousedown so title-bar drag doesn't fire,
+    // and handle click for the actual collapse toggle.
+    this.toggleBtn.addEventListener('mousedown', (e: MouseEvent) => {
+      e.stopPropagation();
+    });
     this.toggleBtn.addEventListener('click', (e: MouseEvent) => {
       e.stopPropagation();
       this.toggleCollapse();

--- a/phalanx-ecs/src/debug/index.ts
+++ b/phalanx-ecs/src/debug/index.ts
@@ -1,4 +1,5 @@
 export { DebugDataProvider } from './DebugDataProvider';
+export { DebugPanel } from './DebugPanel';
 export type {
   DebugSnapshot,
   DebugEntitySnapshot,
@@ -6,4 +7,5 @@ export type {
   DebugSoAStoreSnapshot,
   DebugPoolSnapshot,
   DebugDataProviderConfig,
+  DebugPanelConfig,
 } from './types';

--- a/phalanx-ecs/src/debug/types.ts
+++ b/phalanx-ecs/src/debug/types.ts
@@ -94,3 +94,13 @@ export interface DebugDataProviderConfig {
    */
   updateInterval?: number;
 }
+
+/**
+ * Configuration for the built-in DebugPanel DOM renderer.
+ */
+export interface DebugPanelConfig {
+  /** Keyboard shortcut to toggle panel. Set to '' to disable. Default: '`' (backtick) */
+  toggleKey?: string;
+  /** Initial collapsed state. Default: false */
+  startCollapsed?: boolean;
+}

--- a/phalanx-ecs/src/index.ts
+++ b/phalanx-ecs/src/index.ts
@@ -59,7 +59,7 @@ export type {
 } from './SoASchema';
 
 // Debug / Introspection
-export { DebugDataProvider } from './debug';
+export { DebugDataProvider, DebugPanel } from './debug';
 export type {
   DebugSnapshot,
   DebugEntitySnapshot,
@@ -67,6 +67,7 @@ export type {
   DebugSoAStoreSnapshot,
   DebugPoolSnapshot,
   DebugDataProviderConfig,
+  DebugPanelConfig,
 } from './debug';
 
 // Tick/Frame Management

--- a/phalanx-ecs/tests/debug/DebugPanel.test.ts
+++ b/phalanx-ecs/tests/debug/DebugPanel.test.ts
@@ -1,0 +1,424 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { Entity, resetEntityIdCounter } from '../../src/Entity';
+import { EntityManager } from '../../src/EntityManager';
+import { SoAComponent } from '../../src/SoAComponent';
+import { defineSoASchema } from '../../src/SoASchema';
+import { PoolManager } from '../../src/pool/PoolManager';
+import { DebugDataProvider } from '../../src/debug/DebugDataProvider';
+import { DebugPanel } from '../../src/debug/DebugPanel';
+import type { IComponent } from '../../src/Component';
+
+// ── Test fixtures ──────────────────────────────────────────────────
+
+const HealthType = Symbol('Health');
+const ArmorType = Symbol('Armor');
+
+class HealthComponent implements IComponent {
+  readonly type = HealthType;
+  constructor(public hp: number = 100) {}
+}
+
+class ArmorComponent implements IComponent {
+  readonly type = ArmorType;
+  constructor(public armor: number = 10) {}
+}
+
+const PhysicsSoASchema = defineSoASchema(
+  { velocityX: 'i64', velocityY: 'i64', radius: 'f64', isStatic: 'u8' },
+  'PhysicsBody',
+);
+
+class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.definition> {
+  public readonly type = Symbol('PhysicsBody');
+  static readonly soaSchema = PhysicsSoASchema;
+
+  constructor(entityId: number, radius: number = 1.0) {
+    super(PhysicsSoASchema, entityId, {
+      velocityX: 0n,
+      velocityY: 0n,
+      radius,
+      isStatic: 0,
+    });
+  }
+}
+
+// ── Helper ─────────────────────────────────────────────────────
+
+function createProvider(
+  em: EntityManager,
+  pools: PoolManager | null = null,
+): DebugDataProvider {
+  return new DebugDataProvider(em, pools, { updateInterval: 0 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('DebugPanel', () => {
+  let em: EntityManager;
+  let provider: DebugDataProvider;
+  let panel: DebugPanel;
+
+  beforeEach(() => {
+    resetEntityIdCounter();
+    em = new EntityManager();
+    em.registerComponentTypes([HealthType, ArmorType]);
+    SoAComponent.useEntityManager(em);
+    provider = createProvider(em);
+  });
+
+  afterEach(() => {
+    // Clean up panel if it was created
+    if (panel) {
+      panel.destroy();
+    }
+    SoAComponent.resetContext();
+  });
+
+  // ── DOM lifecycle ──────────────────────────────────────────────
+
+  describe('DOM lifecycle', () => {
+    it('creates root DOM element on construction', () => {
+      panel = new DebugPanel(provider);
+      expect(panel.element).toBeInstanceOf(HTMLDivElement);
+      expect(document.body.contains(panel.element)).toBe(true);
+    });
+
+    it('removes root DOM element on destroy()', () => {
+      panel = new DebugPanel(provider);
+      const el = panel.element;
+      expect(document.body.contains(el)).toBe(true);
+      panel.destroy();
+      expect(document.body.contains(el)).toBe(false);
+    });
+
+    it('unsubscribes from provider on destroy()', () => {
+      const entity = new Entity();
+      entity.addComponent(new HealthComponent(100));
+      em.addEntity(entity);
+
+      panel = new DebugPanel(provider);
+
+      // Get initial text content
+      const initialText = panel.element.textContent;
+      expect(initialText).toContain('1');
+
+      // Destroy the panel
+      panel.destroy();
+
+      // Add more entities — panel should NOT update since it's destroyed
+      const e2 = new Entity();
+      e2.addComponent(new HealthComponent(200));
+      em.addEntity(e2);
+
+      // The element is detached, but its content should not have been updated
+      // since destroy() unsubscribed. We can verify by checking the text still
+      // reflects the old state (1 entity, not 2).
+      // After destroy the element is removed, but we can check that
+      // provider.getSnapshot shows 2 while the detached element doesn't update.
+      const snap = provider.getSnapshot();
+      expect(snap.world.entityCount).toBe(2);
+      // The panel element content should still show the old "1" count, not "2"
+      // (since we unsubscribed and the panel doesn't get new snapshots)
+      expect(panel.element.textContent).not.toContain('[ID: ' + e2.id + ']');
+    });
+  });
+
+  // ── Rendering ──────────────────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders world overview section with entity count', () => {
+      const e1 = new Entity();
+      em.addEntity(e1);
+      const e2 = new Entity();
+      em.addEntity(e2);
+
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain('Entities:');
+      expect(text).toContain('2');
+      expect(text).toContain('World Overview');
+    });
+
+    it('renders entity list with component names', () => {
+      const entity = new Entity();
+      entity.addComponent(new HealthComponent(75));
+      entity.addComponent(new ArmorComponent(20));
+      em.addEntity(entity);
+
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain(`[ID: ${entity.id}]`);
+      expect(text).toContain('Health');
+      expect(text).toContain('Armor');
+    });
+
+    it('renders SoA store section with field types', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+      new PhysicsBodyComponent(entity.id, 2.5);
+
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain('PhysicsBody');
+      expect(text).toContain('velocityX');
+      expect(text).toContain('i64');
+      expect(text).toContain('f64');
+    });
+
+    it('renders pool stats table', () => {
+      const pools = new PoolManager();
+      pools.registerEntityType('projectile', {
+        factory: () => new Entity(),
+        pool: { initialSize: 5 },
+      });
+      pools.prewarmAll();
+
+      provider = new DebugDataProvider(em, pools, { updateInterval: 0 });
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain('projectile');
+      expect(text).toContain('5'); // available and totalCreated
+    });
+
+    it('renders empty state gracefully', () => {
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain('0');
+      expect(text).toContain('(0 entities)');
+      expect(text).toContain('No pools registered');
+    });
+
+    it('formats bigint values with n suffix', () => {
+      const entity = new Entity();
+      em.addEntity(entity);
+      new PhysicsBodyComponent(entity.id, 3.14);
+
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      // SoA grid should show bigint values with 'n' suffix
+      expect(text).toContain('0n');
+    });
+
+    it('shows paused indicator', () => {
+      provider.paused = true;
+
+      panel = new DebugPanel(provider);
+
+      const text = panel.element.textContent!;
+      expect(text).toContain('PAUSED');
+    });
+  });
+
+  // ── Collapse behavior ──────────────────────────────────────────
+
+  describe('collapse behavior', () => {
+    it('starts expanded by default', () => {
+      panel = new DebugPanel(provider);
+      // Body should be visible
+      const body = panel.element.querySelector('div:nth-child(2)') as HTMLDivElement;
+      expect(body.style.display).not.toBe('none');
+      // Toggle button should show minus
+      expect(panel.element.textContent).toContain('\u2212');
+    });
+
+    it('collapses to stripe on toggle button click', () => {
+      panel = new DebugPanel(provider);
+
+      // Find the toggle button [−]
+      const titleBar = panel.element.firstElementChild as HTMLDivElement;
+      const toggleBtn = titleBar.querySelector('span:last-child') as HTMLSpanElement;
+      toggleBtn.click();
+
+      // Body should be hidden
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).toBe('none');
+      expect(panel.element.textContent).toContain('[+]');
+    });
+
+    it('expands from stripe on toggle button click', () => {
+      panel = new DebugPanel(provider, { startCollapsed: true });
+
+      // Should start collapsed
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).toBe('none');
+
+      // Click toggle to expand
+      const titleBar = panel.element.firstElementChild as HTMLDivElement;
+      const toggleBtn = titleBar.querySelector('span:last-child') as HTMLSpanElement;
+      toggleBtn.click();
+
+      expect(body.style.display).toBe('block');
+      expect(panel.element.textContent).toContain('\u2212');
+    });
+
+    it('starts collapsed when startCollapsed is true', () => {
+      panel = new DebugPanel(provider, { startCollapsed: true });
+
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).toBe('none');
+      expect(panel.element.textContent).toContain('[+]');
+    });
+
+    it('section collapse toggles section visibility', () => {
+      const entity = new Entity();
+      entity.addComponent(new HealthComponent());
+      em.addEntity(entity);
+
+      panel = new DebugPanel(provider);
+
+      // Find the Entities section header (first collapsible section after world overview)
+      const body = panel.element.children[1] as HTMLDivElement;
+      // World overview is first child, then Entities section
+      const entitiesSection = body.children[1] as HTMLDivElement;
+      const entitiesHeader = entitiesSection.children[0] as HTMLDivElement;
+      const entitiesBody = entitiesSection.children[1] as HTMLDivElement;
+
+      // Should start expanded
+      expect(entitiesBody.style.display).not.toBe('none');
+
+      // Click to collapse
+      entitiesHeader.click();
+      expect(entitiesBody.style.display).toBe('none');
+
+      // Click to expand
+      entitiesHeader.click();
+      expect(entitiesBody.style.display).toBe('block');
+    });
+  });
+
+  // ── Drag behavior ──────────────────────────────────────────────
+
+  describe('drag behavior', () => {
+    it('updates position on mouse drag of title bar', () => {
+      panel = new DebugPanel(provider);
+      const titleBar = panel.element.firstElementChild as HTMLDivElement;
+
+      // Simulate drag
+      const mousedown = new MouseEvent('mousedown', {
+        clientX: 100,
+        clientY: 50,
+        bubbles: true,
+      });
+      titleBar.dispatchEvent(mousedown);
+
+      const mousemove = new MouseEvent('mousemove', {
+        clientX: 200,
+        clientY: 150,
+        bubbles: true,
+      });
+      document.dispatchEvent(mousemove);
+
+      // Position should have changed
+      expect(panel.element.style.right).toBe('auto');
+      // The left/top should reflect the drag offset
+      expect(panel.element.style.left).toBeTruthy();
+      expect(panel.element.style.top).toBeTruthy();
+
+      const mouseup = new MouseEvent('mouseup', { bubbles: true });
+      document.dispatchEvent(mouseup);
+    });
+
+    it('does not drag when clicking panel body', () => {
+      panel = new DebugPanel(provider);
+      const body = panel.element.children[1] as HTMLDivElement;
+
+      const initialRight = panel.element.style.right;
+
+      // Click on body, not title bar
+      const mousedown = new MouseEvent('mousedown', {
+        clientX: 100,
+        clientY: 100,
+        bubbles: true,
+      });
+      body.dispatchEvent(mousedown);
+
+      const mousemove = new MouseEvent('mousemove', {
+        clientX: 200,
+        clientY: 200,
+        bubbles: true,
+      });
+      document.dispatchEvent(mousemove);
+
+      // Position should NOT have changed (right should still be set)
+      expect(panel.element.style.right).toBe(initialRight);
+
+      const mouseup = new MouseEvent('mouseup', { bubbles: true });
+      document.dispatchEvent(mouseup);
+    });
+  });
+
+  // ── Keyboard shortcut ──────────────────────────────────────────
+
+  describe('keyboard shortcut', () => {
+    it('toggles collapse on backtick press', () => {
+      panel = new DebugPanel(provider);
+
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).not.toBe('none');
+
+      // Press backtick
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '`', bubbles: true }));
+      expect(body.style.display).toBe('none');
+
+      // Press again to expand
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '`', bubbles: true }));
+      expect(body.style.display).toBe('block');
+    });
+
+    it('ignores backtick when typing in input element', () => {
+      panel = new DebugPanel(provider);
+
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).not.toBe('none');
+
+      // Create an input element and simulate keydown targeting it
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+
+      const event = new KeyboardEvent('keydown', { key: '`', bubbles: true });
+      Object.defineProperty(event, 'target', { value: input, writable: false });
+      document.dispatchEvent(event);
+
+      // Should still be expanded (shortcut ignored)
+      expect(body.style.display).not.toBe('none');
+
+      document.body.removeChild(input);
+    });
+
+    it('respects custom toggleKey config', () => {
+      panel = new DebugPanel(provider, { toggleKey: 'F2' });
+
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).not.toBe('none');
+
+      // Backtick should NOT toggle
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '`', bubbles: true }));
+      expect(body.style.display).not.toBe('none');
+
+      // F2 should toggle
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F2', bubbles: true }));
+      expect(body.style.display).toBe('none');
+    });
+
+    it('disables shortcut when toggleKey is empty string', () => {
+      panel = new DebugPanel(provider, { toggleKey: '' });
+
+      const body = panel.element.children[1] as HTMLDivElement;
+      expect(body.style.display).not.toBe('none');
+
+      // No key should toggle
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: '`', bubbles: true }));
+      expect(body.style.display).not.toBe('none');
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'F2', bubbles: true }));
+      expect(body.style.display).not.toBe('none');
+    });
+  });
+});

--- a/phalanx-ecs/tests/debug/DebugPanel.test.ts
+++ b/phalanx-ecs/tests/debug/DebugPanel.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Entity, resetEntityIdCounter } from '../../src/Entity';
 import { EntityManager } from '../../src/EntityManager';
 import { SoAComponent } from '../../src/SoAComponent';
@@ -93,34 +93,42 @@ describe('DebugPanel', () => {
     });
 
     it('unsubscribes from provider on destroy()', () => {
+      vi.useFakeTimers();
+
+      // Use a provider with a real update interval so it pushes snapshots
+      const timedProvider = new DebugDataProvider(em, null, { updateInterval: 200 });
+      timedProvider.start();
+
       const entity = new Entity();
       entity.addComponent(new HealthComponent(100));
       em.addEntity(entity);
 
-      panel = new DebugPanel(provider);
+      panel = new DebugPanel(timedProvider);
 
-      // Get initial text content
-      const initialText = panel.element.textContent;
-      expect(initialText).toContain('1');
+      // Advance timers so the provider pushes a snapshot
+      vi.advanceTimersByTime(200);
+      expect(panel.element.textContent).toContain('1');
 
-      // Destroy the panel
+      // Destroy the panel (should unsubscribe)
       panel.destroy();
 
-      // Add more entities — panel should NOT update since it's destroyed
+      // Add another entity
       const e2 = new Entity();
       e2.addComponent(new HealthComponent(200));
       em.addEntity(e2);
 
-      // The element is detached, but its content should not have been updated
-      // since destroy() unsubscribed. We can verify by checking the text still
-      // reflects the old state (1 entity, not 2).
-      // After destroy the element is removed, but we can check that
-      // provider.getSnapshot shows 2 while the detached element doesn't update.
-      const snap = provider.getSnapshot();
+      // Advance timers again — provider pushes a new snapshot, but
+      // the panel should NOT update because destroy() unsubscribed.
+      vi.advanceTimersByTime(200);
+
+      // Provider sees 2 entities, but the detached panel still shows 1
+      const snap = timedProvider.getSnapshot();
       expect(snap.world.entityCount).toBe(2);
-      // The panel element content should still show the old "1" count, not "2"
-      // (since we unsubscribed and the panel doesn't get new snapshots)
       expect(panel.element.textContent).not.toContain('[ID: ' + e2.id + ']');
+
+      timedProvider.stop();
+      timedProvider.dispose();
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary

This PR implements **Iteration 2** of the debug panel feature: the **DebugPanel DOM renderer** — a pure DOM overlay that subscribes to the `DebugDataProvider` from Iteration 1 (PR #8) and renders live ECS debug information.

## What's included

### DebugPanel (`src/debug/DebugPanel.ts`)
A zero-dependency DOM overlay (~640 lines) with:
- **World Overview** — entity count, SoA store count, paused state
- **Entities section** — clickable list with expandable component detail (shows field names + values)
- **SoA Stores section** — typed array field layouts, count/capacity with utilisation %, per-entity field data grid (formats `bigint` values with `n` suffix)
- **Pool Stats section** — table with typeKey, available, totalCreated, acquireCount, releaseCount, missCount

### UX Features
- **Draggable** via title bar (mousedown → mousemove → mouseup)
- **Collapsible** to a single stripe (`[+]`/`[−]` toggle button)
- **Keyboard shortcut** — backtick (\`) by default, configurable via `DebugPanelConfig.toggleKey` (ignored when focused on `INPUT`/`TEXTAREA`)
- **Section-level collapse** — each sub-section (Entities, SoA, Pools) independently collapsible
- **Inline styles only** — no external CSS dependencies

### GameWorld Integration (`src/GameWorld.ts`)
- Stores `debugPanelConfig` from `GameWorldConfig`
- Auto-creates `DebugPanel` in `start()` when `debug: true` and `document` is available
- Destroys panel in `stop()`
- Exposes `debugPanel` getter

### Types (`src/debug/types.ts`)
- Added `DebugPanelConfig` interface (`toggleKey`, `startCollapsed`)

### Exports
- `DebugPanel` and `DebugPanelConfig` added to `src/debug/index.ts` and `src/index.ts`

## Tests
21 new tests in `tests/debug/DebugPanel.test.ts` using `happy-dom`:
- DOM lifecycle (create, destroy, unsubscribe)
- Rendering (world overview, entities, SoA stores, pool stats, empty state, bigint formatting, paused indicator)
- Collapse behavior (default expanded, toggle, startCollapsed config, section-level collapse)
- Drag behavior (title bar drag, body click no-drag)
- Keyboard shortcuts (backtick toggle, input ignore, custom key, disable)

## Test Results
```
Test Files  8 passed (8)
     Tests  109 passed (109)
```
`tsc --noEmit` — clean, no errors.

## Usage
```ts
const world = new GameWorld({
  debug: true,
  debugPanelConfig: {
    toggleKey: '\`',       // default
    startCollapsed: false, // default
  },
});
world.start();
// Panel auto-appears in top-right corner of the browser viewport
```