### PR TITLE
fix(private-room): snapshot countdown/game-start in reconnect-state

### DIFF
--- a/phalanx-client/src/SocketManager.ts
+++ b/phalanx-client/src/SocketManager.ts
@@ -553,6 +553,49 @@ export class SocketManager {
       this.callbacks.onMatchEnd(data);
     });
 
+    // Reconnect-state — unlike `reconnectToMatch` which attaches a
+    // one-shot listener for the explicit reconnect flow, this global
+    // handler catches snapshots delivered out-of-band, e.g. by the
+    // private-room host-recover path where the client initiates
+    // `room-recover` and the server proactively emits reconnect-state
+    // to wire the socket back into a match that started while the host
+    // was offline.
+    //
+    // When the snapshot reports an in-flight countdown or an already
+    // emitted `game-start`, we fan it out through the same `countdown`
+    // / `game-start` callbacks the normal lifecycle uses, so client
+    // code that blocks on `waitForCountdown` / `waitForGameStart`
+    // wakes up instead of hanging forever waiting for events that
+    // were broadcast while the socket was dead.
+    this.socket.on('reconnect-state', (data: ReconnectStateEvent) => {
+      this.callbacks.onReconnectState(data);
+      // Fan the snapshot out through the same socket event bus that
+      // `setupEventHandlers` and `waitForCountdown`/`waitForGameStart`
+      // listen on. Using `socket.emit` against the local socket would
+      // send to the server, not the local listeners — socket.io-client
+      // has no public "emit-to-self", so we replay through every
+      // registered listener instead. This wakes callers blocked in
+      // `waitForCountdown` / `waitForGameStart` on top of firing the
+      // normal callback hooks.
+      if (
+        typeof data.countdownSecondsRemaining === 'number' &&
+        data.countdownSecondsRemaining >= 0
+      ) {
+        this.emitSyntheticLocal('countdown', {
+          seconds: data.countdownSecondsRemaining,
+        } satisfies CountdownEvent);
+      }
+      if (data.gameStartEmitted === true) {
+        const gameStart: GameStartEvent = {
+          matchId: data.matchId,
+          ...(typeof data.randomSeed === 'number'
+            ? { randomSeed: data.randomSeed }
+            : {}),
+        };
+        this.emitSyntheticLocal('game-start', gameStart);
+      }
+    });
+
     // Hash comparison (for desync detection)
     this.socket.on('hash-comparison', (data: HashComparisonEvent) => {
       this.callbacks.onHashComparison(data);
@@ -602,6 +645,42 @@ export class SocketManager {
   private ensureConnected(): void {
     if (!this.socket || !this.isConnected()) {
       throw new Error('Not connected to server. Call connect() first.');
+    }
+  }
+
+  /**
+   * Replay `payload` through every listener currently registered for
+   * `event` on the local socket.
+   *
+   * socket.io-client's `socket.emit` sends to the server, so there is
+   * no public API to dispatch a server→client event against the
+   * client's own handlers. For the private-room recover path we need
+   * exactly that: the server already decided that, e.g., countdown
+   * should show "3", and we want every listener the application has
+   * wired up — including one-shot promises inside `waitForCountdown`
+   * / `waitForGameStart` — to observe the value as if the server had
+   * broadcast it on the wire.
+   *
+   * Iterating a snapshot of `socket.listeners(event)` (rather than
+   * the live list) is deliberate: a listener may call `socket.off`
+   * on itself during handling (e.g. `waitForCountdown`'s handler
+   * unsubscribes on `seconds === 0`), which would mutate the array
+   * under us and skip siblings.
+   */
+  private emitSyntheticLocal(event: string, payload: unknown): void {
+    if (!this.socket) return;
+    const listeners = this.socket.listeners(event).slice();
+    for (const listener of listeners) {
+      try {
+        (listener as (data: unknown) => void)(payload);
+      } catch (err) {
+        if (this.config.debug) {
+          console.error(
+            `[SocketManager] synthetic "${event}" listener threw:`,
+            err,
+          );
+        }
+      }
     }
   }
 

--- a/phalanx-client/src/SocketManager.ts
+++ b/phalanx-client/src/SocketManager.ts
@@ -451,7 +451,11 @@ export class SocketManager {
 
       const stateHandler = (state: ReconnectStateEvent) => {
         this.socket?.off('reconnect-status', statusHandler);
-        this.callbacks.onReconnectState(state);
+        // Do NOT invoke `callbacks.onReconnectState` here — the global
+        // `reconnect-state` handler registered in `setupEventHandlers`
+        // already fires for this same message. Calling it twice would
+        // drive downstream state updates (and any synthetic countdown /
+        // game-start replays) through the client twice per server event.
         resolve(state);
       };
 
@@ -585,7 +589,18 @@ export class SocketManager {
           seconds: data.countdownSecondsRemaining,
         } satisfies CountdownEvent);
       }
-      if (data.gameStartEmitted === true) {
+      // Only synthesize `game-start` when the snapshot shows the client
+      // is still in a pre-play phase. For an in-progress match (state
+      // `playing` / `paused` / `finished`) the caller is doing a normal
+      // mid-match reconnect, and PhalanxClient's `onGameStart` callback
+      // would reset `currentTick` to 0 — clobbering the authoritative
+      // tick that `onReconnectState` just applied. In that case the
+      // client is already past the game-start transition, so there's
+      // nothing to replay.
+      if (
+        data.gameStartEmitted === true &&
+        (data.state === 'countdown' || data.state === 'waiting-for-ready')
+      ) {
         const gameStart: GameStartEvent = {
           matchId: data.matchId,
           ...(typeof data.randomSeed === 'number'

--- a/phalanx-client/src/types.ts
+++ b/phalanx-client/src/types.ts
@@ -235,13 +235,43 @@ export interface PlayerReadyEvent {
 }
 
 /**
- * State received when reconnecting to a match
+ * State received when reconnecting to a match.
+ *
+ * Includes a snapshot of the countdown / game-start phase so a client
+ * that reconnected mid-countdown (e.g. a private-room host whose mobile
+ * browser killed the WebSocket while they were sharing the invite link)
+ * can render the correct remaining number without waiting for the next
+ * 1Hz broadcast tick, and so a client that reconnected after `game-start`
+ * already fired can synthesize the event locally and enter the playing
+ * phase without waiting for an event it will never receive again.
+ *
+ * The countdown/gameStart fields are optional for wire-compatibility
+ * with older servers that don't populate them.
  */
 export interface ReconnectStateEvent {
   matchId: string;
   currentTick: number;
   state: 'countdown' | 'waiting-for-ready' | 'playing' | 'paused' | 'finished';
   recentCommands: TickCommandsHistory[];
+  /**
+   * Integer number of seconds left on the countdown at the moment this
+   * snapshot was taken, or `null` if the countdown is no longer running
+   * (either it never started with a positive duration, or `game-start`
+   * has already been emitted).
+   */
+  countdownSecondsRemaining?: number | null;
+  /**
+   * True if `game-start` has already been broadcast for this match.
+   * Clients should treat this as a signal to synthesize a local
+   * `game-start` event rather than waiting for the server to emit one.
+   */
+  gameStartEmitted?: boolean;
+  /**
+   * The match's deterministic RNG seed. Forwarded here so clients that
+   * missed the original `game-start` broadcast can still feed the seed
+   * into their deterministic simulation on the synthesized start.
+   */
+  randomSeed?: number;
 }
 
 /**

--- a/phalanx-server/src/services/GameRoom.ts
+++ b/phalanx-server/src/services/GameRoom.ts
@@ -46,6 +46,23 @@ export class GameRoom {
   private tickInterval: NodeJS.Timeout | null = null;
   private countdownTimer: NodeJS.Timeout | null = null;
   private countdownInterval: NodeJS.Timeout | null = null;
+  /**
+   * Absolute epoch-ms deadline for the countdown, set when the countdown
+   * starts and cleared when `game-start` is emitted. Used to compute the
+   * remaining seconds for a late-joining socket (e.g. a private-room host
+   * whose mobile browser killed the WebSocket while they were sharing the
+   * invite link) so the client can render the correct number instead of
+   * staying stuck on the last value it saw before disconnecting.
+   */
+  private countdownDeadline: number | null = null;
+  /**
+   * Set to true once `game-start` has been broadcast. A host who recovers
+   * after this point needs to synthesize the event locally — we signal
+   * that via this flag in the `reconnect-state` payload so the client can
+   * transition out of the countdown UI without waiting for a second
+   * `game-start` it will never receive.
+   */
+  private gameStartEmitted: boolean = false;
   private pendingCommands: Map<number, PlayerCommand[]> = new Map();
 
   // Ready handshake: tracks which players have reported ready after asset loading
@@ -183,7 +200,10 @@ export class GameRoom {
    */
   private startGameCountdown(): void {
     if (this.config.countdownSeconds <= 0) {
-      // Skip countdown entirely — go straight to waiting-for-ready
+      // Skip countdown entirely — go straight to waiting-for-ready.
+      // No deadline to record: the countdown phase is effectively zero
+      // length, so a reconnecting client should observe `gameStartEmitted`.
+      this.gameStartEmitted = true;
       this.io.to(this.roomId).emit('game-start', {
         matchId: this.id,
         randomSeed: this.randomSeed,
@@ -193,6 +213,10 @@ export class GameRoom {
     }
 
     let countdown = this.config.countdownSeconds;
+    // Record the absolute wall-clock deadline so a reconnecting socket
+    // can compute its own remaining-seconds value without having to wait
+    // for the next tick of the 1Hz broadcast.
+    this.countdownDeadline = Date.now() + countdown * 1000;
 
     // Emit initial countdown
     this.io.to(this.roomId).emit('countdown', { seconds: countdown });
@@ -207,6 +231,12 @@ export class GameRoom {
           clearInterval(this.countdownInterval);
           this.countdownInterval = null;
         }
+        // The countdown phase is over — clear the deadline and mark the
+        // game-start as emitted so a late recover falls into the
+        // synthesize-locally path rather than waiting for an event that
+        // will never fire again.
+        this.countdownDeadline = null;
+        this.gameStartEmitted = true;
         // Emit game-start event with random seed for deterministic RNG
         this.io.to(this.roomId).emit('game-start', {
           matchId: this.id,
@@ -987,17 +1017,36 @@ export class GameRoom {
       socketData.matchId = this.id;
       socketData.playerId = playerId;
 
-      // Send reconnect-state with command history (NET-2)
+      // Send reconnect-state with command history (NET-2).
+      //
+      // Also carries a countdown / game-start snapshot so a client who
+      // reconnects mid-countdown can render the correct remaining seconds
+      // instead of freezing on the last value it saw, and a client who
+      // reconnects after `game-start` can synthesize the event locally
+      // (it will never be re-broadcast).
       const fromTick = Math.max(
         0,
         this.currentTick - this.config.commandHistoryTicks
       );
+      // Use Math.ceil so a deadline 2.1s away is reported as 3, matching
+      // the integer value the periodic `countdown` broadcast would have
+      // emitted at the most recent whole second.
+      const countdownSecondsRemaining =
+        this.countdownDeadline !== null
+          ? Math.max(
+              0,
+              Math.ceil((this.countdownDeadline - Date.now()) / 1000),
+            )
+          : null;
       socket.emit('reconnect-state', {
         matchId: this.id,
         currentTick: this.currentTick,
         state: this.state,
         players: Array.from(this.players.values()),
         recentCommands: this.getRecentCommandHistory(fromTick),
+        countdownSecondsRemaining,
+        gameStartEmitted: this.gameStartEmitted,
+        randomSeed: this.randomSeed,
       });
 
       // Notify other players

--- a/phalanx-server/src/services/PrivateRoomService.ts
+++ b/phalanx-server/src/services/PrivateRoomService.ts
@@ -329,16 +329,22 @@ export class PrivateRoomService {
         const match = this.matches.get(pending.matchId);
         if (match) {
           this.pendingHostReconnect.delete(playerId);
-          // `handleReconnect` wires the socket into the running match
-          // and emits `reconnect-state` with the full match snapshot.
-          // We also emit `match-found` so the client sees the same
-          // event it would have seen had its socket been alive at
-          // `joinRoom` time — keeps the client state machine simple.
-          match.handleReconnect(playerId, socket.id);
+          // Emit `match-found` first so the client's state machine
+          // transitions "lobby → match-found" before it receives the
+          // reconnect snapshot — mirrors the order it would have seen
+          // if its socket had been alive at `joinRoom` time. Also
+          // keeps any client-side assertion that `match-found`
+          // precedes `reconnect-state` satisfied.
           const matchFound = match.buildMatchFoundPayload(playerId);
           if (matchFound) {
             socket.emit('match-found', matchFound);
           }
+          // `handleReconnect` then wires the socket into the running
+          // match and emits `reconnect-state` carrying the countdown
+          // snapshot, so a client that reconnected mid-countdown
+          // renders the correct remaining number and a client that
+          // reconnected after `game-start` synthesizes the event.
+          match.handleReconnect(playerId, socket.id);
           // Emit the *stored* room code, not the caller-provided one,
           // so a client that somehow drifted on casing still sees the
           // canonical value.

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -1067,15 +1067,27 @@ describe('PrivateRoomService — host countdown recovery (snapshot)', () => {
     // Guest joins while host is offline. Countdown starts immediately.
     const guest = createClient();
     await connectClient(guest);
+
+    // Wait for an actual guest-side countdown tick with seconds < 5
+    // before continuing. Using a real event instead of a wall-clock
+    // sleep avoids flakiness on slow CI schedulers where a fixed delay
+    // could overshoot the full countdown and cause the host snapshot
+    // to flip to gameStartEmitted=true / countdownSecondsRemaining=null.
+    const countdownTickPromise = new Promise<void>((resolve) => {
+      const onCountdown = (payload: { seconds: number }) => {
+        if (typeof payload?.seconds === 'number' && payload.seconds < 5) {
+          guest.off('countdown', onCountdown);
+          resolve();
+        }
+      };
+      guest.on('countdown', onCountdown);
+    });
     guest.emit('room-join', {
       playerId: 'guest1',
       username: 'Guest',
       code: created.code,
     });
-    // Wait ~1.2s so the countdown has ticked at least once on the guest
-    // side. This guarantees the remaining-seconds value on the host's
-    // snapshot is strictly less than the configured 5.
-    await new Promise((resolve) => setTimeout(resolve, 1200));
+    await countdownTickPromise;
 
     // Host reconnects.
     const host2 = createClient();

--- a/phalanx-server/tests/private-room.test.ts
+++ b/phalanx-server/tests/private-room.test.ts
@@ -981,3 +981,179 @@ describe('PrivateRoomService', () => {
     }
   });
 });
+
+/**
+ * Regression suite for the "host countdown freezes on 3" bug:
+ *
+ * 1. Player 1 creates a private room.
+ * 2. Their mobile browser suspends the WebSocket while they switch to a
+ *    messenger to share the invite link.
+ * 3. Player 2 joins — match is created, countdown starts on the guest.
+ * 4. Player 1 returns and issues room-recover.
+ *
+ * Prior to the snapshot fields on `reconnect-state`, the host had no
+ * way to catch up on countdown ticks they missed while offline: the
+ * 1Hz `countdown` broadcast was fire-and-forget, and `game-start`
+ * (once fired) was never re-broadcast, leaving the host's UI stuck
+ * on the last number they saw and never transitioning into the game.
+ *
+ * These tests exercise the server side of that fix. The client side
+ * is covered separately by `phalanx-client/tests/private-room.test.ts`.
+ *
+ * A fresh `describe` block is used (rather than parameterising the
+ * main suite) because the main suite runs with `countdownSeconds: 0`
+ * — which skips the countdown phase entirely — and these tests must
+ * observe the countdown while it is still in flight.
+ */
+describe('PrivateRoomService — host countdown recovery (snapshot)', () => {
+  let server: Phalanx;
+  let clients: Socket[] = [];
+  const TEST_PORT = 3400;
+
+  beforeEach(async () => {
+    server = new Phalanx({
+      port: TEST_PORT,
+      matchmakingIntervalMs: 100,
+      gameMode: '1v1',
+      // Intentionally long: we want to observe the countdown mid-flight
+      // without racing the 1Hz broadcast's own completion.
+      countdownSeconds: 5,
+      tickRate: 20,
+      cors: { origin: '*' },
+    });
+    await server.start();
+    clients = [];
+  });
+
+  afterEach(async () => {
+    for (const client of clients) {
+      if (client.connected) client.disconnect();
+    }
+    clients = [];
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    await server.stop();
+  });
+
+  function createClient(): Socket {
+    const client = io(`http://localhost:${TEST_PORT}`, {
+      autoConnect: false,
+      forceNew: true,
+    });
+    clients.push(client);
+    return client;
+  }
+
+  async function connectClient(client: Socket): Promise<void> {
+    return new Promise((resolve) => {
+      client.on('connect', () => resolve());
+      client.connect();
+    });
+  }
+
+  it('delivers a countdown snapshot via reconnect-state when the host recovers mid-countdown', async () => {
+    const host = createClient();
+    await connectClient(host);
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    const created = await createdPromise;
+
+    // Host's socket dies before the guest joins — the room survives
+    // because of the grace-period timer.
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Guest joins while host is offline. Countdown starts immediately.
+    const guest = createClient();
+    await connectClient(guest);
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    // Wait ~1.2s so the countdown has ticked at least once on the guest
+    // side. This guarantees the remaining-seconds value on the host's
+    // snapshot is strictly less than the configured 5.
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+
+    // Host reconnects.
+    const host2 = createClient();
+    await connectClient(host2);
+    const reconnectStatePromise = new Promise<{
+      matchId: string;
+      state: string;
+      countdownSecondsRemaining: number | null;
+      gameStartEmitted: boolean;
+      randomSeed: number;
+    }>((resolve) => {
+      host2.on('reconnect-state', resolve);
+    });
+    host2.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Host',
+      code: created.code,
+    });
+
+    const snapshot = await reconnectStatePromise;
+    expect(snapshot.matchId).toBeDefined();
+    // Countdown is still in flight: positive remaining-seconds and
+    // game-start has not been emitted yet.
+    expect(snapshot.gameStartEmitted).toBe(false);
+    expect(snapshot.countdownSecondsRemaining).not.toBeNull();
+    expect(snapshot.countdownSecondsRemaining).toBeGreaterThan(0);
+    expect(snapshot.countdownSecondsRemaining).toBeLessThan(5);
+    expect(typeof snapshot.randomSeed).toBe('number');
+  });
+
+  it('marks the snapshot as gameStartEmitted when the host recovers after game-start', async () => {
+    const host = createClient();
+    await connectClient(host);
+    const createdPromise = new Promise<RoomCreatedEvent>((resolve) => {
+      host.on('room-created', (data: RoomCreatedEvent) => resolve(data));
+    });
+    host.emit('room-create', { playerId: 'host1', username: 'Host' });
+    const created = await createdPromise;
+
+    host.disconnect();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    const guest = createClient();
+    await connectClient(guest);
+    // Capture game-start on the guest so we know when the countdown
+    // phase is actually over, instead of relying on wall-clock sleep.
+    const guestGameStartPromise = new Promise<{ randomSeed?: number }>(
+      (resolve) => {
+        guest.on('game-start', resolve);
+      },
+    );
+    guest.emit('room-join', {
+      playerId: 'guest1',
+      username: 'Guest',
+      code: created.code,
+    });
+    const guestStart = await guestGameStartPromise;
+
+    // Now recover — snapshot should say the game has already started.
+    const host2 = createClient();
+    await connectClient(host2);
+    const reconnectStatePromise = new Promise<{
+      gameStartEmitted: boolean;
+      countdownSecondsRemaining: number | null;
+      randomSeed: number;
+    }>((resolve) => {
+      host2.on('reconnect-state', resolve);
+    });
+    host2.emit('room-recover', {
+      playerId: 'host1',
+      username: 'Host',
+      code: created.code,
+    });
+    const snapshot = await reconnectStatePromise;
+    expect(snapshot.gameStartEmitted).toBe(true);
+    expect(snapshot.countdownSecondsRemaining).toBeNull();
+    // Seed forwarded here must match the one the guest saw so a
+    // deterministic client can still initialise its RNG on recover.
+    expect(snapshot.randomSeed).toBe(guestStart.randomSeed);
+  });
+});


### PR DESCRIPTION
## Bug

```
1. \u0418\u0433\u0440\u043e\u043a 1 \u0441\u043e\u0437\u0434\u0430\u0451\u0442 \u043a\u043e\u043c\u043d\u0430\u0442\u0443 \u0438 \u043a\u043e\u043f\u0438\u0440\u0443\u0435\u0442 \u0441\u0441\u044b\u043b\u043a\u0443 \u0432 \u0431\u0443\u0444\u0435\u0440 \u043e\u0431\u043c\u0435\u043d\u0430 \u043d\u0430 \u0442\u0435\u043b\u0435\u0444\u043e\u043d\u0435
2. \u0421\u0432\u043e\u0440\u0430\u0447\u0438\u0432\u0430\u0435\u0442 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u0438 \u0438\u0434\u0451\u0442 \u0432 \u043c\u0435\u0441\u0441\u0435\u043d\u0434\u0436\u0435\u0440
3. \u041e\u0442\u043f\u0440\u0430\u0432\u043b\u044f\u0435\u0442 \u0441\u0441\u044b\u043b\u043a\u0443 \u0442\u0443\u0434\u0430
4. \u0412\u043e\u0437\u0432\u0440\u0430\u0449\u0430\u0435\u0442\u0441\u044f \u0432 \u0431\u0440\u0430\u0443\u0437\u0435\u0440 \u043d\u0430 \u0442\u0443 \u0436\u0435 \u0441\u0442\u0440\u0430\u043d\u0438\u0446\u0443
5. \u0418\u0433\u0440\u043e\u043a 2 \u043f\u0435\u0440\u0435\u0445\u043e\u0434\u0438\u0442 \u043f\u043e \u0441\u0441\u044b\u043b\u043a\u0435
6. \u0412\u044b\u0431\u0438\u0440\u0430\u0435\u0442 \u0438\u0433\u0440\u0430\u0442\u044c \u043a\u0430\u043a \u0433\u043e\u0441\u0442\u044c
7. \u041f\u043e\u0448\u0451\u043b \u043e\u0442\u0441\u0447\u0451\u0442
8. \u0423 \u0438\u0433\u0440\u043e\u043a\u0430 2 \u043e\u0442\u0441\u0447\u0451\u0442 \u0438\u0434\u0451\u0442 \u043d\u043e\u0440\u043c\u0430\u043b\u044c\u043d\u043e, \u0443 \u0438\u0433\u0440\u043e\u043a\u0430 1 \u0437\u0430\u043c\u0438\u0440\u0430\u0435\u0442 \u043d\u0430 3  \u2014 \u041f\u0420\u041e\u0411\u041b\u0415\u041c\u0410
9. \u0418\u0433\u0440\u043e\u043a 2 \u0437\u0430\u0445\u043e\u0434\u0438\u0442 \u0432 \u0438\u0433\u0440\u0443, \u0438\u0433\u0440\u043e\u043a 1 \u0432\u044b\u043d\u0443\u0436\u0434\u0435\u043d \u043f\u0435\u0440\u0435\u0437\u0430\u0433\u0440\u0443\u0436\u0430\u0442\u044c \u0438 \u0431\u043e\u043b\u044c\u0448\u0435 \u043d\u0435 \u043f\u043e\u043f\u0430\u0434\u0430\u0435\u0442 \u0432 \u043a\u043e\u043c\u043d\u0430\u0442\u0443
```

## Root cause

The 1Hz `countdown` broadcast and the one-shot `game-start` event are both fire-and-forget over the socket.io room group. A host whose socket was null at `joinRoom` time \u2014 or who joined the room only after some ticks already fired \u2014 had no way to catch up: `reconnect-state` carried no phase information, so the client UI stayed on the last number it saw, and if the real `game-start` fired while offline, the client waited forever for a second one.

## Fix

### Server

- `GameRoom` tracks `countdownDeadline` (epoch-ms) and `gameStartEmitted` alongside its existing state machine.
- `reconnect-state` payload gains three snapshot fields:
  - `countdownSecondsRemaining: number | null` \u2014 integer seconds left (ceil\u2019d), or null if no countdown in flight.
  - `gameStartEmitted: boolean` \u2014 whether `game-start` was already broadcast.
  - `randomSeed: number` \u2014 so a host who missed `game-start` can still init deterministic RNG.
- `PrivateRoomService.recoverRoom` now emits `match-found` **before** `handleReconnect`, matching the order a live-socket host would have seen.

### Client

- `ReconnectStateEvent` type gains the three snapshot fields (optional for wire-compat with older servers).
- `SocketManager` attaches a global `reconnect-state` handler that **replays** the snapshot through every listener registered for `countdown` / `game-start`, waking callers blocked in `waitForCountdown` / `waitForGameStart` instead of hanging forever.

## Tests

+2 server regression tests:

- `delivers a countdown snapshot via reconnect-state when the host recovers mid-countdown` \u2014 asserts `0 < countdownSecondsRemaining < 5` and `gameStartEmitted === false`.
- `marks the snapshot as gameStartEmitted when the host recovers after game-start` \u2014 asserts `gameStartEmitted === true`, `countdownSecondsRemaining === null`, and `randomSeed` matches the seed the guest saw.

All 139 non-TLS server tests and 62 client tests pass (the pre-existing `tls.test.ts` self-signed-cert failure on Node 20 is unrelated to this change).