### PR TITLE
fix(private-room): add host-disconnect grace period to survive mobile tab switches

### DIFF
--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -448,13 +448,17 @@ export class Phalanx extends EventEmitter {
       // their still-alive room. `code` is required to prove the caller
       // is actually the host who created the room — in an anonymous
       // socket environment, `playerId` alone is not an authentication
-      // token. `code` stays optional on the wire for backward
-      // compatibility with older clients; recoverRoom logs a warning
-      // when it's omitted.
+      // token. If it's missing we reject with the same `Room expired`
+      // error the service itself uses, so clients can't distinguish
+      // "wrong code" from "missing code" from "no such room".
       socket.on(
         'room-recover',
-        (data: { playerId: string; username?: string; code?: string }) => {
+        (data: { playerId: string; username?: string; code: string }) => {
           playerId = data.playerId;
+          if (typeof data.code !== 'string' || data.code.length === 0) {
+            socket.emit('room-error', { message: 'Room expired' });
+            return;
+          }
           this.privateRooms!.recoverRoom(playerId, socket, data.code);
         }
       );

--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -441,6 +441,19 @@ export class Phalanx extends EventEmitter {
         }
       });
 
+      // Handle room-recover (private match)
+      // Called when a host reconnects after a transient socket disconnect
+      // (e.g. mobile browser killing the WebSocket when the user switches
+      // to a messenger to share the invite link) and wants to reclaim
+      // their still-alive room.
+      socket.on(
+        'room-recover',
+        (data: { playerId: string; username?: string }) => {
+          playerId = data.playerId;
+          this.privateRooms!.recoverRoom(playerId, socket);
+        }
+      );
+
       // Handle player command
       socket.on('player-command', (command: PlayerCommand) => {
         if (!playerId) return;

--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -454,12 +454,27 @@ export class Phalanx extends EventEmitter {
       socket.on(
         'room-recover',
         (data: { playerId: string; username?: string; code: string }) => {
-          playerId = data.playerId;
+          // Validate the untrusted payload before touching any state
+          // on this connection. A failed recover must not mutate the
+          // captured `playerId` — otherwise a later handler like
+          // `room-cancel` would act on a playerId the socket was
+          // never authenticated to own.
           if (typeof data.code !== 'string' || data.code.length === 0) {
             socket.emit('room-error', { message: 'Room expired' });
             return;
           }
-          this.privateRooms!.recoverRoom(playerId, socket, data.code);
+          if (typeof data.playerId !== 'string' || data.playerId.length === 0) {
+            socket.emit('room-error', { message: 'Room expired' });
+            return;
+          }
+          const recovered = this.privateRooms!.recoverRoom(
+            data.playerId,
+            socket,
+            data.code,
+          );
+          if (recovered) {
+            playerId = data.playerId;
+          }
         }
       );
 

--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -445,12 +445,17 @@ export class Phalanx extends EventEmitter {
       // Called when a host reconnects after a transient socket disconnect
       // (e.g. mobile browser killing the WebSocket when the user switches
       // to a messenger to share the invite link) and wants to reclaim
-      // their still-alive room.
+      // their still-alive room. `code` is required to prove the caller
+      // is actually the host who created the room — in an anonymous
+      // socket environment, `playerId` alone is not an authentication
+      // token. `code` stays optional on the wire for backward
+      // compatibility with older clients; recoverRoom logs a warning
+      // when it's omitted.
       socket.on(
         'room-recover',
-        (data: { playerId: string; username?: string }) => {
+        (data: { playerId: string; username?: string; code?: string }) => {
           playerId = data.playerId;
-          this.privateRooms!.recoverRoom(playerId, socket);
+          this.privateRooms!.recoverRoom(playerId, socket, data.code);
         }
       );
 

--- a/phalanx-server/src/Phalanx.ts
+++ b/phalanx-server/src/Phalanx.ts
@@ -451,32 +451,43 @@ export class Phalanx extends EventEmitter {
       // token. If it's missing we reject with the same `Room expired`
       // error the service itself uses, so clients can't distinguish
       // "wrong code" from "missing code" from "no such room".
-      socket.on(
-        'room-recover',
-        (data: { playerId: string; username?: string; code: string }) => {
-          // Validate the untrusted payload before touching any state
-          // on this connection. A failed recover must not mutate the
-          // captured `playerId` — otherwise a later handler like
-          // `room-cancel` would act on a playerId the socket was
-          // never authenticated to own.
-          if (typeof data.code !== 'string' || data.code.length === 0) {
-            socket.emit('room-error', { message: 'Room expired' });
-            return;
-          }
-          if (typeof data.playerId !== 'string' || data.playerId.length === 0) {
-            socket.emit('room-error', { message: 'Room expired' });
-            return;
-          }
-          const recovered = this.privateRooms!.recoverRoom(
-            data.playerId,
-            socket,
-            data.code,
-          );
-          if (recovered) {
-            playerId = data.playerId;
-          }
+      socket.on('room-recover', (payload: unknown) => {
+        // The payload is untrusted — a client can emit literally
+        // anything (including `null`, a primitive, or a missing
+        // argument, which Socket.IO will surface as `undefined`).
+        // Guard the top-level shape before dereferencing any field
+        // so a malformed message can't crash the connection
+        // handler, and validate each field before touching state
+        // on this connection. A failed recover must not mutate the
+        // captured `playerId` — otherwise a later handler like
+        // `room-cancel` would act on a playerId the socket was
+        // never authenticated to own.
+        if (!payload || typeof payload !== 'object') {
+          socket.emit('room-error', { message: 'Room expired' });
+          return;
         }
-      );
+        const data = payload as {
+          playerId?: unknown;
+          username?: unknown;
+          code?: unknown;
+        };
+        if (typeof data.code !== 'string' || data.code.length === 0) {
+          socket.emit('room-error', { message: 'Room expired' });
+          return;
+        }
+        if (typeof data.playerId !== 'string' || data.playerId.length === 0) {
+          socket.emit('room-error', { message: 'Room expired' });
+          return;
+        }
+        const recovered = this.privateRooms!.recoverRoom(
+          data.playerId,
+          socket,
+          data.code,
+        );
+        if (recovered) {
+          playerId = data.playerId;
+        }
+      });
 
       // Handle player command
       socket.on('player-command', (command: PlayerCommand) => {

--- a/phalanx-server/src/index.ts
+++ b/phalanx-server/src/index.ts
@@ -53,6 +53,10 @@ export type {
   // Game type routing
   TickMode,
   GameTypeConfig,
+  // Private room events
+  RoomCreatedEvent,
+  RoomRecoveredEvent,
+  RoomErrorEvent,
 } from './types/index.js';
 
 // Constants

--- a/phalanx-server/src/services/GameRoom.ts
+++ b/phalanx-server/src/services/GameRoom.ts
@@ -235,37 +235,69 @@ export class GameRoom {
    */
   private notifyMatchFound(): void {
     this.teams.forEach((team, teamId) => {
-      // Build teammate info for this team
-      const teammateInfo = team.map((p) => ({
-        playerId: p.playerId,
-        username: p.username,
-      }));
-
-      // Build opponent info (all players from other teams)
-      const opponentInfo = this.teams
-        .filter((_, i) => i !== teamId)
-        .flat()
-        .map((p) => ({
-          playerId: p.playerId,
-          username: p.username,
-        }));
-
-      // Notify each player on this team
       team.forEach((player) => {
         const socket = this.io.sockets.sockets.get(player.socketId);
         if (socket) {
-          socket.emit('match-found', {
-            matchId: this.id,
-            playerId: player.playerId,
+          const payload = this.buildMatchFoundPayloadForTeam(
+            player.playerId,
             teamId,
-            teammates: teammateInfo.filter(
-              (t) => t.playerId !== player.playerId
-            ),
-            opponents: opponentInfo,
-          });
+            team,
+          );
+          if (payload) socket.emit('match-found', payload);
         }
       });
     });
+  }
+
+  /**
+   * Build the personalized `match-found` payload for `playerId`.
+   *
+   * Used by the initial broadcast in {@link notifyMatchFound} and by
+   * retroactive delivery when a host who was offline at `joinRoom`
+   * time finally reconnects via `room-recover`. Returns `null` if
+   * the player is not in this match.
+   */
+  buildMatchFoundPayload(playerId: string): {
+    matchId: string;
+    playerId: string;
+    teamId: number;
+    teammates: { playerId: string; username: string }[];
+    opponents: { playerId: string; username: string }[];
+  } | null {
+    for (let teamId = 0; teamId < this.teams.length; teamId++) {
+      const team = this.teams[teamId];
+      if (team && team.some((p) => p.playerId === playerId)) {
+        return this.buildMatchFoundPayloadForTeam(playerId, teamId, team);
+      }
+    }
+    return null;
+  }
+
+  private buildMatchFoundPayloadForTeam(
+    playerId: string,
+    teamId: number,
+    team: QueuedPlayer[],
+  ): {
+    matchId: string;
+    playerId: string;
+    teamId: number;
+    teammates: { playerId: string; username: string }[];
+    opponents: { playerId: string; username: string }[];
+  } {
+    const teammates = team
+      .filter((p) => p.playerId !== playerId)
+      .map((p) => ({ playerId: p.playerId, username: p.username }));
+    const opponents = this.teams
+      .filter((_, i) => i !== teamId)
+      .flat()
+      .map((p) => ({ playerId: p.playerId, username: p.username }));
+    return {
+      matchId: this.id,
+      playerId,
+      teamId,
+      teammates,
+      opponents,
+    };
   }
 
   /**

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -45,6 +45,16 @@ interface PrivateRoom {
 export class PrivateRoomService {
   private readonly rooms: Map<string, PrivateRoom> = new Map();
   private readonly matches: Map<string, GameRoom> = new Map();
+  /**
+   * Matches whose host was still disconnected at the moment a guest
+   * joined their room. The host never received `match-found` because
+   * their socket was null at `joinRoom` time, so we remember the
+   * `matchId` keyed by the host's `playerId` and deliver it when the
+   * host finally reconnects via `room-recover`. Entries are purged
+   * when the match ends (see `removeMatch`), so a dead match can't
+   * leak through an indefinite pending-recover entry.
+   */
+  private readonly pendingHostReconnect: Map<string, string> = new Map();
   private readonly io: SocketIOServer;
   private readonly config: PhalanxConfig;
   private readonly eventEmitter: (
@@ -222,6 +232,19 @@ export class PrivateRoomService {
     this.eventEmitter('match-created', gameRoom.getMatchInfo());
     gameRoom.start();
 
+    // If the host was still in the disconnect grace window at the
+    // moment the guest joined, `match-found` was emitted by GameRoom
+    // but never reached them (their socket is null / dead). Record
+    // the pairing so a subsequent `room-recover` on the host's new
+    // socket can retroactively deliver match-found and wire the
+    // socket into the running match.
+    if (!room.hostSocket) {
+      this.pendingHostReconnect.set(room.host.playerId, matchId);
+      console.log(
+        `[PrivateRoom] Host ${room.host.playerId} was offline when match ${matchId} started — pending recover`
+      );
+    }
+
     console.log(
       `[PrivateRoom] Room ${code} → match ${matchId} (${room.host.playerId} vs ${playerId})`
     );
@@ -279,6 +302,42 @@ export class PrivateRoomService {
     const normalizedCode = code.toUpperCase();
     const room = this.rooms.get(normalizedCode);
     if (!room || room.host.playerId !== playerId) {
+      // Fallback: maybe the host's original room was consumed by a
+      // guest while the host was still in the disconnect grace window,
+      // which means a match exists but the host never learned its id.
+      // If so, promote the host into that match now. We still require
+      // the host to know their original room code — we looked it up
+      // above — but since the room is gone, we can only authenticate
+      // on playerId here. That's acceptable because the pending entry
+      // only exists if that playerId actually created the now-consumed
+      // room in the first place.
+      const pendingMatchId = this.pendingHostReconnect.get(playerId);
+      if (pendingMatchId) {
+        const match = this.matches.get(pendingMatchId);
+        if (match) {
+          this.pendingHostReconnect.delete(playerId);
+          // `handleReconnect` wires the socket into the running match
+          // and emits `reconnect-state` with the full match snapshot.
+          // We also emit `match-found` so the client sees the same
+          // event it would have seen had its socket been alive at
+          // `joinRoom` time — keeps the client state machine simple.
+          match.handleReconnect(playerId, socket.id);
+          const matchFound = match.buildMatchFoundPayload(playerId);
+          if (matchFound) {
+            socket.emit('match-found', matchFound);
+          }
+          socket.emit('room-recovered', {
+            code: normalizedCode,
+          } satisfies RoomRecoveredEvent);
+          console.log(
+            `[PrivateRoom] Host ${playerId} recovered into pending match ${pendingMatchId}`
+          );
+          return true;
+        }
+        // Match vanished before recover — drop the stale entry and
+        // fall through to the generic 'Room expired' response below.
+        this.pendingHostReconnect.delete(playerId);
+      }
       socket.emit('room-error', {
         message: 'Room expired',
       } satisfies RoomErrorEvent);
@@ -357,9 +416,18 @@ export class PrivateRoomService {
   /**
    * Remove a finished match from the private matches map.
    * Called from the match-ended listener — the match already stopped itself.
+   *
+   * Also purges any pending host-reconnect entry that still points at
+   * this match, so a host who never came back within the match's
+   * lifetime can't later collide with a fresh room they create.
    */
   removeMatch(matchId: string): void {
     this.matches.delete(matchId);
+    for (const [playerId, pendingMatchId] of this.pendingHostReconnect) {
+      if (pendingMatchId === matchId) {
+        this.pendingHostReconnect.delete(playerId);
+      }
+    }
   }
 
   /**
@@ -395,6 +463,7 @@ export class PrivateRoomService {
       }
     }
     this.rooms.clear();
+    this.pendingHostReconnect.clear();
   }
 
   /**

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -112,11 +112,18 @@ export class PrivateRoomService {
     const code = this.generateCode();
     const resolvedGameType = gameType ?? 'default';
 
-    // Auto-expire room after TTL
+    // Auto-expire room after TTL.
+    //
+    // Look the room back up inside the timer and emit on its *current*
+    // host socket rather than the one captured at creation time, because
+    // the host may have reconnected on a new socket via `room-recover`
+    // before the TTL elapsed. If the host is disconnected at the moment
+    // of expiry, there's simply no one to notify — that's fine.
     const expirationTimer = setTimeout(() => {
-      if (this.rooms.has(code)) {
+      const expired = this.rooms.get(code);
+      if (expired) {
         this.removeRoom(code);
-        socket.emit('room-expired', { code });
+        expired.hostSocket?.emit('room-expired', { code });
         console.log(`[PrivateRoom] Room ${code} expired`);
       }
     }, PrivateRoomService.ROOM_TTL_MS);
@@ -241,20 +248,51 @@ export class PrivateRoomService {
   /**
    * Recover a room after the host's socket disconnected within the grace period.
    *
-   * Rebinds the room to the host's new socket, clears the pending
-   * destruction timer, and emits `room-recovered` on the new socket.
-   * If no matching room exists (never created, or grace period already
-   * elapsed), emits `room-error` instead.
+   * The caller must present the room `code` along with the `playerId` —
+   * possession of the code is what authenticates the host in the
+   * anonymous-socket case. Without that check, any client that knew
+   * (or guessed) a host's `playerId` could reclaim their room and
+   * learn its invite code.
+   *
+   * On success: clears the pending destruction timer, rebinds the
+   * room to the host's new socket (updating both the service-level
+   * `hostSocket`/`hostSocketId` and the matchmaking-level
+   * `host.socketId` used by GameRoom to look up the host's socket),
+   * and emits `room-recovered` on the new socket.
+   *
+   * If no matching room exists for this player (never created, or
+   * grace period / TTL already elapsed) OR the code doesn't match
+   * the stored room, emits `room-error: "Room expired"`. We use
+   * the same message for both cases so we don't leak whether a
+   * given playerId currently owns a room.
    */
-  recoverRoom(playerId: string, socket: Socket): void {
+  recoverRoom(playerId: string, socket: Socket, code?: string): void {
+    const normalizedCode = code?.toUpperCase();
     for (const [, room] of this.rooms) {
-      if (room.host.playerId === playerId) {
+      if (
+        room.host.playerId === playerId &&
+        (normalizedCode === undefined || room.code === normalizedCode)
+      ) {
+        if (normalizedCode === undefined) {
+          // Legacy callers that don't pass a code still work but are
+          // logged so we can spot them in downstream games.
+          console.warn(
+            `[PrivateRoom] recoverRoom called without a code for ${playerId} — ` +
+              `future versions will require it`,
+          );
+        }
+
         if (room.hostDisconnectTimer) {
           clearTimeout(room.hostDisconnectTimer);
           room.hostDisconnectTimer = null;
         }
         room.hostSocket = socket;
         room.hostSocketId = socket.id;
+        // Keep the QueuedPlayer.socketId in sync so that when a guest
+        // later joins, GameRoom's socketId→playerId map and its
+        // `io.sockets.sockets.get(player.socketId)` lookups resolve
+        // to the host's *current* socket rather than the dead one.
+        room.host.socketId = socket.id;
         socket.emit('room-recovered', {
           code: room.code,
         } satisfies RoomRecoveredEvent);

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -49,12 +49,23 @@ export class PrivateRoomService {
    * Matches whose host was still disconnected at the moment a guest
    * joined their room. The host never received `match-found` because
    * their socket was null at `joinRoom` time, so we remember the
-   * `matchId` keyed by the host's `playerId` and deliver it when the
-   * host finally reconnects via `room-recover`. Entries are purged
-   * when the match ends (see `removeMatch`), so a dead match can't
-   * leak through an indefinite pending-recover entry.
+   * `matchId` — and the *original* room code the host must present
+   * to claim it — keyed by the host's `playerId`, and deliver it
+   * when the host finally reconnects via `room-recover`.
+   *
+   * Storing the code alongside the matchId lets the recovery fallback
+   * keep the same security posture as the live-room path: an attacker
+   * who only knows a host's `playerId` cannot harvest the code by
+   * guessing, because the fallback also refuses to promote a socket
+   * into the match unless the caller presents the matching code.
+   *
+   * Entries are purged when the match ends (see `removeMatch`), so a
+   * dead match can't leak through an indefinite pending-recover entry.
    */
-  private readonly pendingHostReconnect: Map<string, string> = new Map();
+  private readonly pendingHostReconnect: Map<
+    string,
+    { matchId: string; code: string }
+  > = new Map();
   private readonly io: SocketIOServer;
   private readonly config: PhalanxConfig;
   private readonly eventEmitter: (
@@ -239,7 +250,10 @@ export class PrivateRoomService {
     // socket can retroactively deliver match-found and wire the
     // socket into the running match.
     if (!room.hostSocket) {
-      this.pendingHostReconnect.set(room.host.playerId, matchId);
+      this.pendingHostReconnect.set(room.host.playerId, {
+        matchId,
+        code: room.code,
+      });
       console.log(
         `[PrivateRoom] Host ${room.host.playerId} was offline when match ${matchId} started — pending recover`
       );
@@ -302,18 +316,17 @@ export class PrivateRoomService {
     const normalizedCode = code.toUpperCase();
     const room = this.rooms.get(normalizedCode);
     if (!room || room.host.playerId !== playerId) {
-      // Fallback: maybe the host's original room was consumed by a
-      // guest while the host was still in the disconnect grace window,
-      // which means a match exists but the host never learned its id.
-      // If so, promote the host into that match now. We still require
-      // the host to know their original room code — we looked it up
-      // above — but since the room is gone, we can only authenticate
-      // on playerId here. That's acceptable because the pending entry
-      // only exists if that playerId actually created the now-consumed
-      // room in the first place.
-      const pendingMatchId = this.pendingHostReconnect.get(playerId);
-      if (pendingMatchId) {
-        const match = this.matches.get(pendingMatchId);
+      // Fallback: the host's original room may already have been
+      // consumed by a guest while the host was in the disconnect
+      // grace window. In that case a match exists but the host never
+      // learned its id. Promote the host into that match, but only
+      // if they present the matching original room code — we must
+      // not weaken authentication in the fallback path relative to
+      // the live-room path, or an attacker who only knows a playerId
+      // could harvest the match by guessing any code.
+      const pending = this.pendingHostReconnect.get(playerId);
+      if (pending && pending.code === normalizedCode) {
+        const match = this.matches.get(pending.matchId);
         if (match) {
           this.pendingHostReconnect.delete(playerId);
           // `handleReconnect` wires the socket into the running match
@@ -326,11 +339,14 @@ export class PrivateRoomService {
           if (matchFound) {
             socket.emit('match-found', matchFound);
           }
+          // Emit the *stored* room code, not the caller-provided one,
+          // so a client that somehow drifted on casing still sees the
+          // canonical value.
           socket.emit('room-recovered', {
-            code: normalizedCode,
+            code: pending.code,
           } satisfies RoomRecoveredEvent);
           console.log(
-            `[PrivateRoom] Host ${playerId} recovered into pending match ${pendingMatchId}`
+            `[PrivateRoom] Host ${playerId} recovered into pending match ${pending.matchId}`
           );
           return true;
         }
@@ -423,8 +439,8 @@ export class PrivateRoomService {
    */
   removeMatch(matchId: string): void {
     this.matches.delete(matchId);
-    for (const [playerId, pendingMatchId] of this.pendingHostReconnect) {
-      if (pendingMatchId === matchId) {
+    for (const [playerId, pending] of this.pendingHostReconnect) {
+      if (pending.matchId === matchId) {
         this.pendingHostReconnect.delete(playerId);
       }
     }

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -265,35 +265,42 @@ export class PrivateRoomService {
    * the stored room, emits `room-error: "Room expired"`. We use
    * the same message for both cases so we don't leak whether a
    * given playerId currently owns a room.
+   *
+   * Returns `true` on success and `false` on any failure, so the
+   * Phalanx handler can gate updating the socket's captured
+   * `playerId` on an authenticated recover.
    */
-  recoverRoom(playerId: string, socket: Socket, code: string): void {
+  recoverRoom(playerId: string, socket: Socket, code: string): boolean {
+    // O(1) lookup by code (the map's key) rather than scanning every
+    // room. The same 'Room expired' error is emitted whether the code
+    // is unknown or the code is known but owned by a different player,
+    // so an attacker who guesses a playerId can't tell a valid code
+    // from an invalid one.
     const normalizedCode = code.toUpperCase();
-    for (const [, room] of this.rooms) {
-      if (
-        room.host.playerId === playerId &&
-        room.code === normalizedCode
-      ) {
-        if (room.hostDisconnectTimer) {
-          clearTimeout(room.hostDisconnectTimer);
-          room.hostDisconnectTimer = null;
-        }
-        room.hostSocket = socket;
-        room.hostSocketId = socket.id;
-        // Keep the QueuedPlayer.socketId in sync so that when a guest
-        // later joins, GameRoom's socketId→playerId map and its
-        // `io.sockets.sockets.get(player.socketId)` lookups resolve
-        // to the host's *current* socket rather than the dead one.
-        room.host.socketId = socket.id;
-        socket.emit('room-recovered', {
-          code: room.code,
-        } satisfies RoomRecoveredEvent);
-        console.log(`[PrivateRoom] Room ${room.code} recovered by ${playerId}`);
-        return;
-      }
+    const room = this.rooms.get(normalizedCode);
+    if (!room || room.host.playerId !== playerId) {
+      socket.emit('room-error', {
+        message: 'Room expired',
+      } satisfies RoomErrorEvent);
+      return false;
     }
-    socket.emit('room-error', {
-      message: 'Room expired',
-    } satisfies RoomErrorEvent);
+
+    if (room.hostDisconnectTimer) {
+      clearTimeout(room.hostDisconnectTimer);
+      room.hostDisconnectTimer = null;
+    }
+    room.hostSocket = socket;
+    room.hostSocketId = socket.id;
+    // Keep the QueuedPlayer.socketId in sync so that when a guest
+    // later joins, GameRoom's socketId→playerId map and its
+    // `io.sockets.sockets.get(player.socketId)` lookups resolve
+    // to the host's *current* socket rather than the dead one.
+    room.host.socketId = socket.id;
+    socket.emit('room-recovered', {
+      code: room.code,
+    } satisfies RoomRecoveredEvent);
+    console.log(`[PrivateRoom] Room ${room.code} recovered by ${playerId}`);
+    return true;
   }
 
   /**

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -252,7 +252,7 @@ export class PrivateRoomService {
    * possession of the code is what authenticates the host in the
    * anonymous-socket case. Without that check, any client that knew
    * (or guessed) a host's `playerId` could reclaim their room and
-   * learn its invite code.
+   * learn its invite code, so `code` is required and must match.
    *
    * On success: clears the pending destruction timer, rebinds the
    * room to the host's new socket (updating both the service-level
@@ -266,22 +266,13 @@ export class PrivateRoomService {
    * the same message for both cases so we don't leak whether a
    * given playerId currently owns a room.
    */
-  recoverRoom(playerId: string, socket: Socket, code?: string): void {
-    const normalizedCode = code?.toUpperCase();
+  recoverRoom(playerId: string, socket: Socket, code: string): void {
+    const normalizedCode = code.toUpperCase();
     for (const [, room] of this.rooms) {
       if (
         room.host.playerId === playerId &&
-        (normalizedCode === undefined || room.code === normalizedCode)
+        room.code === normalizedCode
       ) {
-        if (normalizedCode === undefined) {
-          // Legacy callers that don't pass a code still work but are
-          // logged so we can spot them in downstream games.
-          console.warn(
-            `[PrivateRoom] recoverRoom called without a code for ${playerId} — ` +
-              `future versions will require it`,
-          );
-        }
-
         if (room.hostDisconnectTimer) {
           clearTimeout(room.hostDisconnectTimer);
           room.hostDisconnectTimer = null;

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -1,27 +1,39 @@
 import type { Server as SocketIOServer, Socket } from 'socket.io';
-import type { PhalanxConfig, QueuedPlayer } from '../types/index.js';
+import type {
+  PhalanxConfig,
+  QueuedPlayer,
+  RoomCreatedEvent,
+  RoomRecoveredEvent,
+  RoomErrorEvent,
+} from '../types/index.js';
 import { GameRoom } from './GameRoom.js';
+
+// Re-export private-room event types from this module for backward
+// compatibility — callers (and existing tests) historically import them
+// from `services/PrivateRoomService.js`.
+export type { RoomCreatedEvent, RoomRecoveredEvent, RoomErrorEvent };
 
 /**
  * Represents a private room waiting for a second player.
+ *
+ * The host socket may be temporarily `null` if the host disconnects —
+ * e.g. a mobile browser killing the WebSocket when the user switches
+ * to another app to share the invite link. In that case the room
+ * survives for `HOST_DISCONNECT_GRACE_MS` so the host can reconnect
+ * via `room-recover` and reclaim it.
  */
 interface PrivateRoom {
   readonly code: string;
   readonly host: QueuedPlayer;
-  readonly hostSocket: Socket;
+  /** Current host socket; null while the host is disconnected. */
+  hostSocket: Socket | null;
+  /** Tracked separately from the socket object because hostSocket may be null. */
+  hostSocketId: string;
   readonly gameType: string;
   readonly createdAt: number;
   expirationTimer: ReturnType<typeof setTimeout>;
-}
-
-/** Event sent to the host when a room is created. */
-export interface RoomCreatedEvent {
-  code: string;
-}
-
-/** Event sent when a room join fails. */
-export interface RoomErrorEvent {
-  message: string;
+  /** Pending grace-period timer set when the host disconnects. */
+  hostDisconnectTimer: ReturnType<typeof setTimeout> | null;
 }
 
 /**
@@ -35,19 +47,25 @@ export class PrivateRoomService {
   private readonly matches: Map<string, GameRoom> = new Map();
   private readonly io: SocketIOServer;
   private readonly config: PhalanxConfig;
-  private readonly eventEmitter: (event: string, ...args: unknown[]) => boolean | void;
+  private readonly eventEmitter: (
+    event: string,
+    ...args: unknown[]
+  ) => boolean | void;
   private readonly resolveGameTypeConfig: (gameType: string) => PhalanxConfig;
   private readonly isPlayerQueued?: (playerId: string) => boolean;
 
   /** TTL for rooms in ms (5 minutes). */
   private static readonly ROOM_TTL_MS = 5 * 60 * 1000;
 
+  /** How long a room survives after the host disconnects, in ms (2 minutes). */
+  private static readonly HOST_DISCONNECT_GRACE_MS = 2 * 60 * 1000;
+
   constructor(
     io: SocketIOServer,
     config: PhalanxConfig,
     eventEmitter: (event: string, ...args: unknown[]) => boolean | void,
     resolveGameTypeConfig: (gameType: string) => PhalanxConfig,
-    isPlayerQueued?: (playerId: string) => boolean,
+    isPlayerQueued?: (playerId: string) => boolean
   ) {
     this.io = io;
     this.config = config;
@@ -63,24 +81,30 @@ export class PrivateRoomService {
     playerId: string,
     username: string,
     socket: Socket,
-    gameType?: string,
+    gameType?: string
   ): void {
     // Reject if player is already in a match
     if ((socket.data as { matchId?: string }).matchId) {
-      socket.emit('room-error', { message: 'Already in a match' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Already in a match',
+      } satisfies RoomErrorEvent);
       return;
     }
 
     // Reject if player is currently queued in matchmaking
     if (this.isPlayerQueued?.(playerId)) {
-      socket.emit('room-error', { message: 'Already in matchmaking queue' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Already in matchmaking queue',
+      } satisfies RoomErrorEvent);
       return;
     }
 
     // Prevent duplicate rooms per player
     for (const room of this.rooms.values()) {
       if (room.host.playerId === playerId) {
-        socket.emit('room-error', { message: 'You already have an active room' } satisfies RoomErrorEvent);
+        socket.emit('room-error', {
+          message: 'You already have an active room',
+        } satisfies RoomErrorEvent);
         return;
       }
     }
@@ -107,9 +131,11 @@ export class PrivateRoomService {
         gameType: resolvedGameType,
       },
       hostSocket: socket,
+      hostSocketId: socket.id,
       gameType: resolvedGameType,
       createdAt: Date.now(),
       expirationTimer,
+      hostDisconnectTimer: null,
     };
 
     this.rooms.set(code, room);
@@ -125,29 +151,37 @@ export class PrivateRoomService {
     playerId: string,
     username: string,
     socket: Socket,
-    code: string,
+    code: string
   ): void {
     // Reject if player is already in a match
     if ((socket.data as { matchId?: string }).matchId) {
-      socket.emit('room-error', { message: 'Already in a match' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Already in a match',
+      } satisfies RoomErrorEvent);
       return;
     }
 
     // Reject if player is currently queued in matchmaking
     if (this.isPlayerQueued?.(playerId)) {
-      socket.emit('room-error', { message: 'Already in matchmaking queue' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Already in matchmaking queue',
+      } satisfies RoomErrorEvent);
       return;
     }
 
     const room = this.rooms.get(code.toUpperCase());
 
     if (!room) {
-      socket.emit('room-error', { message: 'Room not found' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Room not found',
+      } satisfies RoomErrorEvent);
       return;
     }
 
     if (room.host.playerId === playerId) {
-      socket.emit('room-error', { message: 'Cannot join your own room' } satisfies RoomErrorEvent);
+      socket.emit('room-error', {
+        message: 'Cannot join your own room',
+      } satisfies RoomErrorEvent);
       return;
     }
 
@@ -174,18 +208,24 @@ export class PrivateRoomService {
       resolvedConfig,
       teams,
       this.eventEmitter,
-      room.gameType,
+      room.gameType
     );
 
     this.matches.set(matchId, gameRoom);
     this.eventEmitter('match-created', gameRoom.getMatchInfo());
     gameRoom.start();
 
-    console.log(`[PrivateRoom] Room ${code} → match ${matchId} (${room.host.playerId} vs ${playerId})`);
+    console.log(
+      `[PrivateRoom] Room ${code} → match ${matchId} (${room.host.playerId} vs ${playerId})`
+    );
   }
 
   /**
    * Cancel a room that the player previously created.
+   *
+   * Looks up by `playerId` (not `socketId`) so a host who reconnected with
+   * a new socket after a disconnect can still cancel their own room.
+   * `room-cancelled` is emitted on the socket that initiated the cancel.
    */
   cancelRoom(playerId: string, socket: Socket): void {
     for (const [code, room] of this.rooms) {
@@ -199,13 +239,62 @@ export class PrivateRoomService {
   }
 
   /**
-   * Handle socket disconnect — clean up rooms owned by this socket.
+   * Recover a room after the host's socket disconnected within the grace period.
+   *
+   * Rebinds the room to the host's new socket, clears the pending
+   * destruction timer, and emits `room-recovered` on the new socket.
+   * If no matching room exists (never created, or grace period already
+   * elapsed), emits `room-error` instead.
+   */
+  recoverRoom(playerId: string, socket: Socket): void {
+    for (const [, room] of this.rooms) {
+      if (room.host.playerId === playerId) {
+        if (room.hostDisconnectTimer) {
+          clearTimeout(room.hostDisconnectTimer);
+          room.hostDisconnectTimer = null;
+        }
+        room.hostSocket = socket;
+        room.hostSocketId = socket.id;
+        socket.emit('room-recovered', {
+          code: room.code,
+        } satisfies RoomRecoveredEvent);
+        console.log(`[PrivateRoom] Room ${room.code} recovered by ${playerId}`);
+        return;
+      }
+    }
+    socket.emit('room-error', {
+      message: 'Room expired',
+    } satisfies RoomErrorEvent);
+  }
+
+  /**
+   * Handle socket disconnect — start a grace period during which the host
+   * can reclaim their room via `room-recover`. This keeps the room alive
+   * while the host opens a messenger to share the invite link on mobile,
+   * since mobile browsers aggressively kill background WebSockets.
+   *
+   * The room is destroyed at whichever fires first: this grace timer
+   * or the original TTL timer (`ROOM_TTL_MS`).
    */
   handleDisconnect(socketId: string): void {
     for (const [code, room] of this.rooms) {
-      if (room.host.socketId === socketId) {
-        this.removeRoom(code);
-        console.log(`[PrivateRoom] Room ${code} removed (host disconnected)`);
+      if (room.hostSocketId === socketId) {
+        room.hostSocket = null;
+        // Only start a grace timer if one isn't already running.
+        // (Defensive; in practice a fresh disconnect won't have one.)
+        if (!room.hostDisconnectTimer) {
+          room.hostDisconnectTimer = setTimeout(() => {
+            if (this.rooms.has(code)) {
+              this.removeRoom(code);
+              console.log(
+                `[PrivateRoom] Room ${code} removed (host stayed disconnected)`
+              );
+            }
+          }, PrivateRoomService.HOST_DISCONNECT_GRACE_MS);
+        }
+        console.log(
+          `[PrivateRoom] Host of room ${code} disconnected — grace period started`
+        );
       }
     }
 
@@ -238,18 +327,24 @@ export class PrivateRoomService {
   }
 
   /**
-   * Remove a room and clear its expiration timer.
+   * Remove a room and clear all of its pending timers (TTL and any
+   * host-disconnect grace timer).
    */
   private removeRoom(code: string): void {
     const room = this.rooms.get(code);
     if (room) {
       clearTimeout(room.expirationTimer);
+      if (room.hostDisconnectTimer) {
+        clearTimeout(room.hostDisconnectTimer);
+        room.hostDisconnectTimer = null;
+      }
       this.rooms.delete(code);
     }
   }
 
   /**
-   * Stop all active matches and clear rooms.
+   * Stop all active matches and clear rooms, including any pending
+   * TTL and host-disconnect grace timers.
    */
   stop(): void {
     for (const match of this.matches.values()) {
@@ -258,6 +353,10 @@ export class PrivateRoomService {
     this.matches.clear();
     for (const room of this.rooms.values()) {
       clearTimeout(room.expirationTimer);
+      if (room.hostDisconnectTimer) {
+        clearTimeout(room.hostDisconnectTimer);
+        room.hostDisconnectTimer = null;
+      }
     }
     this.rooms.clear();
   }
@@ -277,4 +376,3 @@ export class PrivateRoomService {
     return code;
   }
 }
-

--- a/phalanx-server/src/types/index.ts
+++ b/phalanx-server/src/types/index.ts
@@ -362,13 +362,15 @@ export interface QueueStatusEvent {
  *   • client → server: `room-create`    → `{ playerId, username?, gameType? }`
  *   • client → server: `room-join`      → `{ playerId, username?, code }`
  *   • client → server: `room-cancel`    → `{}`
- *   • client → server: `room-recover`   → `{ playerId, username?, code? }`
+ *   • client → server: `room-recover`   → `{ playerId, username?, code }`
  *
- * The `code` on `room-recover` is strongly recommended: it proves the
- * caller is actually the host who created the room. Without it any
- * client that knew a host's `playerId` could reclaim the room.
- * It is optional on the wire for backward compatibility; the server
- * logs a warning when a client omits it.
+ * The `code` on `room-recover` is required: it proves the caller is
+ * actually the host who created the room. In an unauthenticated
+ * socket environment `playerId` alone is not a credential, so the
+ * server refuses to recover without a matching code and emits
+ * `room-error: "Room expired"` instead (same message as "no such
+ * room" so we never leak whether a given playerId currently owns
+ * a room).
  */
 
 /** Event sent to the host when a room is created. */

--- a/phalanx-server/src/types/index.ts
+++ b/phalanx-server/src/types/index.ts
@@ -347,6 +347,43 @@ export interface QueueStatusEvent {
 }
 
 /**
+ * Private room events — client/server wire contracts.
+ *
+ * These mirror the interfaces exported from
+ * `services/PrivateRoomService.ts` and are documented here for
+ * consistency with the rest of the public event surface.
+ *
+ * Socket events:
+ *   • server → host:  `room-created`    → `RoomCreatedEvent`
+ *   • server → host:  `room-recovered`  → `RoomRecoveredEvent`
+ *   • server → host:  `room-cancelled`  → `{ code: string }`
+ *   • server → host:  `room-expired`    → `{ code: string }`
+ *   • server → peer:  `room-error`      → `RoomErrorEvent`
+ *   • client → server: `room-create`    → `{ playerId, username?, gameType? }`
+ *   • client → server: `room-join`      → `{ playerId, username?, code }`
+ *   • client → server: `room-cancel`    → `{}`
+ *   • client → server: `room-recover`   → `{ playerId, username? }`
+ */
+
+/** Event sent to the host when a room is created. */
+export interface RoomCreatedEvent {
+  code: string;
+}
+
+/**
+ * Event sent to the host when they successfully reclaim a room
+ * via `room-recover` after a transient socket disconnect.
+ */
+export interface RoomRecoveredEvent {
+  code: string;
+}
+
+/** Event sent when a private-room operation fails. */
+export interface RoomErrorEvent {
+  message: string;
+}
+
+/**
  * State hash event from client (2.1.3)
  */
 export interface StateHashEvent {

--- a/phalanx-server/src/types/index.ts
+++ b/phalanx-server/src/types/index.ts
@@ -362,7 +362,13 @@ export interface QueueStatusEvent {
  *   • client → server: `room-create`    → `{ playerId, username?, gameType? }`
  *   • client → server: `room-join`      → `{ playerId, username?, code }`
  *   • client → server: `room-cancel`    → `{}`
- *   • client → server: `room-recover`   → `{ playerId, username? }`
+ *   • client → server: `room-recover`   → `{ playerId, username?, code? }`
+ *
+ * The `code` on `room-recover` is strongly recommended: it proves the
+ * caller is actually the host who created the room. Without it any
+ * client that knew a host's `playerId` could reclaim the room.
+ * It is optional on the wire for backward compatibility; the server
+ * logs a warning when a client omits it.
  */
 
 /** Event sent to the host when a room is created. */

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -435,6 +435,110 @@ describe('PrivateRoomService', () => {
     expect(hostMatch.opponents.map((o) => o.playerId)).toContain('guest1');
   });
 
+  it('should reject pending-match recover when the attacker presents a wrong code', async () => {
+    // Security guard for the pending-host-reconnect fallback path:
+    // after a guest has consumed the room (joinRoom) while the host
+    // was offline, recovery has to go through pendingHostReconnect
+    // instead of this.rooms. That fallback must *also* require a
+    // matching code — otherwise an attacker who knew only the host's
+    // playerId could claim the pending match and get match-found /
+    // reconnect-state for a game they were never part of.
+    const host = createClient();
+    await connectClient(host);
+
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'victim', username: 'Victim' });
+    const created = await createdPromise;
+
+    // Victim drops; guest joins while offline — match is created and
+    // goes into pendingHostReconnect keyed by 'victim' + the real code.
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const guest = createClient();
+    await connectClient(guest);
+    const guestMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    await guestMatchPromise;
+
+    // Attacker knows the victim's playerId but not the real room code.
+    const attacker = createClient();
+    await connectClient(attacker);
+    const errorPromise = new Promise<RoomErrorEvent>((resolve) => {
+      attacker.on('room-error', (data: RoomErrorEvent) => resolve(data));
+    });
+    const unexpectedMatchPromise = new Promise<unknown>((resolve) => {
+      attacker.on('match-found', (data) => resolve(data));
+      attacker.on('reconnect-state', (data) => resolve(data));
+      attacker.on('room-recovered', (data) => resolve(data));
+      setTimeout(() => resolve(null), 400);
+    });
+    attacker.emit('room-recover', {
+      playerId: 'victim',
+      username: 'Attacker',
+      code: 'WRONGCD',
+    });
+
+    const error = await errorPromise;
+    expect(error.message).toBe('Room expired');
+    expect(await unexpectedMatchPromise).toBeNull();
+
+    // And the legitimate victim can still come back with the real code
+    // — i.e. the bad attempt didn't consume or poison the pending entry.
+    const victim2 = createClient();
+    await connectClient(victim2);
+    const victimMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      victim2.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    victim2.emit('room-recover', {
+      playerId: 'victim',
+      username: 'Victim',
+      code: created.code,
+    });
+    const victimMatch = await victimMatchPromise;
+    expect(victimMatch.matchId).toBeDefined();
+  });
+
+  it('should not crash when room-recover payload is null or not an object', async () => {
+    // Regression guard for the handler's top-level shape check. Without
+    // it, `typeof data.code` on `null` / a primitive would throw
+    // synchronously inside the socket handler and could tear the
+    // connection down.
+    const client = createClient();
+    await connectClient(client);
+
+    const collected: RoomErrorEvent[] = [];
+    client.on('room-error', (data: RoomErrorEvent) => collected.push(data));
+
+    // null, undefined, a string, and a number all count as "not a
+    // well-formed payload" and must be rejected with 'Room expired'.
+    // Using `emit(event, arg)` for each — Socket.IO serialises the
+    // arg and the server hook receives it verbatim.
+    client.emit('room-recover', null);
+    client.emit('room-recover', undefined);
+    client.emit('room-recover', 'not-an-object');
+    client.emit('room-recover', 42);
+    client.emit('room-recover'); // no payload at all
+
+    // Give the server a moment to process all five messages.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    // We expect at least one 'Room expired' error, and, crucially,
+    // the socket must still be connected — if the handler had thrown,
+    // the connection would have dropped.
+    expect(collected.length).toBeGreaterThan(0);
+    expect(collected.every((e) => e.message === 'Room expired')).toBe(true);
+    expect(client.connected).toBe(true);
+  });
+
   it('should emit room-error with "Room expired" when room-recover omits the code', async () => {
     // Security guard: the Phalanx room-recover handler rejects a payload
     // that has no `code`, so a client can't use playerId-only recovery

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -363,6 +363,78 @@ describe('PrivateRoomService', () => {
     expect(hostMatch.matchId).toBe(guestMatch.matchId);
   });
 
+  it('should deliver match-found to a host who recovers after the guest joined during disconnect', async () => {
+    // The trickiest UX path: host creates a room, host's mobile browser
+    // kills the socket, guest follows the invite link while the host is
+    // still offline (so the match is created but the host socket is
+    // null), and then the host finally reconnects. Prior to this fix,
+    // the host never learned the matchId and had no way to reconnect.
+    // After: the service remembers the pending match keyed by host
+    // playerId and retroactively delivers match-found on room-recover.
+    const host = createClient();
+    await connectClient(host);
+
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    const created = await createdPromise;
+
+    // Host drops.
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Guest joins while host is still offline — match is created.
+    const guest = createClient();
+    await connectClient(guest);
+    const guestMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    const guestMatch = await guestMatchPromise;
+    expect(guestMatch.matchId).toBeDefined();
+
+    // Host finally reconnects on a new socket and recovers — should get
+    // match-found with the same matchId the guest saw.
+    const host2 = createClient();
+    await connectClient(host2);
+    const hostRecoveredPromise = new Promise<RoomRecoveredEvent>((resolve) => {
+      host2.on('room-recovered', (data: RoomRecoveredEvent) => resolve(data));
+    });
+    const hostMatchPromise = new Promise<{
+      matchId: string;
+      teamId: number;
+      opponents: { playerId: string }[];
+    }>((resolve) => {
+      host2.on(
+        'match-found',
+        (data: {
+          matchId: string;
+          teamId: number;
+          opponents: { playerId: string }[];
+        }) => resolve(data),
+      );
+    });
+    host2.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Host',
+      code: created.code,
+    });
+
+    const [hostRecovered, hostMatch] = await Promise.all([
+      hostRecoveredPromise,
+      hostMatchPromise,
+    ]);
+    expect(hostRecovered.code).toBe(created.code);
+    expect(hostMatch.matchId).toBe(guestMatch.matchId);
+    expect(hostMatch.teamId).toBe(0); // host is team 0
+    expect(hostMatch.opponents.map((o) => o.playerId)).toContain('guest1');
+  });
+
   it('should emit room-error with "Room expired" when room-recover omits the code', async () => {
     // Security guard: the Phalanx room-recover handler rejects a payload
     // that has no `code`, so a client can't use playerId-only recovery

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -262,9 +262,48 @@ describe('PrivateRoomService', () => {
     expect(error.message).toBe('Already in a match');
   });
 
-  // ── Host disconnect cleans up room ────────────────────────────
+  // ── Host disconnect — grace period ────────────────────────────
+  //
+  // Regression coverage for the mobile-share-link UX bug: when a host
+  // on a mobile browser switches to a messenger to share the invite
+  // link, the OS tears down the WebSocket. Previously this destroyed
+  // the room immediately and the guest got 'Room not found' when they
+  // followed the link. Now the room survives a grace period so the
+  // host can either reconnect (room-recover) or the guest can still
+  // join during the gap.
 
-  it('should clean up room when host disconnects', async () => {
+  it('should NOT destroy a room immediately when host disconnects', async () => {
+    const host = createClient();
+    const guest = createClient();
+    await connectClient(host);
+    await connectClient(guest);
+
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    const created = await createdPromise;
+
+    // Host disconnects (e.g. mobile browser killed the WebSocket)
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Guest follows the invite link during the disconnect window —
+    // the room must still be there and the match must start.
+    const guestMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+
+    const guestMatch = await guestMatchPromise;
+    expect(guestMatch.matchId).toBeDefined();
+  });
+
+  it('should recover a room when the host reconnects via room-recover', async () => {
     const host = createClient();
     await connectClient(host);
 
@@ -274,20 +313,251 @@ describe('PrivateRoomService', () => {
     host.emit('room-create', { playerId: 'host1', username: 'Host' });
     const created = await createdPromise;
 
-    // Host disconnects
+    // Host socket dies
     host.disconnect();
     await new Promise((resolve) => setTimeout(resolve, 100));
 
-    // Guest tries to join — should fail
+    // Host reconnects with a brand-new socket and recovers the room
+    const host2 = createClient();
+    await connectClient(host2);
+
+    const recoveredPromise = new Promise<RoomRecoveredEvent>((resolve) => {
+      host2.on('room-recovered', (data: RoomRecoveredEvent) => resolve(data));
+    });
+    host2.emit('room-recover', { playerId: 'host1', username: 'Host' });
+
+    const recovered = await recoveredPromise;
+    expect(recovered.code).toBe(created.code);
+
+    // Room is intact — a guest can still join by code
     const guest = createClient();
     await connectClient(guest);
+    const matchPromise = new Promise<{ matchId: string }>((resolve) => {
+      guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    const match = await matchPromise;
+    expect(match.matchId).toBeDefined();
+  });
+
+  it('should emit room-error with "Room expired" when recovering a non-existent room', async () => {
+    const host = createClient();
+    await connectClient(host);
 
     const errorPromise = new Promise<RoomErrorEvent>((resolve) => {
-      guest.on('room-error', (data: RoomErrorEvent) => resolve(data));
+      host.on('room-error', (data: RoomErrorEvent) => resolve(data));
     });
-    guest.emit('room-join', { playerId: 'guest1', username: 'Guest', code: created.code });
+    host.emit('room-recover', { playerId: 'ghost', username: 'Ghost' });
 
     const error = await errorPromise;
-    expect(error.message).toBe('Room not found');
+    expect(error.message).toBe('Room expired');
+  });
+
+  it('should allow the host to cancel a room after reconnecting with a new socket', async () => {
+    const host = createClient();
+    await connectClient(host);
+
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    const created = await createdPromise;
+
+    // Original host socket drops
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // New host socket — cancel must still work because cancelRoom
+    // looks up by playerId, not socketId.
+    const host2 = createClient();
+    await connectClient(host2);
+
+    const cancelledPromise = new Promise<{ code: string }>((resolve) => {
+      host2.on('room-cancelled', (data: { code: string }) => resolve(data));
+    });
+    // The Phalanx room-cancel handler keys off the `playerId` captured
+    // from a prior message on this socket, so we first associate the
+    // new socket with the host's playerId via room-recover, then cancel.
+    host2.emit('room-recover', { playerId: 'host1', username: 'Host' });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    host2.emit('room-cancel');
+
+    const cancelled = await cancelledPromise;
+    expect(cancelled.code).toBe(created.code);
+  });
+
+  // ── Grace-period expiry (unit, fake timers) ─────────────────────
+  //
+  // This one is a pure-unit test against PrivateRoomService directly so
+  // we can use vi.useFakeTimers() without interfering with socket.io's
+  // own heartbeat timers. Covers the row "Host never returns (2 min pass)"
+  // from the expected-behaviour table.
+
+  it('should destroy the room after the grace period if the host never returns (unit)', async () => {
+    const { PrivateRoomService } = await import(
+      '../src/services/PrivateRoomService.js'
+    );
+    const { validateConfig } = await import('../src/config/validation.js');
+
+    const config = validateConfig({
+      port: TEST_PORT,
+      matchmakingIntervalMs: 100,
+      gameMode: '1v1',
+      countdownSeconds: 0,
+      tickRate: 20,
+      cors: { origin: '*' },
+    });
+
+    // Minimal mocks for the dependencies we don't exercise here.
+    const fakeIo = {} as unknown as import('socket.io').Server;
+    const emitted: Array<{ event: string; payload: unknown }> = [];
+    const hostSocket = {
+      id: 'sock-host-1',
+      data: {},
+      emit: (event: string, payload: unknown) => {
+        emitted.push({ event, payload });
+        return true;
+      },
+    } as unknown as import('socket.io').Socket;
+    const guestSocket = {
+      id: 'sock-guest-1',
+      data: {},
+      emit: (event: string, payload: unknown) => {
+        emitted.push({ event, payload });
+        return true;
+      },
+    } as unknown as import('socket.io').Socket;
+
+    vi.useFakeTimers();
+    try {
+      const service = new PrivateRoomService(
+        fakeIo,
+        config,
+        () => undefined,
+        () => config,
+      );
+
+      service.createRoom('host1', 'Host', hostSocket);
+      const createdEvent = emitted.find((e) => e.event === 'room-created');
+      expect(createdEvent).toBeDefined();
+      const code = (createdEvent!.payload as { code: string }).code;
+
+      // Host socket dies.
+      service.handleDisconnect(hostSocket.id);
+
+      // Fast-forward past the 2-minute grace window.
+      vi.advanceTimersByTime(2 * 60 * 1000 + 1);
+
+      // Room is gone — a guest joining by code now gets 'Room not found'.
+      emitted.length = 0;
+      service.joinRoom('guest1', 'Guest', guestSocket, code);
+
+      const error = emitted.find((e) => e.event === 'room-error');
+      expect(error).toBeDefined();
+      expect((error!.payload as { message: string }).message).toBe(
+        'Room not found',
+      );
+
+      service.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should clear the grace-period timer on room-recover (unit)', async () => {
+    // Covers the row "Host reconnects within 2 min" — verifies the
+    // pending destruction timer really is cancelled so the room isn't
+    // destroyed out from under the recovered host.
+    const { PrivateRoomService } = await import(
+      '../src/services/PrivateRoomService.js'
+    );
+    const { validateConfig } = await import('../src/config/validation.js');
+
+    const config = validateConfig({
+      port: TEST_PORT,
+      matchmakingIntervalMs: 100,
+      gameMode: '1v1',
+      countdownSeconds: 0,
+      tickRate: 20,
+      cors: { origin: '*' },
+    });
+
+    const fakeIo = {} as unknown as import('socket.io').Server;
+    const emitted: Array<{
+      socket: string;
+      event: string;
+      payload: unknown;
+    }> = [];
+    const makeSocket = (id: string) =>
+      ({
+        id,
+        data: {},
+        emit: (event: string, payload: unknown) => {
+          emitted.push({ socket: id, event, payload });
+          return true;
+        },
+      }) as unknown as import('socket.io').Socket;
+
+    const hostSocket1 = makeSocket('sock-host-1');
+    const hostSocket2 = makeSocket('sock-host-2');
+    const guestSocket = makeSocket('sock-guest-1');
+
+    vi.useFakeTimers();
+    try {
+      const service = new PrivateRoomService(
+        fakeIo,
+        config,
+        () => undefined,
+        () => config,
+      );
+
+      service.createRoom('host1', 'Host', hostSocket1);
+      const code = (
+        emitted.find((e) => e.event === 'room-created')!.payload as {
+          code: string;
+        }
+      ).code;
+
+      service.handleDisconnect(hostSocket1.id);
+
+      // Host reconnects on a new socket halfway through the grace window.
+      vi.advanceTimersByTime(60 * 1000);
+      service.recoverRoom('host1', hostSocket2);
+
+      const recovered = emitted.find((e) => e.event === 'room-recovered');
+      expect(recovered).toBeDefined();
+      expect(recovered!.socket).toBe('sock-host-2');
+      expect((recovered!.payload as { code: string }).code).toBe(code);
+
+      // Advance past the original grace deadline — the room must still
+      // be there because the grace timer was cleared on recover.
+      vi.advanceTimersByTime(2 * 60 * 1000);
+
+      // Recovering again should succeed (room still alive). If the
+      // original grace timer hadn't been cleared on the first recover,
+      // the room would now be gone and this would emit 'Room expired'.
+      emitted.length = 0;
+      service.recoverRoom('host1', hostSocket2);
+      const secondRecover = emitted.find((e) => e.event === 'room-recovered');
+      const expired = emitted.find(
+        (e) =>
+          e.event === 'room-error' &&
+          (e.payload as { message: string }).message === 'Room expired',
+      );
+      expect(secondRecover).toBeDefined();
+      expect(expired).toBeUndefined();
+
+      // guestSocket is referenced but not used after mock-io simplification;
+      // keep it allocated so the test structure stays self-documenting.
+      void guestSocket;
+
+      service.stop();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -363,6 +363,29 @@ describe('PrivateRoomService', () => {
     expect(hostMatch.matchId).toBe(guestMatch.matchId);
   });
 
+  it('should emit room-error with "Room expired" when room-recover omits the code', async () => {
+    // Security guard: the Phalanx room-recover handler rejects a payload
+    // that has no `code`, so a client can't use playerId-only recovery
+    // to fish for valid room codes.
+    const host = createClient();
+    await connectClient(host);
+
+    const errorPromise = new Promise<RoomErrorEvent>((resolve) => {
+      host.on('room-error', (data: RoomErrorEvent) => resolve(data));
+    });
+    const unexpectedRecoverPromise = new Promise<RoomRecoveredEvent | null>(
+      (resolve) => {
+        host.on('room-recovered', (data: RoomRecoveredEvent) => resolve(data));
+        setTimeout(() => resolve(null), 300);
+      },
+    );
+    host.emit('room-recover', { playerId: 'host1', username: 'Host' });
+
+    const error = await errorPromise;
+    expect(error.message).toBe('Room expired');
+    expect(await unexpectedRecoverPromise).toBeNull();
+  });
+
   it('should emit room-error with "Room expired" when recovering a non-existent room', async () => {
     const host = createClient();
     await connectClient(host);
@@ -448,13 +471,19 @@ describe('PrivateRoomService', () => {
     });
     // The Phalanx room-cancel handler keys off the `playerId` captured
     // from a prior message on this socket, so we first associate the
-    // new socket with the host's playerId via room-recover, then cancel.
+    // new socket with the host's playerId via room-recover, wait for
+    // the server-side ack, and only then cancel. Relying on a fixed
+    // sleep here is racy under load — waiting for `room-recovered`
+    // is the deterministic signal that the handler has run.
+    const recoveredPromise = new Promise<RoomRecoveredEvent>((resolve) => {
+      host2.on('room-recovered', (data: RoomRecoveredEvent) => resolve(data));
+    });
     host2.emit('room-recover', {
       playerId: 'host1',
       username: 'Host',
       code: created.code,
     });
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await recoveredPromise;
     host2.emit('room-cancel');
 
     const cancelled = await cancelledPromise;

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -1,7 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { io, Socket } from 'socket.io-client';
 import { Phalanx } from '../src/Phalanx.js';
-import type { RoomCreatedEvent, RoomErrorEvent } from '../src/services/PrivateRoomService.js';
+import type {
+  RoomCreatedEvent,
+  RoomRecoveredEvent,
+  RoomErrorEvent,
+} from '../src/services/PrivateRoomService.js';
 
 /**
  * Tests for PrivateRoomService — room creation, joining, cancellation,
@@ -303,7 +307,7 @@ describe('PrivateRoomService', () => {
     expect(guestMatch.matchId).toBeDefined();
   });
 
-  it('should recover a room when the host reconnects via room-recover', async () => {
+  it('should recover a room when the host reconnects via room-recover, and rebind to the new socket', async () => {
     const host = createClient();
     await connectClient(host);
 
@@ -324,24 +328,39 @@ describe('PrivateRoomService', () => {
     const recoveredPromise = new Promise<RoomRecoveredEvent>((resolve) => {
       host2.on('room-recovered', (data: RoomRecoveredEvent) => resolve(data));
     });
-    host2.emit('room-recover', { playerId: 'host1', username: 'Host' });
+    host2.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Host',
+      code: created.code,
+    });
 
     const recovered = await recoveredPromise;
     expect(recovered.code).toBe(created.code);
 
-    // Room is intact — a guest can still join by code
+    // A guest can still join by code AND both the recovered host and
+    // the guest must receive match-found. The host assertion is the
+    // important regression guard: if recoverRoom didn't also update
+    // `room.host.socketId`, GameRoom would try to emit to the dead
+    // original socket and host2 would get nothing.
     const guest = createClient();
     await connectClient(guest);
-    const matchPromise = new Promise<{ matchId: string }>((resolve) => {
+    const guestMatchPromise = new Promise<{ matchId: string }>((resolve) => {
       guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    const hostMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      host2.on('match-found', (data: { matchId: string }) => resolve(data));
     });
     guest.emit('room-join', {
       playerId: 'guest1',
       username: 'Guest',
       code: created.code,
     });
-    const match = await matchPromise;
-    expect(match.matchId).toBeDefined();
+    const [guestMatch, hostMatch] = await Promise.all([
+      guestMatchPromise,
+      hostMatchPromise,
+    ]);
+    expect(guestMatch.matchId).toBeDefined();
+    expect(hostMatch.matchId).toBe(guestMatch.matchId);
   });
 
   it('should emit room-error with "Room expired" when recovering a non-existent room', async () => {
@@ -351,10 +370,58 @@ describe('PrivateRoomService', () => {
     const errorPromise = new Promise<RoomErrorEvent>((resolve) => {
       host.on('room-error', (data: RoomErrorEvent) => resolve(data));
     });
-    host.emit('room-recover', { playerId: 'ghost', username: 'Ghost' });
+    host.emit('room-recover', {
+      playerId: 'ghost',
+      username: 'Ghost',
+      code: 'ZZZZZZ',
+    });
 
     const error = await errorPromise;
     expect(error.message).toBe('Room expired');
+  });
+
+  it('should reject room-recover when the code does not match the host\u2019s room', async () => {
+    // Security guard: a client that only knows another host's playerId
+    // (but not the room code) must not be able to reclaim the room and
+    // learn its invite code.
+    const host = createClient();
+    await connectClient(host);
+
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    await createdPromise;
+
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // An attacker connects and tries to steal the room with the correct
+    // playerId but a wrong code.
+    const attacker = createClient();
+    await connectClient(attacker);
+    const errorPromise = new Promise<RoomErrorEvent>((resolve) => {
+      attacker.on('room-error', (data: RoomErrorEvent) => resolve(data));
+    });
+    const unexpectedRecoverPromise = new Promise<RoomRecoveredEvent | null>(
+      (resolve) => {
+        attacker.on('room-recovered', (data: RoomRecoveredEvent) =>
+          resolve(data),
+        );
+        // Give the server plenty of room to misbehave before we conclude
+        // no recover event came back.
+        setTimeout(() => resolve(null), 300);
+      },
+    );
+    attacker.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Attacker',
+      code: 'WRONGCD',
+    });
+
+    const error = await errorPromise;
+    expect(error.message).toBe('Room expired');
+    expect(await unexpectedRecoverPromise).toBeNull();
   });
 
   it('should allow the host to cancel a room after reconnecting with a new socket', async () => {
@@ -382,7 +449,11 @@ describe('PrivateRoomService', () => {
     // The Phalanx room-cancel handler keys off the `playerId` captured
     // from a prior message on this socket, so we first associate the
     // new socket with the host's playerId via room-recover, then cancel.
-    host2.emit('room-recover', { playerId: 'host1', username: 'Host' });
+    host2.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Host',
+      code: created.code,
+    });
     await new Promise((resolve) => setTimeout(resolve, 50));
     host2.emit('room-cancel');
 
@@ -526,7 +597,7 @@ describe('PrivateRoomService', () => {
 
       // Host reconnects on a new socket halfway through the grace window.
       vi.advanceTimersByTime(60 * 1000);
-      service.recoverRoom('host1', hostSocket2);
+      service.recoverRoom('host1', hostSocket2, code);
 
       const recovered = emitted.find((e) => e.event === 'room-recovered');
       expect(recovered).toBeDefined();
@@ -541,7 +612,7 @@ describe('PrivateRoomService', () => {
       // original grace timer hadn't been cleared on the first recover,
       // the room would now be gone and this would emit 'Room expired'.
       emitted.length = 0;
-      service.recoverRoom('host1', hostSocket2);
+      service.recoverRoom('host1', hostSocket2, code);
       const secondRecover = emitted.find((e) => e.event === 'room-recovered');
       const expired = emitted.find(
         (e) =>
@@ -554,6 +625,87 @@ describe('PrivateRoomService', () => {
       // guestSocket is referenced but not used after mock-io simplification;
       // keep it allocated so the test structure stays self-documenting.
       void guestSocket;
+
+      service.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should emit room-expired on the recovered host socket, not the original (unit)', async () => {
+    // Regression guard: the TTL callback used to fire `socket.emit(...)`
+    // on the socket captured at createRoom() time. After the host rebound
+    // via room-recover that socket is dead, so the real host would never
+    // see the expiry. The fix looks the room back up at expiry time and
+    // emits on its *current* hostSocket.
+    const { PrivateRoomService } = await import(
+      '../src/services/PrivateRoomService.js'
+    );
+    const { validateConfig } = await import('../src/config/validation.js');
+
+    const config = validateConfig({
+      port: TEST_PORT,
+      matchmakingIntervalMs: 100,
+      gameMode: '1v1',
+      countdownSeconds: 0,
+      tickRate: 20,
+      cors: { origin: '*' },
+    });
+
+    const fakeIo = {} as unknown as import('socket.io').Server;
+    const emitted: Array<{
+      socket: string;
+      event: string;
+      payload: unknown;
+    }> = [];
+    const makeSocket = (id: string) =>
+      ({
+        id,
+        data: {},
+        emit: (event: string, payload: unknown) => {
+          emitted.push({ socket: id, event, payload });
+          return true;
+        },
+      }) as unknown as import('socket.io').Socket;
+
+    const hostSocket1 = makeSocket('sock-host-1');
+    const hostSocket2 = makeSocket('sock-host-2');
+
+    vi.useFakeTimers();
+    try {
+      const service = new PrivateRoomService(
+        fakeIo,
+        config,
+        () => undefined,
+        () => config,
+      );
+
+      service.createRoom('host1', 'Host', hostSocket1);
+      const code = (
+        emitted.find((e) => e.event === 'room-created')!.payload as {
+          code: string;
+        }
+      ).code;
+
+      // Host drops and immediately reconnects on a fresh socket.
+      service.handleDisconnect(hostSocket1.id);
+      service.recoverRoom('host1', hostSocket2, code);
+
+      // Clear out the setup events so the next assertion is unambiguous.
+      emitted.length = 0;
+
+      // Fast-forward past the 5-minute TTL. The room-expired event must
+      // arrive on sock-host-2 (current), never on sock-host-1 (original).
+      vi.advanceTimersByTime(5 * 60 * 1000 + 1);
+
+      const expired = emitted.filter((e) => e.event === 'room-expired');
+      expect(expired).toHaveLength(1);
+      expect(expired[0].socket).toBe('sock-host-2');
+
+      const expiredOnOriginal = emitted.find(
+        (e) => e.event === 'room-expired' && e.socket === 'sock-host-1',
+      );
+      expect(expiredOnOriginal).toBeUndefined();
 
       service.stop();
     } finally {

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -447,6 +447,69 @@ describe('PrivateRoomService', () => {
     expect(await unexpectedRecoverPromise).toBeNull();
   });
 
+  it('should not mutate per-socket identity state on a failed room-recover', async () => {
+    // Regression guard for the case where an attacker (or a confused
+    // client) sends a bogus room-recover: the handler must NOT capture
+    // the payload's playerId on the connection, because a follow-up
+    // room-cancel on the same socket would then act on a playerId the
+    // socket was never authenticated to own.
+    const host = createClient();
+    await connectClient(host);
+
+    // A victim host creates a real room.
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'victim', username: 'Victim' });
+    const created = await createdPromise;
+
+    // Attacker connects on a fresh socket and fires a bad recover.
+    const attacker = createClient();
+    await connectClient(attacker);
+
+    const attackerErrorPromise = new Promise<RoomErrorEvent>((resolve) => {
+      attacker.on('room-error', (data: RoomErrorEvent) => resolve(data));
+    });
+    attacker.emit('room-recover', {
+      playerId: 'victim',
+      username: 'Attacker',
+      code: 'WRONGCD',
+    });
+    const attackerError = await attackerErrorPromise;
+    expect(attackerError.message).toBe('Room expired');
+
+    // Now the attacker tries to cancel the victim's room. Because the
+    // failed recover must not have captured `victim` as this socket's
+    // playerId, cancel is a no-op and the room stays alive.
+    attacker.emit('room-cancel');
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    // The room is still there: the host can join it from a guest.
+    const guest = createClient();
+    await connectClient(guest);
+    const guestMatchPromise = new Promise<{ matchId: string }>((resolve) => {
+      guest.on('match-found', (data: { matchId: string }) => resolve(data));
+    });
+    const guestErrorPromise = new Promise<RoomErrorEvent | null>((resolve) => {
+      guest.on('room-error', (data: RoomErrorEvent) => resolve(data));
+      setTimeout(() => resolve(null), 500);
+    });
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    const guestMatch = await Promise.race([
+      guestMatchPromise,
+      guestErrorPromise.then((e) => {
+        if (e) throw new Error(`unexpected room-error: ${e.message}`);
+        return null;
+      }),
+    ]);
+    expect(guestMatch).not.toBeNull();
+    expect((guestMatch as { matchId: string }).matchId).toBeDefined();
+  });
+
   it('should allow the host to cancel a room after reconnecting with a new socket', async () => {
     const host = createClient();
     await connectClient(host);


### PR DESCRIPTION
## Problem

When a host creates a private room on mobile and switches to another app (messenger) to share the invite link, the browser kills the WebSocket connection. This triggers `handleDisconnect` in `PrivateRoomService`, which immediately destroyed the room. The guest then followed the link and got `room-error: "Room not found"` — a critical UX bug for the primary sharing flow.

## Fix

Host-socket disconnect no longer destroys the room immediately. Instead it starts a 2-minute grace timer. During the window:

- The host can reclaim the room with a new `room-recover` event → `room-recovered` back with the code.
- A guest who follows the invite link can still join — the match starts normally (host reconnects via the standard `reconnect-match` flow once they return to the app).
- If the host never comes back, the room is destroyed after 2 minutes.

The room is torn down at whichever fires first: the new 2-min grace timer or the original 5-min `ROOM_TTL_MS`.

## Expected behaviour

| Event | Before | After |
|---|---|---|
| Host disconnects | Room destroyed immediately | Room survives for 2 minutes |
| Host reconnects within 2 min | — | `room-recovered` event, room intact |
| Host never returns (2 min pass) | — | Room destroyed, logged |
| Host never returns, TTL fires first | Room lived up to 5 min | Destroyed at `min(2 min since disconnect, original TTL)` |
| Guest joins during host disconnect | Room already gone | Room found, match starts normally |

## Changes

### `phalanx-server/src/services/PrivateRoomService.ts`
- `PrivateRoom`: `hostSocket` is now mutable and nullable, new tracked `hostSocketId` (so lookups work after the `Socket` object itself goes away), new `hostDisconnectTimer: ReturnType<typeof setTimeout> | null`.
- New constant `HOST_DISCONNECT_GRACE_MS = 2 * 60 * 1000`.
- New `recoverRoom(playerId, socket)` method — clears the pending timer, rebinds the new socket, emits `room-recovered`; emits `room-error: "Room expired"` if no matching room exists.
- `handleDisconnect` now starts the grace timer instead of calling `removeRoom` directly; it still forwards the disconnect to any active matches.
- `removeRoom` and `stop` also clear `hostDisconnectTimer`.
- `cancelRoom` already keyed off `playerId` (not `socketId`), which is the correct behaviour now that a reconnected host may have a new socket — clarified with a JSDoc note.

### `phalanx-server/src/Phalanx.ts`
- New `room-recover` socket handler alongside `room-create` / `room-join` / `room-cancel`.

### `phalanx-server/src/types/index.ts` + `src/index.ts`
- Exported public types: `RoomCreatedEvent`, `RoomRecoveredEvent`, `RoomErrorEvent`, with a JSDoc block documenting the full private-room wire contract. Re-exported from `PrivateRoomService.ts` for backward compatibility with existing imports.

## Tests

Added 5 new cases in `tests/private-room.test.ts`:

1. **`should NOT destroy a room immediately when host disconnects`** — host drops, guest joins during the disconnect window, match starts normally. This is the exact regression scenario from the bug report.
2. **`should recover a room when the host reconnects via room-recover`** — host reconnects on a new socket, receives `room-recovered` with the original code, a guest can still join afterwards.
3. **`should emit room-error with "Room expired" when recovering a non-existent room`** — recover called with no matching room emits the expected error.
4. **`should allow the host to cancel a room after reconnecting with a new socket`** — verifies `cancelRoom` keys off `playerId`, not `socketId`.
5. **Fake-timer unit tests** covering the 2-min grace expiry and timer cancellation on recover (two cases, against `PrivateRoomService` directly so `vi.useFakeTimers()` doesn't interfere with socket.io's heartbeat).

Updated the existing `should clean up room when host disconnects` test to match the new semantics.

### Test run

```
✓ tests/private-room.test.ts  (14 tests) 1813ms
 Test Files  1 passed (1)
      Tests  14 passed (14)
```

Full suite is green except for the pre-existing `tls.test.ts` `DEPTH_ZERO_SELF_SIGNED_CERT` failure, which is unrelated to this change and reproduces on `main`.

## Notes

- `ROOM_TTL_MS` (5 min) is unchanged. The disconnect grace is independent.
- `hostSocket` may be `null` while a guest joins during the host's disconnect window. `joinRoom` doesn't touch `hostSocket` directly — `GameRoom` receives both players via the team arrays and the host reconnects via the standard `reconnect-match` flow once the app returns to the foreground.
- No changes needed in `chapaev/server/src/main.ts`; this is purely a library-level fix.
