### PR TITLE
fix: switch Chapayev from continuous to event-based tick mode

### DIFF
--- a/chapaev/server/src/main.ts
+++ b/chapaev/server/src/main.ts
@@ -22,6 +22,7 @@ async function main() {
       origin: CORS_ORIGINS,
       credentials: true,
     },
+    tickMode: 'event',
     tickRate: 20,
     gameMode: '1v1',
     countdownSeconds: 3,

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -38,8 +38,7 @@ export class Game {
 
   // Network (online mode only)
   private networkManager: NetworkManager | null = null;
-  private lockstepManager: LockstepManager | null = null;
-  private interpolationSystem: InterpolationSystem | null = null;
+  private commandFlushUnsubscribe: (() => void) | null = null;
   private localTeam: TeamTag = TeamTag.White;
 
   constructor(canvas: HTMLCanvasElement, mode: GameMode = 'hotseat') {
@@ -142,7 +141,6 @@ export class Game {
     const rapierVFXSystem = new RapierVFXSystem();
     const soundSystem = new SoundSystem();
     const interpolationSystem = new InterpolationSystem();
-    this.interpolationSystem = interpolationSystem;
 
     // Tick systems: physics first, then rules
     const tickSystems = [physicsSystem, gameRulesSystem];
@@ -158,7 +156,12 @@ export class Game {
       this.world.eventBus,
       this.world.entityManager,
     );
-    this.lockstepManager = lockstepManager;
+
+    // Keep a minimal frame subscription so PhalanxClient can flush
+    // buffered outgoing commands each frame.
+    this.commandFlushUnsubscribe = this.networkManager.client.onFrame(
+      (_alpha: number, _dt: number) => {},
+    );
 
     // Wire up mesh map
     const meshMap = renderSystem.getMeshMap();
@@ -293,6 +296,8 @@ export class Game {
   // ── Cleanup ─────────────────────────────────────────────────────
 
   public dispose(): void {
+    this.commandFlushUnsubscribe?.();
+    this.commandFlushUnsubscribe = null;
     this.world.stop();
     this.world.dispose();
     this.networkManager?.dispose();

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -1,5 +1,4 @@
 import { GameWorld, Entity } from 'phalanx-ecs';
-import type { CommandsBatch } from 'phalanx-ecs';
 import { setupScene } from '../rendering/SceneSetup.ts';
 import type { SceneContext } from '../rendering/SceneSetup.ts';
 import { ThreeRenderSystem } from '../systems/ThreeRenderSystem.ts';
@@ -19,7 +18,7 @@ import { INITIAL_POSITIONS } from '../config/constants.ts';
 import { TeamTag } from '../enums/TeamTag.ts';
 import { LockstepManager } from '../network/LockstepManager.ts';
 import { NetworkManager } from '../network/NetworkManager.ts';
-import { GAME_OVER } from '../events/GameEvents.ts';
+import { ALL_SETTLED, GAME_OVER } from '../events/GameEvents.ts';
 import type { GameOverEvent } from '../events/GameEvents.ts';
 
 export type GameMode = 'hotseat' | 'online';
@@ -30,7 +29,7 @@ export type GameMode = 'hotseat' | 'online';
  *
  * Supports two modes:
  * - hotseat: local two-player (Stage 1, internal tick loop)
- * - online:  network 1v1 via PhalanxClient (Stage 2, server-driven ticks)
+ * - online:  network 1v1 via PhalanxClient (Stage 2, event tick mode — local physics, server relays commands)
  */
 export class Game {
   private world!: GameWorld;
@@ -118,10 +117,12 @@ export class Game {
     this.localTeam = localPlayerIndex === 0 ? TeamTag.White : TeamTag.Black;
     console.log(`[Game] Local player index: ${localPlayerIndex}, team: ${this.localTeam}`);
 
-    // Create ECS world with PhalanxClient as tick/frame provider
+    // Event tick mode: GameWorld uses its own internal TickFrameManager at 60Hz.
+    // The server does NOT drive a tick loop — it relays commands immediately.
+    // Physics runs locally on each client; commands arrive via PhalanxClient events.
     this.world = new GameWorld({
       componentTypes: Object.values(ComponentType),
-      tickFrameProvider: this.networkManager.client,
+      tickRate: 60,
     });
 
     // Create entities with player components for online mode
@@ -167,6 +168,18 @@ export class Game {
     // Enable network mode on FlickInputSystem
     flickInputSystem.setNetworkMode(lockstepManager, this.localTeam);
 
+    // Subscribe to incoming commands from the server (event tick mode).
+    // When a flick command arrives, LockstepManager emits FLICK_EXECUTED,
+    // and PhysicsSystem picks it up on the next local 60Hz tick.
+    this.networkManager.onCommandsBatch((batch) => {
+      lockstepManager.handleIncomingCommands(batch);
+    });
+
+    // Submit state hash when physics settles (ALL_SETTLED) for desync detection
+    this.world.eventBus.on(ALL_SETTLED, () => {
+      lockstepManager.submitHashOnSettle();
+    });
+
     // Setup network event handlers
     this.setupNetworkEvents();
 
@@ -178,28 +191,22 @@ export class Game {
 
     const { composer, controls } = this.sceneCtx;
 
-    // Start the world with lifecycle hooks (following direct-strike pattern)
+    // Start the local 60Hz tick/frame loop.
+    // No beforeTick/afterTick hooks for command processing — commands arrive
+    // asynchronously from the network. Interpolation snapshots still happen
+    // around each local tick for smooth visual rendering.
     this.world.start({
-      beforeTick: (tick: number, commandsBatch: CommandsBatch) => {
-        // Snapshot positions BEFORE simulation tick
+      beforeTick: () => {
         interpolationSystem.snapshotPositions();
-
-        // Execute commands from server batch (before tick systems run)
-        lockstepManager.processTick(tick, commandsBatch);
       },
-      afterTick: (tick: number) => {
-        // Capture positions AFTER simulation tick
+      afterTick: () => {
         interpolationSystem.captureCurrentPositions();
-
-        // Submit state hash for desync detection
-        lockstepManager.submitHashIfNeeded(tick);
       },
       beforeFrame: (alpha: number, _dt: number) => {
-        // Interpolate visual positions BEFORE frame systems sync transforms to meshes
         interpolationSystem.interpolate(alpha);
         controls.update();
       },
-      afterFrame: (_alpha: number, _dt: number) => {
+      afterFrame: () => {
         composer.render();
       },
     });

--- a/chapaev/src/network/LockstepManager.ts
+++ b/chapaev/src/network/LockstepManager.ts
@@ -1,7 +1,7 @@
-import type { CommandsBatch, PlayerCommand, EventBus, EntityManager } from 'phalanx-ecs';
+import type { PlayerCommand, EventBus, EntityManager } from 'phalanx-ecs';
 import { FP } from 'phalanx-math';
 import { StateHasher } from 'phalanx-client';
-import type { PhalanxClient } from 'phalanx-client';
+import type { PhalanxClient, CommandsBatchEvent } from 'phalanx-client';
 import { FLICK_EXECUTED } from '../events/GameEvents.ts';
 import type { FlickExecutedEvent } from '../events/GameEvents.ts';
 import { ComponentType } from '../components/Component.ts';
@@ -22,21 +22,26 @@ export interface FlickCommandData {
   force: string;
 }
 
-/** Interval (in ticks) between state hash submissions */
-const HASH_INTERVAL = 60;
-
 /**
  * LockstepManager — processes commands from the server's commands-batch
  * and applies them deterministically on the local ECS.
  *
+ * In event tick mode, commands arrive asynchronously from PhalanxClient
+ * 'commands' events (not from GameWorld tick hooks). The local ECS runs
+ * its own 60Hz physics loop; this manager bridges network commands into
+ * the local event bus.
+ *
  * Only one command type exists in Chapayev: `flick`.
  *
- * Also handles state hashing for desync detection.
+ * Also handles state hashing for desync detection (at ALL_SETTLED).
  */
 export class LockstepManager {
   private readonly client: PhalanxClient;
   private readonly eventBus: EventBus;
   private readonly entityManager: EntityManager;
+
+  /** Last server tick from a commands-batch (used as hash identifier) */
+  private lastServerTick = 0;
 
   constructor(
     client: PhalanxClient,
@@ -57,19 +62,15 @@ export class LockstepManager {
   }
 
   /**
-   * Process a tick's command batch. Called from GameWorld.start({ beforeTick }).
-   * Extracts flick commands and emits them as FLICK_EXECUTED events so that
+   * Handle an incoming commands-batch event from PhalanxClient.
+   * Called from the Game's commands-batch event listener (event tick mode).
+   * Extracts flick commands and emits FLICK_EXECUTED events so that
    * PhysicsSystem processes them identically on all clients.
    */
-  public processTick(_tick: number, commandsBatch: CommandsBatch): void {
-    // Flatten commands from all players in deterministic order (sorted by playerId)
-    const allCommands: PlayerCommand[] = [];
-    const sortedPlayerIds = Object.keys(commandsBatch.commands).sort();
-    for (const playerId of sortedPlayerIds) {
-      allCommands.push(...commandsBatch.commands[playerId]);
-    }
+  public handleIncomingCommands(batch: CommandsBatchEvent): void {
+    this.lastServerTick = batch.tick;
 
-    for (const cmd of allCommands) {
+    for (const cmd of batch.commands) {
       if (cmd.type === 'flick') {
         this.handleFlickCommand(cmd);
       } else {
@@ -134,11 +135,15 @@ export class LockstepManager {
   }
 
   /**
-   * Submit a state hash every HASH_INTERVAL ticks for desync detection.
+   * Submit a state hash for desync detection.
+   * In event tick mode, call this when physics settles (ALL_SETTLED)
+   * using the last server tick as the hash identifier.
    */
-  public submitHashIfNeeded(tick: number): void {
-    if (tick % HASH_INTERVAL !== 0) return;
+  public submitHashOnSettle(): void {
+    this.submitHash(this.lastServerTick);
+  }
 
+  private submitHash(tick: number): void {
     const hasher = new StateHasher();
     hasher.addInt(tick);
 

--- a/chapaev/src/network/NetworkManager.ts
+++ b/chapaev/src/network/NetworkManager.ts
@@ -1,5 +1,5 @@
 import { PhalanxClient } from 'phalanx-client';
-import type { MatchFoundEvent, CountdownEvent, GameStartEvent } from 'phalanx-client';
+import type { MatchFoundEvent, CountdownEvent, GameStartEvent, CommandsBatchEvent } from 'phalanx-client';
 
 const SERVER_URL = import.meta.env.VITE_SERVER_URL || 'http://localhost:3000';
 
@@ -139,6 +139,17 @@ export class NetworkManager {
 
   public onDesync(handler: (tick: number) => void): () => void {
     const unsub = this.client.on('desync', (event) => handler(event.tick));
+    this.networkUnsubscribers.push(unsub);
+    return unsub;
+  }
+
+  /**
+   * Subscribe to incoming commands-batch events from the server.
+   * In event tick mode, the server broadcasts each command immediately
+   * rather than batching on a tick loop.
+   */
+  public onCommandsBatch(handler: (event: CommandsBatchEvent) => void): () => void {
+    const unsub = this.client.on('commands', handler);
     this.networkUnsubscribers.push(unsub);
     return unsub;
   }


### PR DESCRIPTION
## Summary

- **Server**: Add `tickMode: 'event'` to Phalanx config so the server acts as a pure command relay instead of driving a 20Hz tick loop. Commands are broadcast immediately on receipt.
- **Client**: Decouple physics from server ticks — `GameWorld` now uses its own internal `TickFrameManager` at 60Hz (same as hotseat mode) instead of `PhalanxClient` as `tickFrameProvider`. Commands arrive asynchronously via `PhalanxClient` `'commands'` events.
- **LockstepManager**: Replace `processTick()` (called from tick hooks) with `handleIncomingCommands()` (called from network event listener). Add `submitHashOnSettle()` for desync detection at `ALL_SETTLED` instead of every N server ticks.
- **NetworkManager**: Add `onCommandsBatch()` to expose `PhalanxClient` commands events to the game layer.

### Architecture (before → after)

**Before (wrong for Chapayev):**
```
Server 20Hz tick → commands-batch → PhalanxClient.onTick → GameWorld tick → PhysicsSystem runs once
```

**After (correct):**
```
Player flick → server relays immediately → PhalanxClient 'commands' event → LockstepManager → FLICK_EXECUTED
GameWorld 60Hz local tick → PhysicsSystem runs continuously until ALL_SETTLED
```

### Files changed

| File | Change |
|------|--------|
| `chapaev/server/src/main.ts` | Add `tickMode: 'event'` |
| `chapaev/src/core/Game.ts` | Use local 60Hz tick loop; subscribe to commands-batch events; hash at ALL_SETTLED |
| `chapaev/src/network/LockstepManager.ts` | `handleIncomingCommands()` replaces `processTick()`; `submitHashOnSettle()` replaces `submitHashIfNeeded()` |
| `chapaev/src/network/NetworkManager.ts` | Add `onCommandsBatch()` method |

## Test plan

- [ ] Verify hotseat mode (`?mode=hotseat`) still works unchanged — local physics at 60Hz, no regressions
- [ ] Start two browser tabs in online mode — confirm both connect, match, and reach game start
- [ ] Flick a checker in one tab — verify the command is received and physics runs identically on both clients
- [ ] Verify turn transitions work correctly after ALL_SETTLED on both clients
- [ ] Verify input is blocked during opponent's turn and during physics simulation
- [ ] Check server logs confirm no tick loop (no `tick-sync` events, only `commands-batch`)
- [ ] Verify desync detection works — state hashes are submitted after ALL_SETTLED
- [ ] Test reconnection — client replays missed commands and fast-forwards physics

🤖 Generated with [Claude Code](https://claude.com/claude-code)