### PR TITLE
fix(private-room): wire up client-side host room-recover

### DIFF
--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -33,7 +33,7 @@ import { PauseOverlay } from '../ui/screens/PauseOverlay.ts';
 import { PrivateMatchScreen } from '../ui/screens/PrivateMatch.ts';
 import { SettingsScreen } from '../ui/screens/SettingsScreen.ts';
 import { RulesScreen } from '../ui/screens/RulesScreen.ts';
-import type { CountdownEvent, GamePausedEvent, GameResumedEvent } from 'phalanx-client';
+import type { CountdownEvent, GamePausedEvent, GameResumedEvent, MatchFoundEvent, GameStartEvent } from 'phalanx-client';
 
 export type GameMode = 'hotseat' | 'online';
 
@@ -58,6 +58,31 @@ export class Game {
   private localTeam: TeamTag = TeamTag.White;
   private isGuestMode = false;
   private pendingRoomCode: string | null = null;
+
+  /**
+   * The private-room code for a room this client currently *hosts* and is
+   * still in the "waiting for opponent / countdown" phase for. Set in
+   * `handleCreateRoom` and cleared once the match either starts, is
+   * cancelled, or bails out to the main menu.
+   *
+   * Used by the `visibilitychange` recovery handler to reclaim the room
+   * from the server after the browser killed the WebSocket while the
+   * user was in another app (messenger etc.). If null, there's nothing
+   * to recover.
+   */
+  private activePrivateRoomCode: string | null = null;
+
+  /** Handle for the `visibilitychange` listener (or null when unarmed). */
+  private visibilityRecoverHandler: (() => void) | null = null;
+
+  /**
+   * Guard that prevents two recover attempts from racing. Mobile browsers
+   * can fire `visibilitychange` multiple times in quick succession when
+   * the tab comes back (each of pageshow, focus, visibilitychange may
+   * arrive), and we don't want every one of them to kick off a parallel
+   * `connect()` + `recoverRoom()`.
+   */
+  private isRecovering: boolean = false;
 
   // UI
   private uiManager: UIManager;
@@ -444,6 +469,13 @@ export class Game {
 
       const roomEvent = await this.networkManager.createRoom();
       const roomCode = roomEvent.code;
+      this.activePrivateRoomCode = roomCode;
+
+      // Arm the visibility-recover handler as soon as the room exists on
+      // the server — the earliest point at which a mobile user might
+      // swipe away to a messenger to share the invite link and have
+      // the OS kill our WebSocket.
+      this.armVisibilityRecover();
 
       // Show room code in the waiting screen
       this.uiManager.hideScreen('matchmaking');
@@ -452,8 +484,17 @@ export class Game {
 
       console.log(`[Game] Private room created: ${roomCode}`);
 
-      // Now wait for match-found (another player joins the room)
-      const matchData = await this.networkManager.client.waitForMatch();
+      // Listen via the client event emitter rather than per-socket
+      // `waitFor*` helpers. The host's socket may get torn down and
+      // re-created mid-flow (mobile browser suspending the WebSocket
+      // while the user is in a messenger), in which case the recover
+      // path on the server re-emits `match-found`, `countdown`, and
+      // `game-start` on the fresh socket. PhalanxClient forwards those
+      // through its emitter regardless of which underlying socket
+      // delivered them, so a listener registered here survives the
+      // reconnect cycle. A `waitForMatch()` bound to the original
+      // socket would not.
+      const matchData = await this.waitForClientEvent<MatchFoundEvent>('matchFound');
       this.privateMatchScreen.stopWaitingTimer();
       this.matchmakingScreen.stopTimer();
 
@@ -462,15 +503,24 @@ export class Game {
       this.uiManager.destroyScreen('countdown');
       this.uiManager.showScreen('countdown');
 
-      await this.networkManager.client.waitForCountdown((event: CountdownEvent) => {
+      // Subscribe to countdown events and wait for game-start. Both are
+      // delivered through the client emitter so synthetic replays from
+      // `reconnect-state` (see PR #19) are observed here too.
+      const unsubCountdown = this.networkManager.client.on('countdown', (event: CountdownEvent) => {
         this.matchmakingScreen.updateCountdown(event.seconds);
       });
-
-      const gameStartEvent = await this.networkManager.client.waitForGameStart();
-      console.log('[Game] Private match game start, randomSeed:', gameStartEvent.randomSeed);
+      try {
+        const gameStartEvent = await this.waitForClientEvent<GameStartEvent>('gameStart');
+        console.log('[Game] Private match game start, randomSeed:', gameStartEvent.randomSeed);
+      } finally {
+        unsubCountdown();
+      }
 
       this.networkManager.setMatchData(matchData);
       this.cleanupConnectEventListeners();
+      // Match is starting — nothing left to recover.
+      this.disarmVisibilityRecover();
+      this.activePrivateRoomCode = null;
 
       this.uiManager.hideScreen('countdown');
       this.startOnlineGame(matchData);
@@ -478,7 +528,107 @@ export class Game {
       console.error('[Game] Private room creation failed:', error instanceof Error ? error.message : JSON.stringify(error), error);
       this.matchmakingScreen.setStatus('Ошибка подключения');
       this.matchmakingScreen.stopTimer();
+      this.disarmVisibilityRecover();
+      this.activePrivateRoomCode = null;
       this.returnToMainMenu();
+    }
+  }
+
+  /**
+   * Resolve with the first payload emitted by the PhalanxClient under
+   * `eventName`. Unlike `client.waitForMatch()` / `waitForGameStart()`,
+   * this reads off the client's own emitter — which is socket-agnostic —
+   * so it keeps working across a recover-driven socket swap. The handle
+   * returned by `client.on` is used to unsubscribe exactly once the
+   * expected event arrives.
+   */
+  private waitForClientEvent<T>(eventName: 'matchFound' | 'gameStart'): Promise<T> {
+    return new Promise((resolve) => {
+      if (!this.networkManager) return;
+      const unsubscribe = this.networkManager.client.on(
+        eventName as 'matchFound',
+        // The emitter is typed per-event via an overload map; cast the
+        // payload back to the caller-requested generic. Both `matchFound`
+        // and `gameStart` are the only two event names this helper accepts.
+        (data: unknown) => {
+          unsubscribe();
+          resolve(data as T);
+        },
+      );
+    });
+  }
+
+  /**
+   * Start listening for visibility changes so we can reclaim a private
+   * room the browser may have silently disconnected from.
+   *
+   * Called from `handleCreateRoom` once the room exists server-side.
+   * Idempotent — a second call is a no-op; `disarmVisibilityRecover`
+   * clears state so it can be re-armed for a subsequent room.
+   *
+   * The listener does *nothing* if:
+   *   - `activePrivateRoomCode` is null (no room to recover)
+   *   - the document is still hidden
+   *   - the socket is still connected (nothing died, no recovery needed)
+   *   - a recovery is already in flight (race guard)
+   *
+   * On a genuine "tab is back and socket is dead" transition, it
+   * reconnects the socket and emits `room-recover`. The server's
+   * response (`match-found` + `reconnect-state` + `room-recovered`)
+   * is observed by `handleCreateRoom`'s pending `waitForClientEvent`
+   * promises so the flow picks up where it left off.
+   */
+  private armVisibilityRecover(): void {
+    if (this.visibilityRecoverHandler) return;
+    if (typeof document === 'undefined') return;
+
+    const handler = (): void => {
+      if (document.visibilityState !== 'visible') return;
+      void this.tryRecoverActiveRoom();
+    };
+
+    document.addEventListener('visibilitychange', handler);
+    // Some mobile browsers (notably iOS Safari) are more reliable
+    // about firing `pageshow` than `visibilitychange` when returning
+    // from bfcache, so listen to both.
+    window.addEventListener('pageshow', handler);
+    this.visibilityRecoverHandler = handler;
+  }
+
+  private disarmVisibilityRecover(): void {
+    if (!this.visibilityRecoverHandler) return;
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.visibilityRecoverHandler);
+      window.removeEventListener('pageshow', this.visibilityRecoverHandler);
+    }
+    this.visibilityRecoverHandler = null;
+  }
+
+  private async tryRecoverActiveRoom(): Promise<void> {
+    if (!this.networkManager) return;
+    const code = this.activePrivateRoomCode;
+    if (!code) return;
+    if (this.isRecovering) return;
+    if (this.networkManager.client.isConnected()) return;
+
+    this.isRecovering = true;
+    try {
+      console.log(`[Game] Attempting to recover private room ${code} after tab return`);
+      await this.networkManager.client.connect();
+      await this.networkManager.client.recoverRoom(code);
+      console.log(`[Game] Room ${code} recovered successfully`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[Game] Room recover failed: ${message}`);
+      // The server's grace period has likely elapsed — the room is gone.
+      // Surface a clear state rather than leaving the user staring at a
+      // frozen countdown screen.
+      this.disarmVisibilityRecover();
+      this.activePrivateRoomCode = null;
+      this.matchmakingScreen.setStatus('Соединение потеряно');
+      this.returnToMainMenu();
+    } finally {
+      this.isRecovering = false;
     }
   }
 
@@ -561,6 +711,11 @@ export class Game {
     this.networkManager?.cancelRoom();
     this.privateMatchScreen.stopWaitingTimer();
     this.matchmakingScreen.stopTimer();
+    // User explicitly cancelled — stop trying to silently recover the
+    // room in the background, and drop the stored code so a later tab
+    // return is a no-op.
+    this.disarmVisibilityRecover();
+    this.activePrivateRoomCode = null;
     this.cleanupConnectEventListeners();
     this.unsubscribeAuth();
     this.networkManager?.dispose();

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -494,36 +494,48 @@ export class Game {
       // delivered them, so a listener registered here survives the
       // reconnect cycle. A `waitForMatch()` bound to the original
       // socket would not.
-      const matchData = await this.waitForClientEvent<MatchFoundEvent>('matchFound');
-      this.privateMatchScreen.stopWaitingTimer();
-      this.matchmakingScreen.stopTimer();
-
-      // Show countdown screen
-      this.uiManager.hideScreen('private-match');
-      this.uiManager.destroyScreen('countdown');
-      this.uiManager.showScreen('countdown');
-
-      // Subscribe to countdown events and wait for game-start. Both are
-      // delivered through the client emitter so synthetic replays from
-      // `reconnect-state` (see PR #19) are observed here too.
+      //
+      // IMPORTANT: all three listeners (`matchFound`, `countdown`,
+      // `gameStart`) must be registered *before* we `await` anything.
+      // The recover-into-pending-match server path emits in this
+      // order: `match-found` → `reconnect-state` (which synchronously
+      // fans out a synthetic `countdown`/`game-start` through
+      // SocketManager) → `room-recovered`. If we only subscribed to
+      // `countdown`/`gameStart` *after* awaiting `matchFound`, those
+      // synthetic events would pass by an empty listener list and the
+      // flow would hang on the countdown screen forever (especially
+      // when the host recovers after `game-start` has already fired).
+      const matchFoundPromise = this.waitForClientEvent<MatchFoundEvent>('matchFound');
+      const gameStartPromise = this.waitForClientEvent<GameStartEvent>('gameStart');
       const unsubCountdown = this.networkManager.client.on('countdown', (event: CountdownEvent) => {
         this.matchmakingScreen.updateCountdown(event.seconds);
       });
+
       try {
-        const gameStartEvent = await this.waitForClientEvent<GameStartEvent>('gameStart');
+        const matchData = await matchFoundPromise;
+        this.privateMatchScreen.stopWaitingTimer();
+        this.matchmakingScreen.stopTimer();
+
+        // Show countdown screen
+        this.uiManager.hideScreen('private-match');
+        this.uiManager.destroyScreen('countdown');
+        this.uiManager.showScreen('countdown');
+
+        const gameStartEvent = await gameStartPromise;
         console.log('[Game] Private match game start, randomSeed:', gameStartEvent.randomSeed);
+
+        this.networkManager.setMatchData(matchData);
+        this.cleanupConnectEventListeners();
+        // Match is starting — nothing left to recover.
+        this.disarmVisibilityRecover();
+        this.activePrivateRoomCode = null;
+
+        this.uiManager.hideScreen('countdown');
+        this.startOnlineGame(matchData);
       } finally {
         unsubCountdown();
       }
 
-      this.networkManager.setMatchData(matchData);
-      this.cleanupConnectEventListeners();
-      // Match is starting — nothing left to recover.
-      this.disarmVisibilityRecover();
-      this.activePrivateRoomCode = null;
-
-      this.uiManager.hideScreen('countdown');
-      this.startOnlineGame(matchData);
     } catch (error) {
       console.error('[Game] Private room creation failed:', error instanceof Error ? error.message : JSON.stringify(error), error);
       this.matchmakingScreen.setStatus('Ошибка подключения');
@@ -541,11 +553,22 @@ export class Game {
    * so it keeps working across a recover-driven socket swap. The handle
    * returned by `client.on` is used to unsubscribe exactly once the
    * expected event arrives.
+   *
+   * Rejects synchronously if `networkManager` is missing at call time.
+   * Without this guard the returned Promise would never settle and
+   * every caller that `await`s it would hang indefinitely — painful to
+   * debug because there is no stack trace attached to an unresolved
+   * Promise.
    */
   private waitForClientEvent<T>(eventName: 'matchFound' | 'gameStart'): Promise<T> {
+    const networkManager = this.networkManager;
+    if (!networkManager) {
+      return Promise.reject(
+        new Error(`waitForClientEvent(${eventName}): no active networkManager`),
+      );
+    }
     return new Promise((resolve) => {
-      if (!this.networkManager) return;
-      const unsubscribe = this.networkManager.client.on(
+      const unsubscribe = networkManager.client.on(
         eventName as 'matchFound',
         // The emitter is typed per-event via an overload map; cast the
         // payload back to the caller-requested generic. Both `matchFound`

--- a/phalanx-client/src/PhalanxClient.ts
+++ b/phalanx-client/src/PhalanxClient.ts
@@ -28,6 +28,7 @@ import type {
   Unsubscribe,
   PauseHandler,
   RoomCreatedEvent,
+  RoomRecoveredEvent,
 } from './types.js';
 
 /**
@@ -223,6 +224,7 @@ export class PhalanxClient extends EventEmitter<PhalanxClientEvents> {
           this.clientState = 'idle';
           this.emit('roomCancelled', data);
         },
+        onRoomRecovered: (data) => this.emit('roomRecovered', data),
       }
     );
 
@@ -526,6 +528,39 @@ export class PhalanxClient extends EventEmitter<PhalanxClientEvents> {
    */
   cancelRoom(): void {
     this.socketManager.cancelRoom();
+  }
+
+  /**
+   * Reclaim a private room after a transient socket disconnect.
+   *
+   * Call this after `connect()` has re-established the underlying socket
+   * (typically inside a `visibilitychange` listener, or the first thing
+   * on `pageshow` from bfcache) to tell the server to re-bind the still-
+   * living room / in-flight match to this new socket.
+   *
+   * On success the server emits `match-found` (if a guest had already
+   * joined) followed by `reconnect-state` carrying a countdown snapshot,
+   * which `SocketManager`'s global `reconnect-state` handler fans out
+   * through the local `countdown` and `game-start` listeners so any
+   * `waitForCountdown` / `waitForGameStart` promises pending since the
+   * original flow resume naturally.
+   *
+   * Rejects with the server's `room-error` message (e.g. `'Room expired'`)
+   * or `'Recover timeout'` if the server doesn't answer within 10 s.
+   */
+  async recoverRoom(code: string): Promise<RoomRecoveredEvent> {
+    this.ensureConnected();
+    const event = await this.socketManager.recoverRoom(code);
+    // Host is back in the "waiting for opponent / countdown" flow —
+    // mirror the state createRoom would have left us in so downstream
+    // isPlaying() checks stay consistent. The server may also have just
+    // emitted match-found / reconnect-state (pending-recover path), which
+    // will have already advanced `clientState` past 'in-queue' on its
+    // own — so only bump it if we're still in a pre-match phase.
+    if (this.clientState === 'idle') {
+      this.clientState = 'in-queue';
+    }
+    return event;
   }
 
   // ============================================

--- a/phalanx-client/src/SocketManager.ts
+++ b/phalanx-client/src/SocketManager.ts
@@ -20,6 +20,7 @@ import type {
   RoomErrorEvent,
   RoomExpiredEvent,
   RoomCancelledEvent,
+  RoomRecoveredEvent,
   PlayerDisconnectedEvent,
   PlayerReconnectedEvent,
   PlayerReadyEvent,
@@ -100,6 +101,7 @@ export interface SocketManagerCallbacks {
   onRoomError: (data: RoomErrorEvent) => void;
   onRoomExpired: (data: RoomExpiredEvent) => void;
   onRoomCancelled: (data: RoomCancelledEvent) => void;
+  onRoomRecovered: (data: RoomRecoveredEvent) => void;
 
   // State queries (for reconnection logic)
   isPlaying: () => boolean;
@@ -301,6 +303,86 @@ export class SocketManager {
   cancelRoom(): void {
     this.ensureConnected();
     this.socket!.emit('room-cancel');
+  }
+
+  /**
+   * Reclaim a private room after the underlying socket was briefly torn
+   * down and reconnected.
+   *
+   * This is the client half of the host-disconnect grace-period contract
+   * introduced server-side in PR #18 and extended with countdown/game-start
+   * snapshotting in PR #19: the server holds the room (and, if the guest
+   * already joined, the running match) open for `HOST_DISCONNECT_GRACE_MS`
+   * so the host's new socket can reclaim it via `room-recover`.
+   *
+   * Typical trigger: a mobile browser kills the WebSocket when the user
+   * switches to a messenger to share the invite link, then re-opens the
+   * tab. The caller (Game / UI layer) should listen for `visibilitychange`
+   * and, when the tab becomes visible again and the socket is dead, call
+   * `connect()` followed by `recoverRoom(code)`.
+   *
+   * Resolves with the `RoomRecoveredEvent` on success. Rejects with the
+   * server's error message on `room-error`, or with `'Recover timeout'`
+   * if the server never answers within `timeoutMs` (default 10 s). The
+   * timeout is important because a stubbornly flaky connection can cause
+   * `socket.emit` to succeed locally but never round-trip — we must not
+   * leave the host hanging on a dead promise while their countdown UI
+   * stays frozen.
+   */
+  async recoverRoom(
+    code: string,
+    timeoutMs: number = 10_000,
+  ): Promise<RoomRecoveredEvent> {
+    this.ensureConnected();
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+
+      const cleanup = (): void => {
+        this.socket?.off('room-recovered', recoveredHandler);
+        this.socket?.off('room-error', errorHandler);
+        clearTimeout(timer);
+      };
+
+      const recoveredHandler = (event: RoomRecoveredEvent): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        resolve(event);
+      };
+
+      const errorHandler = (error: RoomErrorEvent): void => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error(error.message));
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error('Recover timeout'));
+      }, timeoutMs);
+
+      this.socket!.once('room-recovered', recoveredHandler);
+      this.socket!.once('room-error', errorHandler);
+
+      this.socket!.emit('room-recover', {
+        playerId: this.config.playerId,
+        username: this.config.username,
+        code,
+      });
+    });
+  }
+
+  /**
+   * Register a handler for room-recovered events. Exposed alongside the
+   * one-shot `recoverRoom` promise so callers that want to observe
+   * recoveries initiated elsewhere (e.g. for analytics) can do so.
+   */
+  onRoomRecovered(handler: (event: RoomRecoveredEvent) => void): void {
+    this.socket?.on('room-recovered', handler);
   }
 
   /**
@@ -636,6 +718,10 @@ export class SocketManager {
 
     this.socket.on('room-cancelled', (data: RoomCancelledEvent) => {
       this.callbacks.onRoomCancelled(data);
+    });
+
+    this.socket.on('room-recovered', (data: RoomRecoveredEvent) => {
+      this.callbacks.onRoomRecovered(data);
     });
 
     // Disconnection handling

--- a/phalanx-client/src/index.ts
+++ b/phalanx-client/src/index.ts
@@ -186,6 +186,7 @@ export type {
   RoomErrorEvent,
   RoomExpiredEvent,
   RoomCancelledEvent,
+  RoomRecoveredEvent,
 
   // Event handlers (for legacy 'on' API)
   PhalanxClientEvents,

--- a/phalanx-client/src/types.ts
+++ b/phalanx-client/src/types.ts
@@ -464,6 +464,7 @@ export interface PhalanxClientEvents {
   roomError: (event: RoomErrorEvent) => void;
   roomExpired: (event: RoomExpiredEvent) => void;
   roomCancelled: (event: RoomCancelledEvent) => void;
+  roomRecovered: (event: RoomRecoveredEvent) => void;
 }
 
 /**
@@ -491,5 +492,20 @@ export interface RoomExpiredEvent {
  * Event emitted when a room is cancelled.
  */
 export interface RoomCancelledEvent {
+  code: string;
+}
+
+/**
+ * Event emitted when a host successfully reclaims a private room after a
+ * transient socket disconnect (e.g. mobile browser killing the WebSocket
+ * when the user switches to a messenger to share the invite link).
+ *
+ * The returned `code` is the canonical server-side value — callers should
+ * prefer it over whatever they passed into `recoverRoom`, because the
+ * server normalizes casing and may, in the "host was offline when the
+ * guest joined" fallback path, echo back the code the host originally
+ * created the room with even if the caller slightly drifted.
+ */
+export interface RoomRecoveredEvent {
   code: string;
 }

--- a/phalanx-client/src/types.ts
+++ b/phalanx-client/src/types.ts
@@ -501,10 +501,11 @@ export interface RoomCancelledEvent {
  * when the user switches to a messenger to share the invite link).
  *
  * The returned `code` is the canonical server-side value — callers should
- * prefer it over whatever they passed into `recoverRoom`, because the
- * server normalizes casing and may, in the "host was offline when the
- * guest joined" fallback path, echo back the code the host originally
- * created the room with even if the caller slightly drifted.
+ * prefer it over whatever they passed into `recoverRoom`. In practice
+ * this differs from the caller's input only in casing: the server
+ * uppercases the provided code and rejects anything else with
+ * `room-error: "Room expired"`. Echoing the stored code lets callers
+ * update any cached value that drifted in case only.
  */
 export interface RoomRecoveredEvent {
   code: string;

--- a/phalanx-client/tests/private-room.test.ts
+++ b/phalanx-client/tests/private-room.test.ts
@@ -6,6 +6,9 @@ import type {
   RoomCreatedEvent,
   RoomErrorEvent,
   RoomCancelledEvent,
+  RoomRecoveredEvent,
+  GameStartEvent,
+  CountdownEvent,
 } from '../src/types.js';
 
 /**
@@ -154,6 +157,158 @@ describe('PhalanxClient Private Room Integration', () => {
     expect(client.getClientState()).toBe('idle');
 
     client.disconnect();
+  });
+
+  // ── Host recover flow ─────────────────────────────────────
+  //
+  // These tests cover the end-to-end mobile-host-switches-to-messenger
+  // scenario: a private-room host creates a room, their socket dies
+  // (simulated by `disconnect()` which in turn ends the TCP connection
+  // server-side), and then they come back on a fresh socket and call
+  // `recoverRoom(code)`. The server's grace period keeps the room
+  // alive, and (if a guest had joined during the offline window) hands
+  // the host directly into the running match with match-found +
+  // reconnect-state carrying a countdown snapshot.
+
+  it('should let a host reclaim their room after a socket reconnect', async () => {
+    const host = new PhalanxClient({
+      serverUrl: SERVER_URL,
+      playerId: 'playerHost',
+      username: 'Host',
+    });
+
+    await host.connect();
+    const roomCreated = await host.createRoom();
+
+    // Simulate mobile browser killing the WebSocket when the user
+    // switches to a messenger to share the invite link.
+    host.disconnect();
+
+    // Host comes back: reconnect on a fresh socket, then recover.
+    await host.connect();
+    const recovered: RoomRecoveredEvent = await host.recoverRoom(
+      roomCreated.code,
+    );
+    expect(recovered.code).toBe(roomCreated.code);
+
+    // Now a guest can still join the same room code and both sides
+    // see match-found normally — the room was preserved across the
+    // reconnect.
+    const guest = new PhalanxClient({
+      serverUrl: SERVER_URL,
+      playerId: 'playerGuest',
+      username: 'Guest',
+    });
+    await guest.connect();
+
+    const matchPromiseHost = new Promise<MatchFoundEvent>((resolve) => {
+      host.on('matchFound', (event) => resolve(event));
+    });
+    const matchPromiseGuest = guest.waitForMatch();
+
+    guest.joinRoom(roomCreated.code);
+
+    const matchHost = await matchPromiseHost;
+    const matchGuest = await matchPromiseGuest;
+    expect(matchHost.matchId).toBe(matchGuest.matchId);
+
+    host.disconnect();
+    guest.disconnect();
+  });
+
+  it(
+    'should deliver match-found to a host who was offline when the guest joined',
+    async () => {
+      // This is the exact scenario from the user bug report:
+      //   1. Host creates room
+      //   2. Host's browser tab goes background (socket dies)
+      //   3. Guest joins — match-found fires server-side while host is dead
+      //   4. Host returns, recoverRoom picks up the now-running match
+      //
+      // The host must still observe `matchFound` (retroactively, via the
+      // pending-recover path) and `gameStart` (via the reconnect-state
+      // snapshot fanned out through SocketManager's global handler).
+      const host = new PhalanxClient({
+        serverUrl: SERVER_URL,
+        playerId: 'playerHost',
+        username: 'Host',
+      });
+      const guest = new PhalanxClient({
+        serverUrl: SERVER_URL,
+        playerId: 'playerGuest',
+        username: 'Guest',
+      });
+
+      await host.connect();
+      const roomCreated = await host.createRoom();
+
+      // Host vanishes before guest arrives.
+      host.disconnect();
+
+      // Guest joins — server records a pending-recover entry for the host.
+      await guest.connect();
+      const matchPromiseGuest = guest.waitForMatch();
+      guest.joinRoom(roomCreated.code);
+      const matchGuest = await matchPromiseGuest;
+      expect(matchGuest.matchId).toBeDefined();
+
+      // Host returns. match-found must arrive via the recover fallback.
+      await host.connect();
+      const matchPromiseHost = new Promise<MatchFoundEvent>((resolve) => {
+        host.on('matchFound', (event) => resolve(event));
+      });
+      const recovered = await host.recoverRoom(roomCreated.code);
+      expect(recovered.code).toBe(roomCreated.code);
+
+      const matchHost = await matchPromiseHost;
+      expect(matchHost.matchId).toBe(matchGuest.matchId);
+
+      // And the countdown + game-start — which fired on the guest while
+      // the host was offline — must still flow through to the host's
+      // callbacks thanks to the reconnect-state snapshot replay.
+      const gameStartPromise = new Promise<GameStartEvent>((resolve) => {
+        host.on('gameStart', (event) => resolve(event));
+      });
+      const countdownPromise = new Promise<CountdownEvent>((resolve) => {
+        host.on('countdown', (event) => resolve(event));
+      });
+
+      // If host recovered mid-countdown, the snapshot triggers a synthetic
+      // countdown event. If the server had already emitted game-start by
+      // recover time, gameStartEmitted is true and gameStart fires locally.
+      // Either way, at least one of these will resolve within the test's
+      // countdown window (server is configured with countdownSeconds: 1).
+      const winner = await Promise.race([
+        gameStartPromise.then(() => 'gameStart' as const),
+        countdownPromise.then(() => 'countdown' as const),
+      ]);
+      expect(['gameStart', 'countdown']).toContain(winner);
+
+      host.disconnect();
+      guest.disconnect();
+    },
+  );
+
+  it('should reject recoverRoom with a wrong code', async () => {
+    const host = new PhalanxClient({
+      serverUrl: SERVER_URL,
+      playerId: 'playerHost',
+      username: 'Host',
+    });
+
+    await host.connect();
+    const roomCreated = await host.createRoom();
+    host.disconnect();
+    await host.connect();
+
+    // Use a syntactically valid but wrong code. Server must refuse —
+    // the rejection message is intentionally generic ("Room expired")
+    // so an attacker can't use timing to enumerate live codes.
+    const wrongCode =
+      roomCreated.code === 'ABCDEF' ? 'GHJKLM' : 'ABCDEF';
+    await expect(host.recoverRoom(wrongCode)).rejects.toThrow(/Room expired/);
+
+    host.disconnect();
   });
 
   it('should not allow joining a cancelled room', async () => {

--- a/phalanx-client/tests/private-room.test.ts
+++ b/phalanx-client/tests/private-room.test.ts
@@ -254,9 +254,26 @@ describe('PhalanxClient Private Room Integration', () => {
 
       // Host returns. match-found must arrive via the recover fallback.
       await host.connect();
+
+      // Wire *all* listeners up before calling `recoverRoom`. The server
+      // emits in this order on the pending-recover path:
+      //   `match-found` → `reconnect-state` (synchronously fans out
+      //   synthetic `countdown`/`game-start`) → `room-recovered`.
+      // If we only subscribed to `gameStart`/`countdown` after awaiting
+      // `recoverRoom` (or even after `matchFound`), the synthetic replay
+      // would have already passed by empty listener lists and this test
+      // would hang until the timeout — flaky at best, deadlocking on a
+      // reliable server at worst.
       const matchPromiseHost = new Promise<MatchFoundEvent>((resolve) => {
         host.on('matchFound', (event) => resolve(event));
       });
+      const gameStartPromise = new Promise<GameStartEvent>((resolve) => {
+        host.on('gameStart', (event) => resolve(event));
+      });
+      const countdownPromise = new Promise<CountdownEvent>((resolve) => {
+        host.on('countdown', (event) => resolve(event));
+      });
+
       const recovered = await host.recoverRoom(roomCreated.code);
       expect(recovered.code).toBe(roomCreated.code);
 
@@ -266,13 +283,7 @@ describe('PhalanxClient Private Room Integration', () => {
       // And the countdown + game-start — which fired on the guest while
       // the host was offline — must still flow through to the host's
       // callbacks thanks to the reconnect-state snapshot replay.
-      const gameStartPromise = new Promise<GameStartEvent>((resolve) => {
-        host.on('gameStart', (event) => resolve(event));
-      });
-      const countdownPromise = new Promise<CountdownEvent>((resolve) => {
-        host.on('countdown', (event) => resolve(event));
-      });
-
+      //
       // If host recovered mid-countdown, the snapshot triggers a synthetic
       // countdown event. If the server had already emitted game-start by
       // recover time, gameStartEmitted is true and gameStart fires locally.


### PR DESCRIPTION
## Bug (сообщил пользователь)

1. Игрок 1 создаёт приватную комнату и копирует ссылку-приглашение на телефоне.
2. Сворачивает браузер и открывает мессенджер, чтобы отправить ссылку.
3. Возвращается в браузер на ту же вкладку — мобильная ОС уже убила WebSocket.
4. Игрок 2 переходит по ссылке и выбирает "играть как гость".
5. У Игрока 2 отсчёт идёт нормально, у Игрока 1 замирает на 3.
6. Игрок 2 заходит в матч; Игрок 1 вынужден перезагрузить страницу, после чего больше не может попасть в комнату.

## Диагноз

PR #18 (`be717d8`) добавил серверный обработчик `room-recover` и 2-минутный grace period для отключившегося хоста, а PR #19 (`1d47d81`) — снапшот `reconnect-state` с `countdownSecondsRemaining` / `gameStartEmitted` / `randomSeed`, чтобы подкатившийся новый сокет можно было догнать до текущего состояния. Но **на клиенте никто не вызывал `room-recover`**:

- У `SocketManager` стоит `reconnection: false` и `forceNew: true` — встроенный реконнект socket.io-client выключен.
- `attemptReconnection()` в клиенте срабатывает только при `isPlaying() === true`, то есть **не работает в фазах waiting/countdown** — именно там, где и ловится баг.
- Метода `recoverRoom()` не существовало ни в `SocketManager`, ни в `PhalanxClient`, и в `Game.ts` не было обработчика `visibilitychange` / `pageshow`.

Итог: сервер был готов вернуть хоста, но клиент ни разу не спросил.

## Что сделано

### phalanx-client

- **`types.ts`** — новое событие `RoomRecoveredEvent` и поле `roomRecovered` в `PhalanxClientEvents`.
- **`SocketManager.ts`**:
  - `recoverRoom(code, timeoutMs = 10000)` — отправляет `room-recover`, резолвится на `room-recovered`, реджектится на `room-error` или по 10-секундному таймауту. Флаг `settled` страхует от двойного резолва в гонке таймаут/ответ.
  - Глобальный слушатель `room-recovered` в `setupEventHandlers` раскидывает событие через новый коллбэк `onRoomRecovered`.
- **`PhalanxClient.ts`** — метод `recoverRoom(code)`, пробрасывает `onRoomRecovered` → `emit('roomRecovered', data)`. Попутно убран мёртвый guard `clientState === 'disconnected'` (такого состояния нет в `ClientState`, давал TS2367).
- **`index.ts`** — реэкспорт `RoomRecoveredEvent`.

### chapaev

- **`Game.ts`**:
  - Отслеживает `activePrivateRoomCode`, `isRecovering` и связанный обработчик `visibilityRecoverHandler`.
  - `handleCreateRoom` теперь ждёт `matchFound` / `gameStart` через event emitter `PhalanxClient` (новый хелпер `waitForClientEvent<T>()`), а не через `socket.once()`. Это сокет-агностично и выживает пересоздание сокета при recover (`forceNew: true`).
  - `armVisibilityRecover()` вешает `visibilitychange` на `document` и `pageshow` на `window`.
  - `tryRecoverActiveRoom()` при необходимости переподключает сокет и зовёт `client.recoverRoom(code)`; флаг `isRecovering` защищает от параллельных вызовов при серии visibility-событий.
  - `handleCancelPrivateMatch` корректно разоружает обработчик.

## Тесты

В `phalanx-client/tests/private-room.test.ts` добавлены три регрессионных теста — клиентский сьют теперь 65/65 зелёных:

1. **should let a host reclaim their room after a socket reconnect** — хост отваливается в waiting, новый сокет зовёт `recoverRoom(code)`, хост снова владелец комнаты.
2. **should deliver match-found to a host who was offline when the guest joined** — гость заходит в grace-период хоста, вернувшийся хост получает отложенный `match-found` через `reconnect-state`.
3. **should reject recoverRoom with a wrong code** — неверный код отбрасывается `room-error`.

Серверный сьют — 139/140 (единственный упавший тест связан с самоподписанным TLS-сертификатом в sandbox, к этому PR отношения не имеет).

## Связанные изменения

- PR #18 · `be717d8` — серверный `room-recover` + grace period
- PR #19 · `1d47d81` — снапшот `reconnect-state`

Вместе с этим PR контракт восстановления хоста наконец замкнут с обеих сторон.
