### PR TITLE
docs: refresh READMEs and skills to match current public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A game-agnostic deterministic lockstep multiplayer engine with authentication, m
 - 📖 [Server Documentation](./phalanx-server/README.md)
 - 📖 [Client Documentation](./phalanx-client/README.md)
 - 📖 [ECS Documentation](./phalanx-ecs/README.md)
+- 📖 [Physics Documentation](./phalanx-physics/README.md)
 - 📖 [Math Documentation](./phalanx-math/README.md)
 - 🎮 [Babylon RTS Demo](./direct-strike-babylon-example/README.md)
 
@@ -24,14 +25,48 @@ pnpm install
 
 # Packages
 
-This repository contains the following packages:
+This repository is a pnpm workspace containing the following publishable packages:
 
-| Package                            | Description                                                |
-| ---------------------------------- | ---------------------------------------------------------- |
-| [phalanx-server](./phalanx-server) | Server library for hosting multiplayer games               |
-| [phalanx-client](./phalanx-client) | Client library for connecting to Phalanx servers           |
-| [phalanx-ecs](./phalanx-ecs)       | Renderer-agnostic ECS library with GameWorld facade        |
-| [phalanx-math](./phalanx-math)     | Deterministic fixed-point math library for lockstep games  |
+| Package                              | Description                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------------- |
+| [phalanx-server](./phalanx-server)   | Server library for hosting multiplayer games (matchmaking, lockstep, rooms)  |
+| [phalanx-client](./phalanx-client)   | Browser/Node client for connecting to Phalanx servers                        |
+| [phalanx-ecs](./phalanx-ecs)         | Renderer-agnostic ECS library with `GameWorld` facade and SoA storage        |
+| [phalanx-physics](./phalanx-physics) | Deterministic fixed-point physics (spatial hash, narrow phase, impulses)     |
+| [phalanx-math](./phalanx-math)       | Deterministic fixed-point math library for lockstep games                    |
+
+In addition to the libraries, the workspace contains reference applications under `direct-strike-babylon-example/`, `chapaev/`, `arena-shooter/`, `game-test/`, and `game-test-server/`.
+
+## Architecture
+
+```
+                        ┌─────────────────────────────┐
+                        │       phalanx-server        │
+                        │ matchmaking · rooms · ticks │
+                        └──────────────┬──────────────┘
+                                       │ Socket.IO (commands & events)
+                                       ▼
+   ┌────────────────────────────┐  ┌──────────────────────────────┐
+   │      phalanx-client        │  │      phalanx-ecs (optional)  │
+   │ connection · matchmaking · │──▶│  EntityManager · GameWorld · │
+   │ command batching · auth ·  │  │  SoA storage · pooling       │
+   │ room recovery · render     │  └────────────────┬─────────────┘
+   │ loop (ITickFrameProvider)  │                   │
+   └────────────────────────────┘                   ▼
+                                       ┌────────────────────────────┐
+                                       │     phalanx-physics        │
+                                       │ deterministic FP physics · │
+                                       │ spatial hash · collisions  │
+                                       └────────────────┬───────────┘
+                                                        │
+                                                        ▼
+                                       ┌────────────────────────────┐
+                                       │       phalanx-math         │
+                                       │ FP fixed-point arithmetic  │
+                                       └────────────────────────────┘
+```
+
+`phalanx-client` and `phalanx-ecs` both implement the `ITickFrameProvider` interface, so a `GameWorld` can be driven by either an internal `TickFrameManager` (single-player) or by the multiplayer client (`PhalanxClient` is fed the server's authoritative ticks).
 
 ## Features
 
@@ -134,16 +169,9 @@ See the [Client Documentation](./phalanx-client/README.md#mobile-friendly-room-r
 
 ## Quick Start
 
-> **Note**: Since the packages are not yet published to npm, use the local packages from the cloned repository.
+> **Note**: Packages are not yet published to npm. Work from the cloned monorepo and consume packages via `workspace:*`.
 
 ### Server
-
-From the cloned repository, navigate to the server package:
-
-```bash
-cd phalanx-server
-npm install
-```
 
 ```typescript
 import { Phalanx } from 'phalanx-server';
@@ -154,35 +182,64 @@ const server = new Phalanx({
   gameMode: '3v3',
 });
 
-server.start().then(() => {
-  console.log('Phalanx server running on port 3000');
-});
+await server.start();
+console.log('Phalanx server running on port 3000');
 ```
 
 ### Client
 
-From the cloned repository, navigate to the client package:
-
-```bash
-cd phalanx-client
-pnpm install
-```
-
 ```typescript
 import { PhalanxClient } from 'phalanx-client';
 
-const client = new PhalanxClient({
+const client = await PhalanxClient.create({
   serverUrl: 'http://localhost:3000',
   playerId: 'player-123',
   username: 'MyPlayer',
 });
 
-await client.connect();
 const match = await client.joinQueueAndWaitForMatch();
 await client.waitForGameStart();
 
-client.on('tick', (data) => {
-  console.log(`Tick ${data.tick}`);
+// After loading assets, tell the server we're ready for ticks.
+client.sendReady();
+
+client.onTick((tick, commands) => {
+  // Run deterministic simulation using `commands`
+});
+
+client.onFrame((alpha, dt) => {
+  // Render with interpolation between ticks
+});
+```
+
+### Single-player ECS + Physics
+
+```typescript
+import { GameWorld } from 'phalanx-ecs';
+import { PhysicsWorld, PhysicsBodyComponent } from 'phalanx-physics';
+import { FP } from 'phalanx-math';
+
+const world = new GameWorld({ tickRate: 20 });
+
+const physics = new PhysicsWorld({
+  gridCellSize: FP.FromFloat(8),
+  subSteps: 3,
+  tickRate: 20,
+});
+
+const { physicsSystem } = physics.getSystems();
+world.registerSystems([physicsSystem], []);
+
+world.start({
+  beforeTick(tick) {
+    if (tick === 0) {
+      physics.setTransformStore(world.entityManager.getOrCreateSoAStore(MyTransformSchema), {
+        fpPositionX: 'fpPositionX',
+        fpPositionY: 'fpPositionY',
+        fpPositionZ: 'fpPositionZ',
+      });
+    }
+  },
 });
 ```
 
@@ -191,14 +248,36 @@ client.on('tick', (data) => {
 - [Server Documentation](./phalanx-server/README.md)
 - [Client Documentation](./phalanx-client/README.md)
 - [ECS Documentation](./phalanx-ecs/README.md)
+- [Physics Documentation](./phalanx-physics/README.md)
 - [Math Documentation](./phalanx-math/README.md)
 - [Babylon RTS Demo & Dev Guide](./direct-strike-babylon-example/README.md)
 
+## Workspace Commands
+
+All commands are run from the repository root.
+
+| Command                   | What it does                                                       |
+| ------------------------- | ------------------------------------------------------------------ |
+| `pnpm install`            | Install workspace dependencies                                     |
+| `pnpm build`              | Build every workspace package (`pnpm -r build`)                    |
+| `pnpm clean`              | Run each package's `clean` script                                  |
+| `pnpm test`               | Run all package test suites (Vitest)                               |
+| `pnpm test:server`        | Run only `phalanx-server` tests                                    |
+| `pnpm test:client`        | Run only `phalanx-client` tests                                    |
+| `pnpm test:watch`         | Run package test suites in watch mode                              |
+| `pnpm dev:server`         | `tsc --watch` for `phalanx-server`                                 |
+| `pnpm dev:client`         | `tsc --watch` for `phalanx-client`                                 |
+| `pnpm dev:game`           | Dev-mode reference game (`game-test`)                              |
+| `pnpm dev:game-server`    | Dev-mode reference game server (`game-test-server`)                |
+| `pnpm build:game-server`  | Build the reference game server                                    |
+| `pnpm lint` / `lint:fix`  | ESLint over the workspace                                          |
+| `pnpm format` / `format:check` | Prettier over the workspace                                   |
+
 ## Requirements
 
-- Node.js 18+
-- pnpm (install with `npm install -g pnpm`)
-- Socket.IO compatible transport
+- Node.js 24.x (`>=24.0.0 <25.0.0`)
+- pnpm 10.x (install with `corepack enable && corepack prepare pnpm@10.33.0 --activate`)
+- Socket.IO compatible transport (HTTP or HTTPS / WSS)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ All commands are run from the repository root.
 ## Requirements
 
 - Node.js 24.x (`>=24.0.0 <25.0.0`)
-- pnpm 10.x (install with `corepack enable && corepack prepare pnpm@10.33.0 --activate`)
+- pnpm 10.x (install with `corepack enable && corepack prepare pnpm@10.33.2 --activate`)
 - Socket.IO compatible transport (HTTP or HTTPS / WSS)
 
 ## License

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -1,6 +1,8 @@
 # Phalanx Physics
 
-A deterministic, fixed-point physics engine for the Phalanx Engine. Designed for lockstep multiplayer games where every client must produce identical simulation results.
+A deterministic, fixed-point physics engine for the [Phalanx Engine](../README.md). Designed for lockstep multiplayer games where every client must produce identical simulation results.
+
+> Sibling packages: [phalanx-ecs](../phalanx-ecs/README.md) (ECS core), [phalanx-math](../phalanx-math/README.md) (fixed-point math), [phalanx-server](../phalanx-server/README.md), [phalanx-client](../phalanx-client/README.md).
 
 ## Features
 
@@ -32,8 +34,7 @@ A deterministic, fixed-point physics engine for the Phalanx Engine. Designed for
 - **NarrowPhase**: Static methods for precise collision geometry tests
 
 ### Systems
-- **PhysicsSystem**: Velocity integration with sub-stepping, world bounds handling, `step()` / `applyImpulse()` / `isSettled()` API
-- **CollisionSystem**: Broad → narrow → resolve → emit pipeline per tick
+- **PhysicsSystem**: Velocity integration with sub-stepping, world bounds handling, broad/narrow/resolve collision pipeline, `step()` / `applyImpulse()` / `isSettled()` / `setCollisionFilter()` API. Created and owned by `PhysicsWorld`; retrieve it via `physicsWorld.getSystems().physicsSystem` to register with `GameWorld`.
 
 ### Tick Providers
 - **IPhysicsTickProvider**: Interface for custom tick scheduling strategies
@@ -48,11 +49,56 @@ A deterministic, fixed-point physics engine for the Phalanx Engine. Designed for
 
 ## Installation
 
+> ⚠️ **Not on npm yet** — clone the monorepo and install via pnpm.
+
 ```bash
-npm install phalanx-physics
+git clone https://github.com/phaeton2040-AI/phalanx-engine.git
+cd phalanx-engine
+pnpm install
+pnpm --filter phalanx-physics build
 ```
 
 Peer dependencies: `phalanx-ecs` ^0.1.0, `phalanx-math` ^0.1.0
+
+## Imports
+
+```typescript
+import {
+  // Facade & config
+  PhysicsWorld,
+  type PhysicsWorldConfig,
+
+  // Components
+  PhysicsBodyComponent,
+  PhysicsSoASchema,
+  PHYSICS_BODY_COMPONENT_TYPE,
+  type PhysicsBodyConfig,
+
+  // Collision primitives
+  SpatialHashGrid,
+  NarrowPhase,
+  type CollisionManifold,
+
+  // System
+  PhysicsSystem,
+
+  // Events & event types
+  PhysicsEvents,
+  type CollisionEvent,
+  type BoundsExitEvent,
+
+  // Tick providers
+  type IPhysicsTickProvider,
+  AutonomousPhysicsTickProvider,
+  type AutonomousProviderOptions,
+  ExternalPhysicsTickProvider,
+
+  // Misc types
+  type TransformFieldMapping,
+  type CollisionFilter,
+  type PhysicsConfig,
+} from 'phalanx-physics';
+```
 
 ## Quick Start
 
@@ -71,9 +117,10 @@ const physicsWorld = new PhysicsWorld({
 });
 
 // 2. Register systems with GameWorld (order matters)
-const { physicsSystem, collisionSystem } = physicsWorld.getSystems();
+//    PhysicsWorld owns one PhysicsSystem that runs the full broad → narrow → resolve pipeline.
+const { physicsSystem } = physicsWorld.getSystems();
 world.registerSystems(
-  [movementSystem, physicsSystem, collisionSystem],
+  [movementSystem, physicsSystem],
   [renderSystem],
 );
 
@@ -162,8 +209,156 @@ physicsWorld.onBoundsExit(({ entityId }) => {
 | `AutonomousPhysicsTickProvider` | Runs until settled or `maxSteps` — turn-based physics |
 | `ExternalPhysicsTickProvider` | Caller invokes `tick()` manually — BabylonJS rAF, unit tests |
 
-### API Reference
+## API Reference
+
+### `PhysicsWorld`
+
+```typescript
+class PhysicsWorld {
+  constructor(config?: PhysicsWorldConfig);
+
+  // System wiring
+  getSystems(): { physicsSystem: PhysicsSystem };
+  setTransformStore(
+    store: SoAComponentStore<SoASchemaDefinition>,
+    fieldMapping: TransformFieldMapping
+  ): void;
+  setCollisionFilter(filter: (entityA: number, entityB: number) => boolean): void;
+
+  // Event subscriptions (must be called after GameWorld.start())
+  onCollision(callback: (event: CollisionEvent) => void): () => void;
+  onTriggerEnter(callback: (event: CollisionEvent) => void): () => void;
+  onTriggerExit(callback: (event: CollisionEvent) => void): () => void;
+  onBoundsExit(callback: (event: BoundsExitEvent) => void): () => void;
+
+  // Impulse / settle queries
+  applyImpulse(entityId: number, vx: FixedPoint, vz: FixedPoint): void;
+  isSettled(threshold?: FixedPoint): boolean;
+
+  // Spatial query escape hatch
+  readonly spatialGrid: SpatialHashGrid;
+
+  // Cleanup
+  dispose(): void;
+}
+```
 
 - **`applyImpulse(entityId, vx, vz)`** — Set body velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
-- **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default `0.01`).
+- **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`).
 - **`onBoundsExit(callback)`** — Subscribe to `BOUNDS_EXIT` events (requires `ejectOnBoundsExit: true`).
+- **`setCollisionFilter(filter)`** — Inject a per-pair predicate. Return `false` to skip collision resolution for that pair.
+
+### `PhysicsWorldConfig`
+
+```typescript
+interface PhysicsWorldConfig {
+  gridCellSize?: FixedPoint;     // default FP.FromFloat(4)
+  subSteps?: number;             // default 3
+  tickRate?: number;             // default 20 — used to compute tickDt
+  worldBounds?: { minX: FixedPoint; minZ: FixedPoint; maxX: FixedPoint; maxZ: FixedPoint };
+  defaultRestitution?: FixedPoint;
+  defaultFriction?: FixedPoint;  // default FP.FromFloat(0.92)
+  maxVelocity?: FixedPoint;      // default FP.FromFloat(15)
+  pushStrength?: FixedPoint;     // default FP.FromFloat(15)
+  tickProvider?: IPhysicsTickProvider;
+  ejectOnBoundsExit?: boolean;   // default false
+  settleThreshold?: FixedPoint;  // default FP.FromFloat(0.01)
+}
+```
+
+### `PhysicsBodyComponent`
+
+```typescript
+class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.definition> {
+  static readonly soaSchema: typeof PhysicsSoASchema;
+  readonly type: symbol; // PHYSICS_BODY_COMPONENT_TYPE
+
+  constructor(entityId: number, config: PhysicsBodyConfig);
+
+  // Velocity
+  velocity: FPVector3;                                       // get/set (returns cached object)
+  setVelocity(x: FixedPoint, y: FixedPoint, z: FixedPoint): void;
+  addVelocity(velocity: FPVector3): void;
+  stopVelocity(): void;
+
+  // Read-only attributes
+  readonly radius: FixedPoint;
+  readonly radiusFloat: number;
+  readonly mass: FixedPoint;
+  readonly restitution: FixedPoint;
+  readonly friction: FixedPoint;
+  readonly isStatic: boolean;
+  ignorePhysics: boolean;        // get/set
+
+  // Spatial-grid bookkeeping
+  lastX: number;
+  lastZ: number;
+}
+
+interface PhysicsBodyConfig {
+  radius: FixedPoint;
+  mass?: FixedPoint;             // default FP._1
+  isStatic?: boolean;            // default false
+  restitution?: FixedPoint;      // default FP.FromFloat(0.5)
+  friction?: FixedPoint;         // default FP._0
+}
+```
+
+For hot-path access, prefer the SoA store directly:
+
+```typescript
+const store = entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+const idx = store.indexOf(entityId);
+store.arrays.velocityX[idx] = FP.ToRaw(newVx);
+```
+
+### Collision primitives
+
+- **`SpatialHashGrid`** — broad-phase O(n) neighbor pairing. Methods: `clear()`, `insert(...)`, `queryPairs()`, `queryRadius(...)`. Access via `physicsWorld.spatialGrid` for ad-hoc range queries.
+- **`NarrowPhase`** — static methods for circle/AABB intersection tests. Returns `CollisionManifold | null`.
+- **`CollisionManifold`** — `{ entityA, entityB, normalX, normalZ, penetration }`.
+
+### Tick providers
+
+```typescript
+interface IPhysicsTickProvider {
+  /** Start the provider; it calls `onStep` whenever physics should advance one step. */
+  start(onStep: () => void): void;
+  /** Stop the provider and release any timers/handles. */
+  stop(): void;
+}
+
+interface AutonomousProviderOptions {
+  /** Called every step to decide whether to stop (defined by the game). */
+  isSettled: () => boolean;
+  /** Called once when simulation settles or `maxSteps` is reached. */
+  onSettled: () => void;
+  /** Max simulation steps before forcing a stop. Default: 10000. */
+  maxSteps?: number;
+}
+
+class AutonomousPhysicsTickProvider implements IPhysicsTickProvider {
+  constructor(options: AutonomousProviderOptions);
+  // Schedules `onStep` via setImmediate (Node) or setTimeout(0) (browser)
+  // until isSettled() returns true or maxSteps is reached.
+}
+
+class ExternalPhysicsTickProvider implements IPhysicsTickProvider {
+  /** Manually advance one physics step from your render loop / test harness. */
+  tick(): void;
+}
+```
+
+### Events
+
+```typescript
+const PhysicsEvents = {
+  COLLISION:     'physics:collision',
+  TRIGGER_ENTER: 'physics:trigger:enter',
+  TRIGGER_EXIT:  'physics:trigger:exit',
+  BOUNDS_EXIT:   'physics:bounds:exit',
+} as const;
+
+interface CollisionEvent { entityA: number; entityB: number; manifold: CollisionManifold; }
+interface BoundsExitEvent { entityId: number; }
+```

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -103,11 +103,36 @@ import {
 ## Quick Start
 
 ```typescript
-import { GameWorld } from 'phalanx-ecs';
+import { GameWorld, GameSystem, defineSoASchema } from 'phalanx-ecs';
 import { PhysicsWorld, PhysicsBodyComponent } from 'phalanx-physics';
 import { FP } from 'phalanx-math';
 
-// 1. Create the physics facade
+// 0. Define the transform schema your game uses (consumer-owned).
+//    Physics will read fpPositionX/Y/Z and optionally write visualPositionX/Z.
+const TransformSoASchema = defineSoASchema({
+  fpPositionX: 'i64',
+  fpPositionY: 'i64',
+  fpPositionZ: 'i64',
+  visualPositionX: 'f64',
+  visualPositionY: 'f64',
+  visualPositionZ: 'f64',
+}, 'Transform');
+
+// Minimal placeholder systems — replace with your real ones.
+// MovementSystem runs BEFORE physics and writes velocities onto PhysicsBody SoA.
+class MovementSystem extends GameSystem {
+  public override processTick(_tick: number): void { /* set velocities here */ }
+}
+// RenderSystem runs in the frame pipeline (interpolation, scene updates, etc.).
+class RenderSystem extends GameSystem {
+  public override update(_alpha: number, _dt: number): void { /* render here */ }
+}
+const movementSystem = new MovementSystem();
+const renderSystem = new RenderSystem();
+
+// 1. Create GameWorld and the physics facade
+const world = new GameWorld({ componentTypes: { /* your ComponentType registry */ } as any });
+
 const physicsWorld = new PhysicsWorld({
   gridCellSize: FP.FromFloat(8),
   subSteps: 3,
@@ -120,19 +145,20 @@ const physicsWorld = new PhysicsWorld({
 //    PhysicsWorld owns one PhysicsSystem that runs the full broad → narrow → resolve pipeline.
 const { physicsSystem } = physicsWorld.getSystems();
 world.registerSystems(
-  [movementSystem, physicsSystem],
-  [renderSystem],
+  [movementSystem, physicsSystem],   // tick systems
+  [renderSystem],                    // frame systems
 );
 
-// 3. Link transform store on first tick
+// 3. Link transform store on first tick (after stores have been created)
 world.start({
   beforeTick: (tick) => {
     if (tick === 0) {
       const txStore = world.entityManager.getOrCreateSoAStore(TransformSoASchema);
-      physicsWorld.setTransformStore(txStore, {
+      physicsWorld.setTransformStore(txStore as any, {
         fpPositionX: 'fpPositionX',
         fpPositionY: 'fpPositionY',
         fpPositionZ: 'fpPositionZ',
+        // Optional: only X and Z are written by PhysicsSystem
         visualPositionX: 'visualPositionX',
         visualPositionZ: 'visualPositionZ',
       });
@@ -141,12 +167,14 @@ world.start({
 });
 
 // 4. Add physics bodies to entities
+//    (entity here is whatever your game uses — typically obtained via world.entityManager)
+declare const entity: { id: number; addComponent(c: unknown): void };
 const body = new PhysicsBodyComponent(entity.id, {
   radius: FP.FromFloat(1.0),
 });
 entity.addComponent(body);
 
-// 5. Subscribe to collision events
+// 5. Subscribe to collision events (must be called after world.start())
 physicsWorld.onCollision((event) => {
   console.log(`Collision: ${event.entityA} ↔ ${event.entityB}`);
 });
@@ -227,9 +255,13 @@ class PhysicsWorld {
 
   // Event subscriptions (must be called after GameWorld.start())
   onCollision(callback: (event: CollisionEvent) => void): () => void;
+  onBoundsExit(callback: (event: BoundsExitEvent) => void): () => void;
+
+  // Planned — not yet emitted by PhysicsSystem.
+  // The handlers exist and subscribe to PhysicsEvents.TRIGGER_ENTER / TRIGGER_EXIT,
+  // but PhysicsSystem currently only emits COLLISION and BOUNDS_EXIT.
   onTriggerEnter(callback: (event: CollisionEvent) => void): () => void;
   onTriggerExit(callback: (event: CollisionEvent) => void): () => void;
-  onBoundsExit(callback: (event: BoundsExitEvent) => void): () => void;
 
   // Impulse / settle queries
   applyImpulse(entityId: number, vx: FixedPoint, vz: FixedPoint): void;

--- a/skills/phalanx-client/SKILL.md
+++ b/skills/phalanx-client/SKILL.md
@@ -25,7 +25,7 @@ Use this skill when the user asks to:
 ## Prerequisites
 
 - A running Phalanx server (see `phalanx-server` skill)
-- Node.js 18+ (or a browser environment)
+- Node.js 24.x (`>=24.0.0 <25.0.0`) — or a browser environment for the client
 - Socket.IO compatible transport
 
 ## Step-by-Step Instructions

--- a/skills/phalanx-physics/SKILL.md
+++ b/skills/phalanx-physics/SKILL.md
@@ -34,7 +34,9 @@ Use this skill when the user asks to:
 PhysicsWorld (Facade)
 └── PhysicsSystem        ← Velocity integration + collision pipeline (sub-stepped)
     ├── SpatialHashGrid  ← O(n) broad-phase via spatial hashing
-    └── NarrowPhase      ← Circle vs Circle / AABB collision tests
+    └── NarrowPhase      ← Circle vs Circle collision tests
+                           (circleVsAABB / aabbVsAABB exist on NarrowPhase but are not
+                            wired into the PhysicsSystem pipeline today — planned.)
 ```
 
 Pipeline per tick (all deterministic, fixed-point), all driven by a single `PhysicsSystem.processTick()`:
@@ -46,10 +48,17 @@ PhysicsSystem.processTick()
       → integrate velocities into positions
       → rebuild spatial grid
       → query candidate pairs
-      → narrow-phase circle-circle / AABB tests
+      → narrow-phase circle-vs-circle tests
       → resolve: impulse push + positional separation
-      → emit PhysicsEvents.COLLISION / TRIGGER_* / BOUNDS_EXIT via EventBus
+      → emit PhysicsEvents.COLLISION via EventBus
+    after iteration: emit PhysicsEvents.BOUNDS_EXIT for any bodies ejected this tick
 ```
+
+> **Events actually emitted by `PhysicsSystem`:** `PhysicsEvents.COLLISION` and
+> `PhysicsEvents.BOUNDS_EXIT` only. `TRIGGER_ENTER` / `TRIGGER_EXIT` are reserved on
+> the event constants and have subscriber methods on `PhysicsWorld`, but are **not yet
+> emitted** — planned, not implemented. Likewise, AABB-based contact tests are not
+> wired into `PhysicsSystem.processTick()`.
 
 ### Key Design Decisions
 
@@ -139,7 +148,7 @@ world.start({
 });
 ```
 
-**Important:** The `visualPositionX/Y/Z` fields are optional. When provided, `PhysicsSystem` writes `FP.ToFloat()` values to these f64 arrays whenever it updates fp positions. This is critical when game systems (like CombatSystem) read visual positions during ticks.
+**Important:** The `visualPositionX` and `visualPositionZ` fields are optional. When provided, `PhysicsSystem` writes `FP.ToFloat()` values to those f64 arrays whenever it updates fp positions. This is critical when game systems (like CombatSystem) read visual positions during ticks. (`visualPositionY` is accepted on the field mapping type for forward-compatibility, but `PhysicsSystem` does not currently write it — only X and Z are synced.)
 
 ### 4. Create PhysicsBodyComponent for Entities
 
@@ -312,13 +321,13 @@ interface TransformFieldMapping {
   fpPositionX: string;       // Required: i64 field name for X position
   fpPositionY: string;       // Required: i64 field name for Y position
   fpPositionZ: string;       // Required: i64 field name for Z position
-  visualPositionX?: string;  // Optional: f64 field to sync with FP.ToFloat(fpX)
-  visualPositionY?: string;  // Optional: f64 field to sync with FP.ToFloat(fpY)
-  visualPositionZ?: string;  // Optional: f64 field to sync with FP.ToFloat(fpZ)
+  visualPositionX?: string;  // Optional: f64 field synced with FP.ToFloat(fpX) by PhysicsSystem
+  visualPositionY?: string;  // Reserved on the type, but NOT written by PhysicsSystem today
+  visualPositionZ?: string;  // Optional: f64 field synced with FP.ToFloat(fpZ) by PhysicsSystem
 }
 ```
 
-When `visualPositionX/Z` are provided, PhysicsSystem writes the float equivalent alongside every fp position update. This avoids stale visual caches between ticks.
+When `visualPositionX` and `visualPositionZ` are provided, PhysicsSystem writes the float equivalent alongside every fp position update. This avoids stale visual caches between ticks. `visualPositionY` is part of the type for forward-compatibility but is not synced by the current implementation.
 
 ## PhysicsWorldConfig
 

--- a/skills/phalanx-physics/SKILL.md
+++ b/skills/phalanx-physics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: phalanx-physics
-description: Add deterministic fixed-point physics to a game using the phalanx-physics library from the phalanx-engine repository. Use when the user wants to set up collision detection, velocity integration, spatial hashing, or physics bodies. Covers PhysicsWorld facade, PhysicsBodyComponent, SpatialHashGrid, NarrowPhase, CollisionSystem, PhysicsSystem, TransformFieldMapping, and collision filtering patterns.
+description: Add deterministic fixed-point physics to a game using the phalanx-physics library from the phalanx-engine repository. Use when the user wants to set up collision detection, velocity integration, spatial hashing, or physics bodies. Covers PhysicsWorld facade, PhysicsBodyComponent, SpatialHashGrid, NarrowPhase, PhysicsSystem (which runs the full broad → narrow → resolve pipeline), TransformFieldMapping, and collision filtering patterns.
 metadata:
   author: phaeton2040-AI
   version: '1.0'
@@ -32,25 +32,23 @@ Use this skill when the user asks to:
 
 ```
 PhysicsWorld (Facade)
-├── PhysicsSystem        ← Velocity integration with sub-stepping
-└── CollisionSystem      ← Broad → Narrow → Resolve → Emit
+└── PhysicsSystem        ← Velocity integration + collision pipeline (sub-stepped)
     ├── SpatialHashGrid  ← O(n) broad-phase via spatial hashing
     └── NarrowPhase      ← Circle vs Circle / AABB collision tests
 ```
 
-Pipeline per tick (all deterministic, fixed-point):
+Pipeline per tick (all deterministic, fixed-point), all driven by a single `PhysicsSystem.processTick()`:
 ```
 MovementSystem (game-specific, sets velocities)
     ↓
 PhysicsSystem.processTick()
-    → for each sub-step: integrate velocities into positions
-    ↓
-CollisionSystem.processTick()
-    → rebuild spatial grid
-    → query candidate pairs
-    → narrow-phase circle-circle test
-    → resolve: impulse push + positional separation
-    → emit PhysicsEvents.COLLISION via EventBus
+    for each sub-step:
+      → integrate velocities into positions
+      → rebuild spatial grid
+      → query candidate pairs
+      → narrow-phase circle-circle / AABB tests
+      → resolve: impulse push + positional separation
+      → emit PhysicsEvents.COLLISION / TRIGGER_* / BOUNDS_EXIT via EventBus
 ```
 
 ### Key Design Decisions
@@ -94,17 +92,18 @@ import { GameWorld } from 'phalanx-ecs';
 
 const world = new GameWorld({ /* ... */ });
 
-// Extract the two systems from the facade
-const { physicsSystem, collisionSystem } = physicsWorld.getSystems();
+// Extract the system from the facade. PhysicsWorld owns a single
+// PhysicsSystem that runs the full broad → narrow → resolve pipeline
+// each tick (with sub-stepping internally).
+const { physicsSystem } = physicsWorld.getSystems();
 
 // Register in tick system order — ORDER MATTERS:
 // 1. Game-specific system sets velocities (e.g., MovementSystem)
-// 2. PhysicsSystem integrates velocities into positions
-// 3. CollisionSystem detects and resolves collisions
+// 2. PhysicsSystem integrates velocities, detects, and resolves collisions
+// 3. Game-specific systems react to the updated positions
 const tickSystems = [
   movementSystem,    // Game-specific: sets velocities on PhysicsBodyComponent
-  physicsSystem,     // phalanx-physics: velocity integration
-  collisionSystem,   // phalanx-physics: collision detection & resolution
+  physicsSystem,     // phalanx-physics: integrate + collide + resolve
   combatSystem,      // Game-specific: reacts to updated positions
 ];
 
@@ -140,7 +139,7 @@ world.start({
 });
 ```
 
-**Important:** The `visualPositionX/Y/Z` fields are optional. When provided, `PhysicsSystem` and `CollisionSystem` will write `FP.ToFloat()` values to these f64 arrays whenever they update fp positions. This is critical when game systems (like CombatSystem) read visual positions during ticks.
+**Important:** The `visualPositionX/Y/Z` fields are optional. When provided, `PhysicsSystem` writes `FP.ToFloat()` values to these f64 arrays whenever it updates fp positions. This is critical when game systems (like CombatSystem) read visual positions during ticks.
 
 ### 4. Create PhysicsBodyComponent for Entities
 
@@ -233,12 +232,10 @@ class MovementSystem extends GameSystem {
 
 ### 7. Add Collision Filtering (Optional)
 
-For game-specific collision rules (e.g., skip same-team collisions), use the collision filter callback:
+For game-specific collision rules (e.g., skip same-team collisions), use the collision filter callback on the `PhysicsWorld` facade (it forwards to the underlying `PhysicsSystem`):
 
 ```typescript
-const { collisionSystem } = physicsWorld.getSystems();
-
-collisionSystem.setCollisionFilter((entityIdA: number, entityIdB: number) => {
+physicsWorld.setCollisionFilter((entityIdA: number, entityIdB: number) => {
   const eA = entityManager.getEntity(entityIdA);
   const eB = entityManager.getEntity(entityIdB);
   if (!eA || !eB) return false;
@@ -321,7 +318,7 @@ interface TransformFieldMapping {
 }
 ```
 
-When `visualPositionX/Z` are provided, PhysicsSystem and CollisionSystem write the float equivalent alongside every fp position update. This avoids stale visual caches between ticks.
+When `visualPositionX/Z` are provided, PhysicsSystem writes the float equivalent alongside every fp position update. This avoids stale visual caches between ticks.
 
 ## PhysicsWorldConfig
 
@@ -402,7 +399,7 @@ interface CollisionManifold {
 
 ### Resolution
 
-CollisionSystem applies:
+PhysicsSystem applies, per sub-step, after broad/narrow detection:
 1. **Impulse-based push**: Velocity change proportional to mass ratio × overlap × pushStrength
 2. **Positional separation**: Direct position correction to prevent overlap (half each side, weighted by mass)
 
@@ -412,29 +409,46 @@ Static entities are never moved. When one entity is static, the dynamic entity a
 
 ```typescript
 // Components
-import { PhysicsBodyComponent, PhysicsSoASchema, PHYSICS_BODY_COMPONENT_TYPE } from 'phalanx-physics';
+import {
+  PhysicsBodyComponent,
+  PhysicsSoASchema,
+  PHYSICS_BODY_COMPONENT_TYPE,
+} from 'phalanx-physics';
 import type { PhysicsBodyConfig } from 'phalanx-physics';
 
-// Collision
+// Collision primitives
 import { SpatialHashGrid, NarrowPhase } from 'phalanx-physics';
 import type { CollisionManifold } from 'phalanx-physics';
 
-// Systems
-import { PhysicsSystem, CollisionSystem } from 'phalanx-physics';
+// System (single system runs the full pipeline)
+import { PhysicsSystem } from 'phalanx-physics';
 
 // Facade
 import { PhysicsWorld } from 'phalanx-physics';
 
-// Config & Types
+// Tick providers
+import {
+  AutonomousPhysicsTickProvider,
+  ExternalPhysicsTickProvider,
+} from 'phalanx-physics';
+import type {
+  IPhysicsTickProvider,
+  AutonomousProviderOptions,
+} from 'phalanx-physics';
+
+// Events & types
+import { PhysicsEvents } from 'phalanx-physics';
 import type {
   PhysicsWorldConfig,
   TransformFieldMapping,
   CollisionFilter,
   CollisionEvent,
+  BoundsExitEvent,
   PhysicsConfig,
 } from 'phalanx-physics';
-import { PhysicsEvents } from 'phalanx-physics';
 ```
+
+> Note: `CollisionSystem` is **not** exported. The collision pipeline is implemented inside `PhysicsSystem` and only exposed via `PhysicsWorld.getSystems().physicsSystem`.
 
 ## Best Practices
 
@@ -455,7 +469,7 @@ import { PhysicsEvents } from 'phalanx-physics';
 
 ### Integration
 
-- PhysicsSystem runs BEFORE CollisionSystem — velocities integrated first, then collisions resolved
+- A single `PhysicsSystem` runs the full pipeline: it integrates velocities, then detects and resolves collisions, per sub-step
 - Game-specific velocity logic (movement, friction) runs BEFORE PhysicsSystem in the tick order
 - Link the transform store on the first tick (in `beforeTick`), not at construction time
 - Always provide `visualPositionX/Z` in the field mapping when game systems read visual positions during ticks

--- a/skills/phalanx-server/SKILL.md
+++ b/skills/phalanx-server/SKILL.md
@@ -21,7 +21,7 @@ Use this skill when the user asks to:
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 24.x (`>=24.0.0 <25.0.0`, as declared in the workspace `engines` field)
 - pnpm (install with `npm install -g pnpm`)
 - The `phalanx-engine` repository cloned locally (packages are not yet on npm)
 
@@ -29,9 +29,10 @@ Use this skill when the user asks to:
 
 ```
 phalanx-engine/
-├── phalanx-server/    ← Server library
+├── phalanx-server/    ← Server library (this skill)
 ├── phalanx-client/    ← Client library
-├── phalanx-ecs/       ← ECS library
+├── phalanx-ecs/       ← ECS library (renderer-agnostic, GameWorld facade)
+├── phalanx-physics/   ← Deterministic FP physics (spatial hash, collisions)
 ├── phalanx-math/      ← Fixed-point math
 └── game-test-server/  ← Reference server implementation
 ```


### PR DESCRIPTION
## Summary

Audited the public API surface of every workspace package against its README, then cleaned up the agent skill files and the root README to match what is actually exported today.

The audit confirmed that **phalanx-server**, **phalanx-client**, and **phalanx-ecs** READMEs are still aligned with their `src/index.ts` exports — no edits needed there. The drift was concentrated in the root README and the **phalanx-physics** documentation.

## Per-package findings

### phalanx-server
- ✅ `Phalanx` class API (`start()`, `stop()`, `getActiveMatches()`, `getQueueSize()`, `getConfig()`, EventEmitter `on`/`off`) matches the README.
- ✅ Server-side events (`match-created`/`match-started`/`match-ended`/`match-paused`/`match-resumed`/`player-command`/`player-timeout`/`player-disconnected`/`player-reconnected`/`desync-detected`) match the `PhalanxEventType` union.
- ✅ All exported types from `src/types/index.ts` (`PhalanxConfig`, `MatchInfo`, `GameTypeConfig`, `TlsConfig`, `AuthConfig`, room events, etc.) are listed and exemplified in the README.
- ✅ Game-mode presets, TLS setup, ready handshake, and private-room recovery sections all map to current source.
- 🚫 No README edits needed; the only related skill update was a Node-version bump (see below).

### phalanx-client
- ✅ `PhalanxClient` API (`create`, `connect`, `disconnect`, `destroy`, `joinQueue`, `waitForMatch`, `joinQueueAndWaitForMatch`, `waitForCountdown`, `waitForGameStart`, `sendReady`, `submitCommands`, `submitCommandsAsync`, `sendCommand`, `onTick`, `onFrame`, `pauseGame`, `resumeGame`, `requestPause`, `requestResume`, `onPause`, `onResume`, `reconnectToMatch`, `attemptReconnection`, `submitStateHash`, `configureDesyncDetection`, state getters, auth methods, `roomRecovery` getter) matches the README.
- ✅ `RoomRecoveryController` surface, helper exports (`isMobileBrowser`, `pickMobileFriendlyTransports`, `loadOrCreateGuestPlayerId`, `RoomPersistence`, `getRecoverTimeoutMs`, `armBrowserLifecycle`, storage adapters), and event taxonomy match the README.
- 🚫 No README edits needed.

### phalanx-ecs
- ✅ Exports in `src/index.ts` (`GameWorld`, `GameWorldEvents`, `EntityManager`, `EventBus`/`globalEventBus`, `SystemRegistry`, `SystemContext`, `GameSystem`, `Entity`/`resetEntityIdCounter`/`nextEntityId`, `IComponent`/`createComponentTypeRegistry`, `ObjectPool`/`EntityPool`/`PoolManager`, `SoAComponent`/`SoAComponentStore`/`defineSoASchema`/`calculateSchemaByteSize`/`TYPED_ARRAY_CONSTRUCTORS`/`FIELD_BYTE_SIZES`, `DebugDataProvider`/`DebugPanel`, `TickFrameManager`) match the README.
- ✅ `GameWorldConfig`, `GameWorldHooks`, `ITickFrameProvider`, and SoA field-type table match the source.
- 🚫 No README edits needed.

### phalanx-physics
- ❌ **Bug fix (docs):** README's quickstart and skill destructured `const { physicsSystem, collisionSystem } = physicsWorld.getSystems()`. The actual return type is `{ physicsSystem: PhysicsSystem }` only — `CollisionSystem` is not exported and the collision pipeline now lives inside `PhysicsSystem`.
- ❌ **Bug fix (docs):** `setCollisionFilter` was documented as a method on a non-existent destructured `collisionSystem`. It is exposed on the `PhysicsWorld` facade (which forwards to `PhysicsSystem.setCollisionFilter`).
- ➕ Added a complete API Reference section covering `PhysicsWorld`, `PhysicsWorldConfig`, `PhysicsBodyComponent`/`PhysicsBodyConfig`, `SpatialHashGrid`, `NarrowPhase`, `CollisionManifold`, `IPhysicsTickProvider`, `AutonomousPhysicsTickProvider` (with the actual `start(onStep)`/`stop()` shape), `ExternalPhysicsTickProvider.tick()`, and the `PhysicsEvents` constants / `CollisionEvent` / `BoundsExitEvent` types.
- ➕ Added an explicit imports block listing every symbol exported from `phalanx-physics/src/index.ts`.
- ➕ Added cross-links to sibling package READMEs and corrected the install snippet (no npm release yet — pnpm workspace).

### Root README
- ➕ Added **phalanx-physics** to Quick Links and the Packages table (it was missing entirely).
- ➕ Added an ASCII architecture diagram showing how server/client/ecs/physics/math fit together via Socket.IO and `ITickFrameProvider`.
- ➕ Added a single-player ECS+Physics quickstart that uses the actual current API (`PhysicsWorld`, `getSystems().physicsSystem`, `setTransformStore`).
- ➕ Replaced the per-package install snippets with a Workspace Commands table sourced from the root `package.json` scripts.
- 🛠 Bumped Node requirement to **24.x** (`>=24.0.0 <25.0.0`) to match the `engines` field in `package.json` (was previously documented as 18+).

## Skills changes

- **`skills/phalanx-physics/SKILL.md`** — collapsed the `PhysicsSystem` + `CollisionSystem` two-system narrative into the single `PhysicsSystem` that ships today; rewrote the per-tick pipeline diagram; routed `setCollisionFilter` through `PhysicsWorld`; rewrote the exports section and added the tick-provider exports; added a callout that `CollisionSystem` is intentionally not exported.
- **`skills/phalanx-server/SKILL.md`** — added `phalanx-physics/` to the repo layout block; bumped Node requirement to 24.x.
- **`skills/phalanx-client/SKILL.md`** — bumped Node requirement to 24.x.
- **`skills/phalanx-ecs/SKILL.md`** — no edits needed; the documented `GameWorld` / `EntityManager` / `EventBus` / `TickFrameManager` API matches `src/index.ts` exports.

## Constraints honored

- No source code was changed — only `*.md` files under the four package READMEs, the root README, and `skills/`.
- No new skill files were created (skill for `phalanx-math` does not exist; per the brief I did not create one).
- All cross-package links are relative and resolve within the repo.

## TODOs / ambiguities

- `CollisionFilter` (bitmask interface) is exported from `phalanx-physics` but the source code annotates it as "Defined for future use. Not yet integrated into PhysicsSystem." It is left documented as a type export but flagged as planned-for-v2 in the existing README — no docs edits made on that front.
- `phalanx-math` has its own README that I did not audit in this pass; it was outside the four-package scope of the request and there is no `skills/phalanx-math` to update.

## Test plan

- [ ] Render each updated README on GitHub and confirm tables, diagrams, and code fences look correct.
- [ ] Spot-check the physics quickstart against `direct-strike-babylon-example/` / `chapaev/` to confirm the `getSystems()` destructuring pattern matches what real consumers do today.
- [ ] Have a maintainer eyeball the architecture diagram in the root README for accuracy of the dependency arrows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)