### PR TITLE
feat: Chapayev Stage 2 — Network multiplayer (lockstep 1v1)

### DIFF
--- a/chapaev/package.json
+++ b/chapaev/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host --mode development",
+    "server": "tsx server/src/main.ts",
     "build": "tsc && vite build",
     "preview": "vite preview",
     "cap:sync": "cap sync android",
@@ -24,10 +25,13 @@
     "@capacitor/core": "^8.3.0",
     "phalanx-client": "workspace:*",
     "phalanx-ecs": "workspace:*",
-    "phalanx-math": "workspace:*"
+    "phalanx-math": "workspace:*",
+    "phalanx-server": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
     "@types/three": "^0.175.0",
+    "tsx": "^4.0.0",
     "typescript": "~5.9.3",
     "vite": "^7.2.4"
   }

--- a/chapaev/server/package.json
+++ b/chapaev/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "chapaev-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Chapayev game server using Phalanx Engine",
+  "type": "module",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/main.js",
+    "dev": "tsx src/main.ts",
+    "clean": "rimraf dist"
+  },
+  "dependencies": {
+    "phalanx-server": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "rimraf": "^5.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.3.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/chapaev/server/src/main.ts
+++ b/chapaev/server/src/main.ts
@@ -39,6 +39,10 @@ async function main() {
     },
   });
 
+  // TODO (Stage 3): Add server-side command validation via phalanx.on('player-command')
+  // to reject invalid command types, malformed payloads, and commands targeting wrong team.
+  // See: PhalanxEventHandlers['player-command'] — return false to reject a command.
+
   phalanx.on('match-created', (match) => {
     console.log(`Match created: ${match.id}`);
   });

--- a/chapaev/server/src/main.ts
+++ b/chapaev/server/src/main.ts
@@ -1,0 +1,85 @@
+/**
+ * Chapayev game server using Phalanx Engine
+ *
+ * Minimal server: matchmaking, tick clock, command relay, desync detection.
+ * No game logic — all simulation runs on clients (lockstep).
+ */
+
+import { Phalanx } from 'phalanx-server';
+
+const PORT = parseInt(process.env.PORT || '3000', 10);
+
+const CORS_ORIGINS = process.env.CORS_ORIGINS
+  ? process.env.CORS_ORIGINS.split(',').map((origin) => origin.trim())
+  : ['http://localhost:5174', 'http://localhost:5173'];
+
+async function main() {
+  console.log('Starting Chapayev server...');
+
+  const phalanx = new Phalanx({
+    port: PORT,
+    cors: {
+      origin: CORS_ORIGINS,
+      credentials: true,
+    },
+    tickRate: 20,
+    gameMode: '1v1',
+    countdownSeconds: 3,
+    matchmakingIntervalMs: 1000,
+    timeoutTicks: 60,
+    disconnectTicks: 200,
+    reconnectGracePeriodMs: 30000,
+    readyTimeoutMs: 15000,
+    enableStateHashing: true,
+    stateHashInterval: 60,
+    desync: {
+      enabled: true,
+      action: 'log-only',
+      gracePeriodTicks: 3,
+    },
+  });
+
+  phalanx.on('match-created', (match) => {
+    console.log(`Match created: ${match.id}`);
+  });
+
+  phalanx.on('match-started', (match) => {
+    console.log(`Match started: ${match.id}`);
+  });
+
+  phalanx.on('match-ended', (matchId: string, reason: string) => {
+    console.log(`Match ended: ${matchId}, reason: ${reason}`);
+  });
+
+  phalanx.on('player-disconnected', (playerId: string, matchId: string) => {
+    console.log(`Player ${playerId} disconnected from ${matchId}`);
+  });
+
+  phalanx.on('player-reconnected', (playerId: string, matchId: string) => {
+    console.log(`Player ${playerId} reconnected to ${matchId}`);
+  });
+
+  phalanx.on('desync-detected', (matchId: string, tick: number, hashes: Record<string, string>) => {
+    console.warn(`Desync detected in ${matchId} at tick ${tick}:`, hashes);
+  });
+
+  try {
+    await phalanx.start();
+    console.log(`Chapayev server running on port ${PORT}`);
+  } catch (error) {
+    console.error('Failed to start server:', error);
+    process.exit(1);
+  }
+
+  process.on('SIGINT', () => {
+    console.log('\nShutting down...');
+    void phalanx.stop().then(() => process.exit(0));
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('\nShutting down...');
+    void phalanx.stop().then(() => process.exit(0));
+  });
+}
+
+void main();

--- a/chapaev/server/tsconfig.json
+++ b/chapaev/server/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/chapaev/src/components/Component.ts
+++ b/chapaev/src/components/Component.ts
@@ -10,6 +10,8 @@ export const ComponentType = createComponentTypeRegistry({
   Board: 'Board',
   PhysicsBody: 'PhysicsBody',
   GameState: 'GameState',
+  Player: 'Player',
+  Interpolation: 'Interpolation',
 });
 
 export type ComponentTypeKey = keyof typeof ComponentType;

--- a/chapaev/src/components/InterpolationComponent.ts
+++ b/chapaev/src/components/InterpolationComponent.ts
@@ -1,0 +1,64 @@
+import type { IComponent } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FPVector3 as FPVector3Type } from 'phalanx-math';
+import { ComponentType } from './Component.ts';
+
+/**
+ * InterpolationComponent — stores interpolation state for smooth rendering
+ * between simulation ticks.
+ *
+ * Simulation runs at 20 ticks/sec, rendering at 60+ fps.
+ * This component stores the previous and current tick positions so the
+ * InterpolationSystem can lerp between them each render frame.
+ *
+ * All position objects are pre-allocated and mutated in-place
+ * to avoid GC pressure on hot paths.
+ */
+export class InterpolationComponent implements IComponent {
+  public readonly type = ComponentType.Interpolation;
+
+  /** Fixed-point position from previous simulation tick */
+  public readonly previousFpPosition: FPVector3Type = { x: FP._0, y: FP._0, z: FP._0 };
+
+  /** Fixed-point position from current simulation tick */
+  public readonly currentFpPosition: FPVector3Type = { x: FP._0, y: FP._0, z: FP._0 };
+
+  /** Whether this entity should be interpolated (false for dead/static entities) */
+  public active: boolean = true;
+
+  constructor(initialPosition?: FPVector3Type) {
+    if (initialPosition) {
+      this.snapToPosition(initialPosition);
+    }
+  }
+
+  /**
+   * Copy current → previous before a simulation tick.
+   */
+  public snapshotPosition(): void {
+    this.previousFpPosition.x = this.currentFpPosition.x;
+    this.previousFpPosition.y = this.currentFpPosition.y;
+    this.previousFpPosition.z = this.currentFpPosition.z;
+  }
+
+  /**
+   * Capture new simulation position after a tick.
+   */
+  public capturePosition(fpPosition: FPVector3Type): void {
+    this.currentFpPosition.x = fpPosition.x;
+    this.currentFpPosition.y = fpPosition.y;
+    this.currentFpPosition.z = fpPosition.z;
+  }
+
+  /**
+   * Snap both previous and current to a position (for teleport / initial spawn).
+   */
+  public snapToPosition(fpPosition: FPVector3Type): void {
+    this.previousFpPosition.x = fpPosition.x;
+    this.previousFpPosition.y = fpPosition.y;
+    this.previousFpPosition.z = fpPosition.z;
+    this.currentFpPosition.x = fpPosition.x;
+    this.currentFpPosition.y = fpPosition.y;
+    this.currentFpPosition.z = fpPosition.z;
+  }
+}

--- a/chapaev/src/components/PlayerComponent.ts
+++ b/chapaev/src/components/PlayerComponent.ts
@@ -1,0 +1,19 @@
+import type { IComponent } from 'phalanx-ecs';
+import { ComponentType } from './Component.ts';
+
+/**
+ * PlayerComponent — associates a checker entity with a network player.
+ *
+ * playerIndex 0 = white (goes first), playerIndex 1 = black.
+ * networkId is the playerId assigned by the server.
+ *
+ * Only used in online mode; not attached in hot-seat.
+ */
+export class PlayerComponent implements IComponent {
+  public readonly type = ComponentType.Player;
+
+  constructor(
+    public readonly playerIndex: number,
+    public readonly networkId: string,
+  ) {}
+}

--- a/chapaev/src/components/index.ts
+++ b/chapaev/src/components/index.ts
@@ -7,4 +7,6 @@ export { PhysicsBodySoASchema, PhysicsBodyComponent } from './PhysicsBodyCompone
 export type { PhysicsBodyOptions } from './PhysicsBodyComponent.ts';
 export { GameStateComponent } from './GameStateComponent.ts';
 export type { GamePhase } from './GameStateComponent.ts';
+export { PlayerComponent } from './PlayerComponent.ts';
+export { InterpolationComponent } from './InterpolationComponent.ts';
 

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -140,22 +140,24 @@ export class Game {
     const renderSystem = new ThreeRenderSystem(this.sceneCtx.scene);
     const rapierVFXSystem = new RapierVFXSystem();
     const soundSystem = new SoundSystem();
-    this.interpolationSystem = new InterpolationSystem();
+    const interpolationSystem = new InterpolationSystem();
+    this.interpolationSystem = interpolationSystem;
 
     // Tick systems: physics first, then rules
     const tickSystems = [physicsSystem, gameRulesSystem];
 
     // Frame systems: input → render → rapier VFX → sound → interpolation
-    const frameSystems = [flickInputSystem, renderSystem, rapierVFXSystem, soundSystem, this.interpolationSystem];
+    const frameSystems = [flickInputSystem, renderSystem, rapierVFXSystem, soundSystem, interpolationSystem];
 
     this.world.registerSystems(tickSystems, frameSystems);
 
     // Create lockstep manager
-    this.lockstepManager = new LockstepManager(
+    const lockstepManager = new LockstepManager(
       this.networkManager.client,
       this.world.eventBus,
       this.world.entityManager,
     );
+    this.lockstepManager = lockstepManager;
 
     // Wire up mesh map
     const meshMap = renderSystem.getMeshMap();
@@ -163,7 +165,7 @@ export class Game {
     rapierVFXSystem.setMeshMap(meshMap);
 
     // Enable network mode on FlickInputSystem
-    flickInputSystem.setNetworkMode(this.lockstepManager, this.localTeam);
+    flickInputSystem.setNetworkMode(lockstepManager, this.localTeam);
 
     // Setup network event handlers
     this.setupNetworkEvents();
@@ -175,8 +177,6 @@ export class Game {
     });
 
     const { composer, controls } = this.sceneCtx;
-    const interpolationSystem = this.interpolationSystem;
-    const lockstepManager = this.lockstepManager;
 
     // Start the world with lifecycle hooks (following direct-strike pattern)
     this.world.start({
@@ -194,12 +194,12 @@ export class Game {
         // Submit state hash for desync detection
         lockstepManager.submitHashIfNeeded(tick);
       },
-      beforeFrame: (_alpha: number, _dt: number) => {
+      beforeFrame: (alpha: number, _dt: number) => {
+        // Interpolate visual positions BEFORE frame systems sync transforms to meshes
+        interpolationSystem.interpolate(alpha);
         controls.update();
       },
-      afterFrame: (alpha: number, _dt: number) => {
-        // Interpolate visual positions between ticks for smooth rendering
-        interpolationSystem.interpolate(alpha);
+      afterFrame: (_alpha: number, _dt: number) => {
         composer.render();
       },
     });

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -1,4 +1,5 @@
 import { GameWorld, Entity } from 'phalanx-ecs';
+import type { CommandsBatch } from 'phalanx-ecs';
 import { setupScene } from '../rendering/SceneSetup.ts';
 import type { SceneContext } from '../rendering/SceneSetup.ts';
 import { ThreeRenderSystem } from '../systems/ThreeRenderSystem.ts';
@@ -7,37 +8,69 @@ import { GameRulesSystem } from '../systems/GameRulesSystem.ts';
 import { FlickInputSystem } from '../systems/FlickInputSystem.ts';
 import { RapierVFXSystem } from '../systems/RapierVFXSystem.ts';
 import { SoundSystem } from '../systems/SoundSystem.ts';
+import { InterpolationSystem } from '../systems/InterpolationSystem.ts';
 import { ComponentType } from '../components/Component.ts';
 import { GameStateComponent } from '../components/GameStateComponent.ts';
+import { InterpolationComponent } from '../components/InterpolationComponent.ts';
+import { PlayerComponent } from '../components/PlayerComponent.ts';
 import { createBoardEntity } from '../entities/BoardEntity.ts';
 import { createCheckerEntity } from '../entities/CheckerEntity.ts';
 import { INITIAL_POSITIONS } from '../config/constants.ts';
 import { TeamTag } from '../enums/TeamTag.ts';
+import { LockstepManager } from '../network/LockstepManager.ts';
+import { NetworkManager } from '../network/NetworkManager.ts';
+import { GAME_OVER } from '../events/GameEvents.ts';
+import type { GameOverEvent } from '../events/GameEvents.ts';
+
+export type GameMode = 'hotseat' | 'online';
 
 /**
  * Game — thin orchestrator that wires together the ECS world,
  * Three.js scene, and the render loop.
  *
- * No game logic lives here — only setup and lifecycle management.
+ * Supports two modes:
+ * - hotseat: local two-player (Stage 1, internal tick loop)
+ * - online:  network 1v1 via PhalanxClient (Stage 2, server-driven ticks)
  */
 export class Game {
-  private world: GameWorld;
+  private world!: GameWorld;
   private sceneCtx: SceneContext;
+  private readonly mode: GameMode;
 
-  constructor(canvas: HTMLCanvasElement) {
-    // ── Three.js scene ─────────────────────────────────────────
+  // Network (online mode only)
+  private networkManager: NetworkManager | null = null;
+  private lockstepManager: LockstepManager | null = null;
+  private interpolationSystem: InterpolationSystem | null = null;
+  private localTeam: TeamTag = TeamTag.White;
+
+  constructor(canvas: HTMLCanvasElement, mode: GameMode = 'hotseat') {
+    this.mode = mode;
     this.sceneCtx = setupScene(canvas);
+  }
 
-    // ── ECS world (single-player, no tickFrameProvider) ────────
+  /**
+   * Start the game. For online mode, this connects to the server,
+   * waits for a match, then initialises the ECS world.
+   */
+  public async start(): Promise<void> {
+    if (this.mode === 'online') {
+      await this.startOnline();
+    } else {
+      this.startHotseat();
+    }
+  }
+
+  // ── Hot-seat mode (Stage 1) ─────────────────────────────────────
+
+  private startHotseat(): void {
+    // ECS world with internal tick loop at 60 Hz
     this.world = new GameWorld({
       componentTypes: Object.values(ComponentType),
       tickRate: 60,
     });
 
-    // ── Create entities ────────────────────────────────────────
     this.createEntities();
 
-    // ── Systems ────────────────────────────────────────────────
     const physicsSystem = new PhysicsSystem();
     const gameRulesSystem = new GameRulesSystem();
     const flickInputSystem = new FlickInputSystem(
@@ -50,23 +83,134 @@ export class Game {
     const rapierVFXSystem = new RapierVFXSystem();
     const soundSystem = new SoundSystem();
 
-    // Tick systems: physics first, then rules
     const tickSystems = [physicsSystem, gameRulesSystem];
-
-    // Frame systems: input → render → rapier VFX → sound
     const frameSystems = [flickInputSystem, renderSystem, rapierVFXSystem, soundSystem];
 
     this.world.registerSystems(tickSystems, frameSystems);
 
-    // Wire up mesh map after systems are initialised
     const meshMap = renderSystem.getMeshMap();
     flickInputSystem.setMeshMap(meshMap);
     rapierVFXSystem.setMeshMap(meshMap);
+
+    const { composer, controls } = this.sceneCtx;
+
+    this.world.start({
+      afterFrame: () => {
+        controls.update();
+        composer.render();
+      },
+    });
   }
 
-  /**
-   * Populate the ECS world with the board, checker, and game-state entities.
-   */
+  // ── Online mode (Stage 2) ───────────────────────────────────────
+
+  private async startOnline(): Promise<void> {
+    this.networkManager = new NetworkManager();
+
+    const gameStartEvent = await this.networkManager.connectAndWaitForMatch(
+      (msg) => console.log(`[Matchmaking] ${msg}`),
+    );
+
+    console.log('[Game] Game start event received, randomSeed:', gameStartEvent.randomSeed);
+
+    // Determine local team from sorted player IDs
+    const localPlayerIndex = this.networkManager.localPlayerIndex;
+    this.localTeam = localPlayerIndex === 0 ? TeamTag.White : TeamTag.Black;
+    console.log(`[Game] Local player index: ${localPlayerIndex}, team: ${this.localTeam}`);
+
+    // Create ECS world with PhalanxClient as tick/frame provider
+    this.world = new GameWorld({
+      componentTypes: Object.values(ComponentType),
+      tickFrameProvider: this.networkManager.client,
+    });
+
+    // Create entities with player components for online mode
+    this.createEntities();
+    this.assignPlayerComponents();
+
+    // Create systems
+    const physicsSystem = new PhysicsSystem();
+    const gameRulesSystem = new GameRulesSystem();
+    const flickInputSystem = new FlickInputSystem(
+      this.sceneCtx.camera,
+      this.sceneCtx.renderer.domElement,
+      this.sceneCtx.scene,
+      this.sceneCtx.controls,
+    );
+    const renderSystem = new ThreeRenderSystem(this.sceneCtx.scene);
+    const rapierVFXSystem = new RapierVFXSystem();
+    const soundSystem = new SoundSystem();
+    this.interpolationSystem = new InterpolationSystem();
+
+    // Tick systems: physics first, then rules
+    const tickSystems = [physicsSystem, gameRulesSystem];
+
+    // Frame systems: input → render → rapier VFX → sound → interpolation
+    const frameSystems = [flickInputSystem, renderSystem, rapierVFXSystem, soundSystem, this.interpolationSystem];
+
+    this.world.registerSystems(tickSystems, frameSystems);
+
+    // Create lockstep manager
+    this.lockstepManager = new LockstepManager(
+      this.networkManager.client,
+      this.world.eventBus,
+      this.world.entityManager,
+    );
+
+    // Wire up mesh map
+    const meshMap = renderSystem.getMeshMap();
+    flickInputSystem.setMeshMap(meshMap);
+    rapierVFXSystem.setMeshMap(meshMap);
+
+    // Enable network mode on FlickInputSystem
+    flickInputSystem.setNetworkMode(this.lockstepManager, this.localTeam);
+
+    // Setup network event handlers
+    this.setupNetworkEvents();
+
+    // Setup game-over logging
+    this.world.eventBus.on<GameOverEvent>(GAME_OVER, (event) => {
+      const isLocalWin = event.winner === this.localTeam;
+      console.log(`[Game] GAME OVER! Winner: ${event.winner}. ${isLocalWin ? 'You win!' : 'You lose.'}`);
+    });
+
+    const { composer, controls } = this.sceneCtx;
+    const interpolationSystem = this.interpolationSystem;
+    const lockstepManager = this.lockstepManager;
+
+    // Start the world with lifecycle hooks (following direct-strike pattern)
+    this.world.start({
+      beforeTick: (tick: number, commandsBatch: CommandsBatch) => {
+        // Snapshot positions BEFORE simulation tick
+        interpolationSystem.snapshotPositions();
+
+        // Execute commands from server batch (before tick systems run)
+        lockstepManager.processTick(tick, commandsBatch);
+      },
+      afterTick: (tick: number) => {
+        // Capture positions AFTER simulation tick
+        interpolationSystem.captureCurrentPositions();
+
+        // Submit state hash for desync detection
+        lockstepManager.submitHashIfNeeded(tick);
+      },
+      beforeFrame: (_alpha: number, _dt: number) => {
+        controls.update();
+      },
+      afterFrame: (alpha: number, _dt: number) => {
+        // Interpolate visual positions between ticks for smooth rendering
+        interpolationSystem.interpolate(alpha);
+        composer.render();
+      },
+    });
+
+    // Signal to server that we're ready
+    this.networkManager.sendReady();
+    console.log('[Game] Sent client-ready signal');
+  }
+
+  // ── Entity creation ─────────────────────────────────────────────
+
   private createEntities(): void {
     const em = this.world.entityManager;
 
@@ -76,7 +220,14 @@ export class Game {
     // Checkers
     for (const placement of INITIAL_POSITIONS) {
       const team = placement.team === 'white' ? TeamTag.White : TeamTag.Black;
-      em.addEntity(createCheckerEntity(team, placement.position));
+      const entity = createCheckerEntity(team, placement.position);
+
+      // In online mode, add InterpolationComponent to each checker
+      if (this.mode === 'online') {
+        entity.addComponent(new InterpolationComponent(placement.position));
+      }
+
+      em.addEntity(entity);
     }
 
     // Game-state singleton entity
@@ -86,25 +237,58 @@ export class Game {
   }
 
   /**
-   * Start the game loop.
+   * Assign PlayerComponent to each checker based on deterministic player ordering.
+   * Player 0 = white, Player 1 = black.
    */
-  public start(): void {
-    const { composer, controls } = this.sceneCtx;
+  private assignPlayerComponents(): void {
+    if (!this.networkManager?.matchData) return;
 
-    this.world.start({
-      afterFrame: () => {
-        controls.update();          // damping needs per-frame update
-        composer.render();
-      },
+    const matchData = this.networkManager.matchData;
+    const allPlayerIds = [
+      matchData.playerId,
+      ...matchData.teammates.map((p) => p.playerId),
+      ...matchData.opponents.map((p) => p.playerId),
+    ].sort();
+
+    const checkerEntities = this.world.entityManager.queryEntities(ComponentType.Checker);
+    for (const entity of checkerEntities) {
+      const checker = entity.getComponent<import('../components/CheckerComponent.ts').CheckerComponent>(ComponentType.Checker);
+      if (!checker) continue;
+
+      const playerIndex = checker.team === TeamTag.White ? 0 : 1;
+      const networkId = allPlayerIds[playerIndex] ?? '';
+      entity.addComponent(new PlayerComponent(playerIndex, networkId));
+    }
+  }
+
+  // ── Network events ──────────────────────────────────────────────
+
+  private setupNetworkEvents(): void {
+    if (!this.networkManager) return;
+
+    this.networkManager.onPlayerDisconnected(() => {
+      console.log('[Game] Opponent disconnected. Victory!');
+    });
+
+    this.networkManager.onPlayerReconnected(() => {
+      console.log('[Game] Opponent reconnected.');
+    });
+
+    this.networkManager.onMatchEnd((reason) => {
+      console.log(`[Game] Match ended: ${reason}`);
+    });
+
+    this.networkManager.onDesync((tick) => {
+      console.warn(`[Game] Desync detected at tick ${tick}`);
     });
   }
 
-  /**
-   * Cleanup everything.
-   */
+  // ── Cleanup ─────────────────────────────────────────────────────
+
   public dispose(): void {
     this.world.stop();
     this.world.dispose();
+    this.networkManager?.dispose();
     this.sceneCtx.renderer.dispose();
   }
 }

--- a/chapaev/src/main.ts
+++ b/chapaev/src/main.ts
@@ -10,12 +10,25 @@ if (!canvas) {
 // Switch between hot-seat and online via query param: ?mode=hotseat or ?mode=online
 // Default is 'online' for Stage 2.
 const params = new URLSearchParams(window.location.search);
-const mode: GameMode = (params.get('mode') as GameMode) || 'online';
+const rawMode = params.get('mode');
+const mode: GameMode = rawMode === 'hotseat' || rawMode === 'online' ? rawMode : 'online';
 
 console.log(`[Chapayev] Starting in ${mode} mode`);
 
+function reportStartupError(error: unknown): void {
+  console.error('[Chapayev] Failed to start game', error);
+  const message = error instanceof Error ? error.message : 'Unknown startup error';
+  const errorElement = document.createElement('div');
+  errorElement.setAttribute('role', 'alert');
+  errorElement.textContent = `Failed to start game: ${message}`;
+  const mountTarget = canvas.parentElement ?? document.body;
+  mountTarget.appendChild(errorElement);
+}
+
 const game = new Game(canvas, mode);
-void game.start();
+void game.start().catch((error: unknown) => {
+  reportStartupError(error);
+});
 
 // Expose for debugging in devtools
 if (import.meta.env.DEV) {

--- a/chapaev/src/main.ts
+++ b/chapaev/src/main.ts
@@ -1,4 +1,5 @@
 import { Game } from './core/Game.ts';
+import type { GameMode } from './core/Game.ts';
 
 const canvas = document.getElementById('app') as HTMLCanvasElement | null;
 
@@ -6,12 +7,17 @@ if (!canvas) {
   throw new Error("Canvas element with id 'app' not found");
 }
 
-const game = new Game(canvas);
-game.start();
+// Switch between hot-seat and online via query param: ?mode=hotseat or ?mode=online
+// Default is 'online' for Stage 2.
+const params = new URLSearchParams(window.location.search);
+const mode: GameMode = (params.get('mode') as GameMode) || 'online';
+
+console.log(`[Chapayev] Starting in ${mode} mode`);
+
+const game = new Game(canvas, mode);
+void game.start();
 
 // Expose for debugging in devtools
 if (import.meta.env.DEV) {
   (window as unknown as Record<string, unknown>)['__game'] = game;
 }
-
-

--- a/chapaev/src/network/LockstepManager.ts
+++ b/chapaev/src/network/LockstepManager.ts
@@ -1,0 +1,145 @@
+import type { CommandsBatch, PlayerCommand, EventBus, EntityManager } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import { StateHasher } from 'phalanx-client';
+import type { PhalanxClient } from 'phalanx-client';
+import { FLICK_EXECUTED } from '../events/GameEvents.ts';
+import type { FlickExecutedEvent } from '../events/GameEvents.ts';
+import { ComponentType } from '../components/Component.ts';
+import type { CheckerComponent } from '../components/CheckerComponent.ts';
+import type { GameStateComponent } from '../components/GameStateComponent.ts';
+import type { PhysicsBodyComponent } from '../components/PhysicsBodyComponent.ts';
+import type { TransformComponent } from '../components/TransformComponent.ts';
+import { TeamTag } from '../enums/TeamTag.ts';
+
+/**
+ * Serialised flick command sent over the wire.
+ * All FixedPoint values are serialised as raw bigint strings for exact reproduction.
+ */
+export interface FlickCommandData {
+  entityId: number;
+  dirX: string;   // FP.ToRaw() → bigint → toString()
+  dirZ: string;
+  force: string;
+}
+
+/** Interval (in ticks) between state hash submissions */
+const HASH_INTERVAL = 60;
+
+/**
+ * LockstepManager — processes commands from the server's commands-batch
+ * and applies them deterministically on the local ECS.
+ *
+ * Only one command type exists in Chapayev: `flick`.
+ *
+ * Also handles state hashing for desync detection.
+ */
+export class LockstepManager {
+  private readonly client: PhalanxClient;
+  private readonly eventBus: EventBus;
+  private readonly entityManager: EntityManager;
+
+  constructor(
+    client: PhalanxClient,
+    eventBus: EventBus,
+    entityManager: EntityManager,
+  ) {
+    this.client = client;
+    this.eventBus = eventBus;
+    this.entityManager = entityManager;
+  }
+
+  /**
+   * Queue a flick command to be sent to the server.
+   * Called from FlickInputSystem when the local player flicks in online mode.
+   */
+  public queueFlickCommand(data: FlickCommandData): void {
+    this.client.sendCommand('flick', data);
+  }
+
+  /**
+   * Process a tick's command batch. Called from GameWorld.start({ beforeTick }).
+   * Extracts flick commands and emits them as FLICK_EXECUTED events so that
+   * PhysicsSystem processes them identically on all clients.
+   */
+  public processTick(_tick: number, commandsBatch: CommandsBatch): void {
+    // Flatten commands from all players in deterministic order (sorted by playerId)
+    const allCommands: PlayerCommand[] = [];
+    const sortedPlayerIds = Object.keys(commandsBatch.commands).sort();
+    for (const playerId of sortedPlayerIds) {
+      allCommands.push(...commandsBatch.commands[playerId]);
+    }
+
+    for (const cmd of allCommands) {
+      if (cmd.type === 'flick') {
+        this.handleFlickCommand(cmd);
+      } else {
+        console.warn(`[Lockstep] Unknown command type: ${cmd.type}`);
+      }
+    }
+  }
+
+  /**
+   * Deserialise a flick command and emit a FLICK_EXECUTED event.
+   * PhysicsSystem already listens for these and applies the impulse.
+   */
+  private handleFlickCommand(cmd: PlayerCommand): void {
+    const data = cmd.data as FlickCommandData;
+    const entity = this.entityManager.getEntity(data.entityId);
+    if (!entity) return;
+
+    const checker = entity.getComponent<CheckerComponent>(ComponentType.Checker);
+    const team = checker?.team ?? TeamTag.White;
+
+    this.eventBus.emit<FlickExecutedEvent>(FLICK_EXECUTED, {
+      entityId: data.entityId,
+      team,
+      directionX: FP.FromRaw(BigInt(data.dirX)),
+      directionZ: FP.FromRaw(BigInt(data.dirZ)),
+      force: FP.FromRaw(BigInt(data.force)),
+    });
+  }
+
+  /**
+   * Submit a state hash every HASH_INTERVAL ticks for desync detection.
+   */
+  public submitHashIfNeeded(tick: number): void {
+    if (tick % HASH_INTERVAL !== 0) return;
+
+    const hasher = new StateHasher();
+    hasher.addInt(tick);
+
+    // Hash all checkers sorted by entity ID
+    const checkerEntities = this.entityManager.queryEntities(
+      ComponentType.Checker,
+      ComponentType.PhysicsBody,
+      ComponentType.Transform,
+    );
+
+    // queryEntities returns sorted by entity ID (deterministic)
+    for (const entity of checkerEntities) {
+      const transform = entity.getComponent<TransformComponent>(ComponentType.Transform)!;
+      const physicsBody = entity.getComponent<PhysicsBodyComponent>(ComponentType.PhysicsBody)!;
+      const checker = entity.getComponent<CheckerComponent>(ComponentType.Checker)!;
+
+      const fpPos = transform.fpPosition;
+      hasher.addInt(entity.id);
+      hasher.addFloat(FP.ToFloat(fpPos.x));
+      hasher.addFloat(FP.ToFloat(fpPos.z));
+      hasher.addFloat(FP.ToFloat(physicsBody.velocityX));
+      hasher.addFloat(FP.ToFloat(physicsBody.velocityZ));
+      hasher.addBool(checker.isAlive);
+    }
+
+    // Hash game state
+    const gsEntities = this.entityManager.queryEntities(ComponentType.GameState);
+    if (gsEntities.length > 0) {
+      const gs = gsEntities[0].getComponent<GameStateComponent>(ComponentType.GameState)!;
+      hasher.addInt(gs.roundNumber);
+      hasher.addString(gs.currentTeam);
+      hasher.addInt(gs.whiteRow);
+      hasher.addInt(gs.blackRow);
+    }
+
+    this.client.submitStateHash(tick, hasher.finalize());
+  }
+}

--- a/chapaev/src/network/LockstepManager.ts
+++ b/chapaev/src/network/LockstepManager.ts
@@ -78,14 +78,48 @@ export class LockstepManager {
     }
   }
 
+  private isFlickCommandData(value: unknown): value is FlickCommandData {
+    if (typeof value !== 'object' || value === null) return false;
+    const obj = value as Record<string, unknown>;
+    return (
+      typeof obj.entityId === 'number' &&
+      typeof obj.dirX === 'string' &&
+      typeof obj.dirZ === 'string' &&
+      typeof obj.force === 'string'
+    );
+  }
+
+  private parseFlickCommandRawValues(
+    data: FlickCommandData,
+  ): { dirX: bigint; dirZ: bigint; force: bigint } | null {
+    try {
+      return {
+        dirX: BigInt(data.dirX),
+        dirZ: BigInt(data.dirZ),
+        force: BigInt(data.force),
+      };
+    } catch {
+      console.warn('[Lockstep] Failed to parse BigInt values from flick command', data);
+      return null;
+    }
+  }
+
   /**
    * Deserialise a flick command and emit a FLICK_EXECUTED event.
    * PhysicsSystem already listens for these and applies the impulse.
    */
   private handleFlickCommand(cmd: PlayerCommand): void {
-    const data = cmd.data as FlickCommandData;
+    if (!this.isFlickCommandData(cmd.data)) {
+      console.warn('[Lockstep] Invalid flick command data', cmd.data);
+      return;
+    }
+
+    const data = cmd.data;
     const entity = this.entityManager.getEntity(data.entityId);
     if (!entity) return;
+
+    const rawValues = this.parseFlickCommandRawValues(data);
+    if (!rawValues) return;
 
     const checker = entity.getComponent<CheckerComponent>(ComponentType.Checker);
     const team = checker?.team ?? TeamTag.White;
@@ -93,9 +127,9 @@ export class LockstepManager {
     this.eventBus.emit<FlickExecutedEvent>(FLICK_EXECUTED, {
       entityId: data.entityId,
       team,
-      directionX: FP.FromRaw(BigInt(data.dirX)),
-      directionZ: FP.FromRaw(BigInt(data.dirZ)),
-      force: FP.FromRaw(BigInt(data.force)),
+      directionX: FP.FromRaw(rawValues.dirX),
+      directionZ: FP.FromRaw(rawValues.dirZ),
+      force: FP.FromRaw(rawValues.force),
     });
   }
 
@@ -123,10 +157,10 @@ export class LockstepManager {
 
       const fpPos = transform.fpPosition;
       hasher.addInt(entity.id);
-      hasher.addFloat(FP.ToFloat(fpPos.x));
-      hasher.addFloat(FP.ToFloat(fpPos.z));
-      hasher.addFloat(FP.ToFloat(physicsBody.velocityX));
-      hasher.addFloat(FP.ToFloat(physicsBody.velocityZ));
+      hasher.addString(FP.ToRaw(fpPos.x).toString());
+      hasher.addString(FP.ToRaw(fpPos.z).toString());
+      hasher.addString(FP.ToRaw(physicsBody.velocityX).toString());
+      hasher.addString(FP.ToRaw(physicsBody.velocityZ).toString());
       hasher.addBool(checker.isAlive);
     }
 

--- a/chapaev/src/network/NetworkManager.ts
+++ b/chapaev/src/network/NetworkManager.ts
@@ -1,0 +1,156 @@
+import { PhalanxClient } from 'phalanx-client';
+import type { MatchFoundEvent, CountdownEvent, GameStartEvent } from 'phalanx-client';
+
+const SERVER_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
+
+/**
+ * NetworkManager — wraps PhalanxClient for Chapayev online mode.
+ *
+ * Handles connection, matchmaking, and exposes the client as
+ * ITickFrameProvider for GameWorld integration.
+ */
+export class NetworkManager {
+  public readonly client: PhalanxClient;
+  private _matchData: MatchFoundEvent | null = null;
+  private _localPlayerIndex = -1;
+  private networkUnsubscribers: (() => void)[] = [];
+
+  constructor() {
+    this.client = new PhalanxClient({
+      serverUrl: SERVER_URL,
+      autoReconnect: true,
+      maxReconnectAttempts: 5,
+      reconnectDelayMs: 1000,
+    });
+  }
+
+  /**
+   * Connect to server, join queue, wait for match, countdown, and game-start.
+   * Returns the GameStartEvent (includes randomSeed).
+   */
+  public async connectAndWaitForMatch(
+    onStatus?: (msg: string) => void,
+    onCountdown?: (event: CountdownEvent) => void,
+  ): Promise<GameStartEvent> {
+    onStatus?.('Connecting to server...');
+
+    this.networkUnsubscribers.push(
+      this.client.on('disconnected', () => {
+        console.warn('[Network] Disconnected from server');
+      }),
+    );
+
+    this.networkUnsubscribers.push(
+      this.client.on('error', (error) => {
+        console.error('[Network] Error:', error.message);
+      }),
+    );
+
+    await this.client.connect();
+    onStatus?.('Connected! Joining queue...');
+
+    await this.client.joinQueue();
+    onStatus?.('In queue. Waiting for opponent...');
+
+    this._matchData = await this.client.waitForMatch();
+    onStatus?.('Match found! Starting countdown...');
+
+    await this.client.waitForCountdown((event: CountdownEvent) => {
+      onStatus?.(`Game starting in ${event.seconds}...`);
+      onCountdown?.(event);
+    });
+
+    const gameStartEvent = await this.client.waitForGameStart();
+    onStatus?.('Game started!');
+
+    return gameStartEvent;
+  }
+
+  /**
+   * Signal to the server that this client is ready (assets loaded, ECS initialized).
+   */
+  public sendReady(): void {
+    this.client.sendReady();
+  }
+
+  /**
+   * Send a flick command via the lockstep channel.
+   */
+  public sendCommand(type: string, data: unknown): void {
+    this.client.sendCommand(type, data);
+  }
+
+  /**
+   * Submit a state hash for desync detection.
+   */
+  public submitStateHash(tick: number, hash: string): void {
+    this.client.submitStateHash(tick, hash);
+  }
+
+  /** The match data from matchmaking. */
+  public get matchData(): MatchFoundEvent | null {
+    return this._matchData;
+  }
+
+  /** The local player ID assigned by the server. */
+  public get localPlayerId(): string {
+    return this.client.getPlayerId();
+  }
+
+  /**
+   * Determine local player index (0 or 1) based on sorted player IDs.
+   * Player 0 = white (goes first), Player 1 = black.
+   */
+  public get localPlayerIndex(): number {
+    if (this._localPlayerIndex !== -1) return this._localPlayerIndex;
+    if (!this._matchData) return 0;
+
+    // Collect all player IDs: self + teammates + opponents
+    const allPlayerIds = [
+      this._matchData.playerId,
+      ...this._matchData.teammates.map((p) => p.playerId),
+      ...this._matchData.opponents.map((p) => p.playerId),
+    ].sort();
+
+    this._localPlayerIndex = allPlayerIds.indexOf(this._matchData.playerId);
+    return this._localPlayerIndex;
+  }
+
+  /**
+   * Register a handler for network events (playerDisconnected, matchEnd, etc).
+   */
+  public onPlayerDisconnected(handler: () => void): () => void {
+    const unsub = this.client.on('playerDisconnected', () => handler());
+    this.networkUnsubscribers.push(unsub);
+    return unsub;
+  }
+
+  public onPlayerReconnected(handler: () => void): () => void {
+    const unsub = this.client.on('playerReconnected', () => handler());
+    this.networkUnsubscribers.push(unsub);
+    return unsub;
+  }
+
+  public onMatchEnd(handler: (reason: string) => void): () => void {
+    const unsub = this.client.on('matchEnd', (event) => handler(event.reason));
+    this.networkUnsubscribers.push(unsub);
+    return unsub;
+  }
+
+  public onDesync(handler: (tick: number) => void): () => void {
+    const unsub = this.client.on('desync', (event) => handler(event.tick));
+    this.networkUnsubscribers.push(unsub);
+    return unsub;
+  }
+
+  /**
+   * Clean up all event subscriptions and disconnect.
+   */
+  public dispose(): void {
+    for (const unsub of this.networkUnsubscribers) {
+      unsub();
+    }
+    this.networkUnsubscribers = [];
+    this.client.disconnect();
+  }
+}

--- a/chapaev/src/network/index.ts
+++ b/chapaev/src/network/index.ts
@@ -1,0 +1,3 @@
+export { NetworkManager } from './NetworkManager.ts';
+export { LockstepManager } from './LockstepManager.ts';
+export type { FlickCommandData } from './LockstepManager.ts';

--- a/chapaev/src/systems/FlickInputSystem.ts
+++ b/chapaev/src/systems/FlickInputSystem.ts
@@ -13,6 +13,7 @@ import {
   FLICK_EXECUTED,
 } from '../events/GameEvents.ts';
 import type { FlickExecutedEvent } from '../events/GameEvents.ts';
+import type { LockstepManager, FlickCommandData } from '../network/LockstepManager.ts';
 
 /**
  * FlickInputSystem — frame system that handles mouse/touch aiming and flicking.
@@ -61,6 +62,17 @@ export class FlickInputSystem extends GameSystem {
   /** Reusable ground plane for raycasting pointer position to world XZ */
   private readonly groundPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), -(BOARD_HEIGHT / 2 + CHECKER_HEIGHT / 2));
 
+  // ── Network mode ──────────────────────────────────────────────
+
+  /** Whether we are in online (network) mode */
+  private networkMode = false;
+
+  /** LockstepManager for sending commands in online mode */
+  private lockstepManager: LockstepManager | null = null;
+
+  /** Local player's team in online mode (null = hot-seat, both teams playable) */
+  private localTeam: TeamTag | null = null;
+
   // ── Bound event handlers (for removal) ─────────────────────────
 
   private readonly onPointerDown = (e: PointerEvent): void => this.handlePointerDown(e);
@@ -81,6 +93,17 @@ export class FlickInputSystem extends GameSystem {
     this.canvas = domElement;
     this.scene = scene;
     this.controls = controls;
+  }
+
+  /**
+   * Enable network mode. In this mode, flicks are sent as commands
+   * via the LockstepManager instead of directly emitting FLICK_EXECUTED.
+   * Input is also blocked when it's not the local player's turn.
+   */
+  public setNetworkMode(lockstepManager: LockstepManager, localTeam: TeamTag): void {
+    this.networkMode = true;
+    this.lockstepManager = lockstepManager;
+    this.localTeam = localTeam;
   }
 
   // ── Lifecycle ──────────────────────────────────────────────────
@@ -119,9 +142,16 @@ export class FlickInputSystem extends GameSystem {
 
   // ── Pointer / Touch handlers ───────────────────────────────────
 
+  /** Returns true if input should be blocked (online mode + not local player's turn) */
+  private isInputBlocked(): boolean {
+    if (!this.networkMode || !this.localTeam) return false;
+    return this.gameState.currentTeam !== this.localTeam;
+  }
+
   private handlePointerDown(e: PointerEvent): void {
     if (!this.enabled) return;
     if (this.gameState.phase !== 'aiming') return;
+    if (this.isInputBlocked()) return;
 
     // Pointer events from touch are handled in handleTouchStart
     if (e.pointerType === 'touch') return;
@@ -150,6 +180,7 @@ export class FlickInputSystem extends GameSystem {
   private handleTouchStart(e: TouchEvent): void {
     if (!this.enabled) return;
     if (this.gameState.phase !== 'aiming') return;
+    if (this.isInputBlocked()) return;
 
     // Multi-finger gesture (pinch-to-zoom) — let orbit controls handle it
     if (e.touches.length > 1) {
@@ -314,17 +345,36 @@ export class FlickInputSystem extends GameSystem {
     const dirX = dx / dragLen;
     const dirZ = dz / dragLen;
 
-    const entity = this.entityManager.getEntity(this.dragEntityId);
-    const checker = entity?.getComponent<CheckerComponent>(ComponentType.Checker);
-    const team = checker?.team ?? TeamTag.White;
+    if (this.networkMode && this.lockstepManager) {
+      // Online mode: send command via lockstep — do NOT modify physics directly.
+      // The command will arrive back in a commands-batch and be applied by
+      // LockstepManager on all clients simultaneously.
+      const fpDirX = FP.FromFloat(dirX);
+      const fpDirZ = FP.FromFloat(dirZ);
+      const fpForce = FP.FromFloat(force);
 
-    this.eventBus.emit<FlickExecutedEvent>(FLICK_EXECUTED, {
-      entityId: this.dragEntityId,
-      team,
-      directionX: FP.FromFloat(dirX),
-      directionZ: FP.FromFloat(dirZ),
-      force: FP.FromFloat(force),
-    });
+      const commandData: FlickCommandData = {
+        entityId: this.dragEntityId,
+        dirX: FP.ToRaw(fpDirX).toString(),
+        dirZ: FP.ToRaw(fpDirZ).toString(),
+        force: FP.ToRaw(fpForce).toString(),
+      };
+
+      this.lockstepManager.queueFlickCommand(commandData);
+    } else {
+      // Hot-seat mode: emit directly (original Stage 1 behaviour)
+      const entity = this.entityManager.getEntity(this.dragEntityId);
+      const checker = entity?.getComponent<CheckerComponent>(ComponentType.Checker);
+      const team = checker?.team ?? TeamTag.White;
+
+      this.eventBus.emit<FlickExecutedEvent>(FLICK_EXECUTED, {
+        entityId: this.dragEntityId,
+        team,
+        directionX: FP.FromFloat(dirX),
+        directionZ: FP.FromFloat(dirZ),
+        force: FP.FromFloat(force),
+      });
+    }
 
     this.dragEntityId = -1;
   }

--- a/chapaev/src/systems/InterpolationSystem.ts
+++ b/chapaev/src/systems/InterpolationSystem.ts
@@ -1,5 +1,5 @@
 import { GameSystem } from 'phalanx-ecs';
-import { FP, FPVector3 } from 'phalanx-math';
+import { FP } from 'phalanx-math';
 import { ComponentType } from '../components/Component.ts';
 import type { InterpolationComponent } from '../components/InterpolationComponent.ts';
 import type { TransformComponent } from '../components/TransformComponent.ts';
@@ -75,13 +75,17 @@ export class InterpolationSystem extends GameSystem {
       if (!transform) continue;
 
       // Convert FP to float then lerp (avoids FP math overhead for visuals)
-      const prevPos = FPVector3.ToFloat(interp.previousFpPosition);
-      const curPos = FPVector3.ToFloat(interp.currentFpPosition);
+      const prevX = FP.ToFloat(interp.previousFpPosition.x);
+      const prevY = FP.ToFloat(interp.previousFpPosition.y);
+      const prevZ = FP.ToFloat(interp.previousFpPosition.z);
+      const curX = FP.ToFloat(interp.currentFpPosition.x);
+      const curY = FP.ToFloat(interp.currentFpPosition.y);
+      const curZ = FP.ToFloat(interp.currentFpPosition.z);
 
       transform.setVisualPosition(
-        prevPos.x + (curPos.x - prevPos.x) * alpha,
-        prevPos.y + (curPos.y - prevPos.y) * alpha,
-        prevPos.z + (curPos.z - prevPos.z) * alpha,
+        prevX + (curX - prevX) * alpha,
+        prevY + (curY - prevY) * alpha,
+        prevZ + (curZ - prevZ) * alpha,
       );
     }
   }
@@ -100,8 +104,11 @@ export class InterpolationSystem extends GameSystem {
       const fpPos = transform.fpPosition;
       interp.snapToPosition(fpPos);
 
-      const floats = FPVector3.ToFloat(fpPos);
-      transform.setVisualPosition(floats.x, floats.y, floats.z);
+      transform.setVisualPosition(
+        FP.ToFloat(fpPos.x),
+        FP.ToFloat(fpPos.y),
+        FP.ToFloat(fpPos.z),
+      );
     }
   }
 }

--- a/chapaev/src/systems/InterpolationSystem.ts
+++ b/chapaev/src/systems/InterpolationSystem.ts
@@ -1,0 +1,107 @@
+import { GameSystem } from 'phalanx-ecs';
+import { FP, FPVector3 } from 'phalanx-math';
+import { ComponentType } from '../components/Component.ts';
+import type { InterpolationComponent } from '../components/InterpolationComponent.ts';
+import type { TransformComponent } from '../components/TransformComponent.ts';
+import type { CheckerComponent } from '../components/CheckerComponent.ts';
+
+/**
+ * InterpolationSystem — provides smooth visual movement between network ticks.
+ *
+ * Simulation: 20 ticks/sec (deterministic, lockstep-synchronised).
+ * Rendering: 60+ fps (visual only, local).
+ *
+ * Usage from GameWorld lifecycle hooks:
+ * 1. beforeTick:  snapshotPositions()  — save positions BEFORE tick systems run
+ * 2. afterTick:   captureCurrentPositions() — capture positions AFTER tick systems run
+ * 3. afterFrame:  interpolate(alpha)   — lerp visual positions between ticks
+ *
+ * Only interpolates alive checkers. Dead checkers are managed by RapierVFXSystem.
+ */
+export class InterpolationSystem extends GameSystem {
+  /**
+   * Snapshot current positions as "previous" positions.
+   * Call BEFORE running simulation tick.
+   */
+  public snapshotPositions(): void {
+    const entities = this.entityManager.queryEntities(ComponentType.Interpolation);
+    for (const entity of entities) {
+      const interp = entity.getComponent<InterpolationComponent>(ComponentType.Interpolation);
+      if (interp?.active) {
+        interp.snapshotPosition();
+      }
+    }
+  }
+
+  /**
+   * Capture current simulation positions.
+   * Call AFTER running simulation tick.
+   */
+  public captureCurrentPositions(): void {
+    const entities = this.entityManager.queryEntities(ComponentType.Interpolation);
+    for (const entity of entities) {
+      const interp = entity.getComponent<InterpolationComponent>(ComponentType.Interpolation);
+      const transform = entity.getComponent<TransformComponent>(ComponentType.Transform);
+      if (!interp?.active || !transform) continue;
+
+      // Deactivate interpolation for dead checkers
+      const checker = entity.getComponent<CheckerComponent>(ComponentType.Checker);
+      if (checker && !checker.isAlive) {
+        interp.active = false;
+        continue;
+      }
+
+      interp.capturePosition(transform.fpPosition);
+    }
+  }
+
+  /**
+   * Interpolate visual positions and write them to TransformComponent.
+   * Call every render frame.
+   *
+   * Uses float lerp (more efficient than FP lerp for visuals).
+   *
+   * @param alpha Interpolation factor (0 = previous tick, 1 = current tick)
+   */
+  public interpolate(alpha: number): void {
+    alpha = Math.max(0, Math.min(1, alpha));
+
+    const entities = this.entityManager.queryEntities(ComponentType.Interpolation);
+    for (const entity of entities) {
+      const interp = entity.getComponent<InterpolationComponent>(ComponentType.Interpolation);
+      if (!interp?.active) continue;
+
+      const transform = entity.getComponent<TransformComponent>(ComponentType.Transform);
+      if (!transform) continue;
+
+      // Convert FP to float then lerp (avoids FP math overhead for visuals)
+      const prevPos = FPVector3.ToFloat(interp.previousFpPosition);
+      const curPos = FPVector3.ToFloat(interp.currentFpPosition);
+
+      transform.setVisualPosition(
+        prevPos.x + (curPos.x - prevPos.x) * alpha,
+        prevPos.y + (curPos.y - prevPos.y) * alpha,
+        prevPos.z + (curPos.z - prevPos.z) * alpha,
+      );
+    }
+  }
+
+  /**
+   * Snap all interpolated entities to their current simulation position.
+   * Use on initial spawn or after reconnect fast-forward.
+   */
+  public snapToCurrentPositions(): void {
+    const entities = this.entityManager.queryEntities(ComponentType.Interpolation);
+    for (const entity of entities) {
+      const interp = entity.getComponent<InterpolationComponent>(ComponentType.Interpolation);
+      const transform = entity.getComponent<TransformComponent>(ComponentType.Transform);
+      if (!interp || !transform) continue;
+
+      const fpPos = transform.fpPosition;
+      interp.snapToPosition(fpPos);
+
+      const floats = FPVector3.ToFloat(fpPos);
+      transform.setVisualPosition(floats.x, floats.y, floats.z);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Implements **lockstep 1v1 network multiplayer** for Chapayev checkers using phalanx-server/phalanx-client
- Two players in separate browsers connect via WebSocket, matchmake, and play with **deterministic simulation** synchronized through server-relayed command batches
- **Hot-seat mode preserved** — switch via `?mode=hotseat` query parameter (default is `online`)

## Architecture

```
Player 1 (browser)         Phalanx Server          Player 2 (browser)
─────────────────         ──────────────          ─────────────────
Flick checker              tick clock (20/s)       Waiting for turn
     │                          │                         │
     ├─── sendCommand ─────────►│                         │
     │    {flick, dir, force}   │                         │
     │                          ├── commands-batch ──────►│
     │◄── commands-batch ───────┤                         │
     │                          │                         │
 PhysicsSystem.processTick()    │    PhysicsSystem.processTick()
 GameRulesSystem.processTick()  │    GameRulesSystem.processTick()
 (identical result)             │    (identical result)
```

## New Files

| File | Purpose |
|------|---------|
| `chapaev/server/src/main.ts` | Phalanx server entry point (matchmaking, tick clock, desync detection) |
| `chapaev/server/package.json` | Standalone server package for deployment |
| `chapaev/src/network/NetworkManager.ts` | PhalanxClient wrapper — connect, queue, match lifecycle |
| `chapaev/src/network/LockstepManager.ts` | Deserialise flick commands, emit as ECS events, state hashing |
| `chapaev/src/components/PlayerComponent.ts` | Links checker entities to network player IDs |
| `chapaev/src/components/InterpolationComponent.ts` | Stores prev/current FP positions for smooth rendering |
| `chapaev/src/systems/InterpolationSystem.ts` | Lerps visual positions at 60fps between 20-tick simulation |

## Modified Files

| File | Change |
|------|--------|
| `chapaev/src/core/Game.ts` | Two-mode startup (hotseat/online), PhalanxClient as `tickFrameProvider`, lifecycle hooks |
| `chapaev/src/systems/FlickInputSystem.ts` | `sendCommand` via LockstepManager in online mode; block input on opponent's turn |
| `chapaev/src/main.ts` | Parse `?mode=hotseat` query param, async `game.start()` |
| `chapaev/src/components/Component.ts` | Register `Player` + `Interpolation` component types |
| `chapaev/src/components/index.ts` | Export new components |
| `chapaev/package.json` | Add `server` script, `phalanx-server` + `tsx` deps |

## Key Design Decisions

- **FlickInputSystem** does NOT modify physics directly in online mode — only `sendCommand`. Commands arrive back through server batch and are applied by LockstepManager → FLICK_EXECUTED event → PhysicsSystem
- **State hashing** every 60 ticks for desync detection (FNV-1a hash of all checker positions + velocities + game state)
- **InterpolationSystem** follows the direct-strike-babylon-example pattern: snapshot → tick → capture → interpolate
- **Player assignment** is deterministic: sorted player IDs, index 0 = white, index 1 = black

## Test Plan

- [ ] `pnpm run server` starts Phalanx server on port 3000
- [ ] Two browser tabs at `localhost:5174` connect, match, and see countdown
- [ ] Flick sends command → both clients see identical checker movement
- [ ] Input blocked when not local player's turn
- [ ] `?mode=hotseat` preserves Stage 1 hot-seat gameplay
- [ ] State hash submitted every 60 ticks, desync logged if detected
- [ ] Page refresh → reconnect catches up (auto-reconnect)
- [ ] Opponent disconnect → "Opponent disconnected" logged
- [ ] No console errors during normal gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)