### PR TITLE
fix: allow better-sqlite3 to run install scripts under pnpm v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
   "engines": {
     "node": ">=24.0.0 <25.0.0"
   },
+  "pnpm": {
+    "onlyBuiltDependencies": ["better-sqlite3"]
+  },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",


### PR DESCRIPTION
pnpm v10 no longer runs lifecycle scripts for any package by default. Add better-sqlite3 to pnpm.onlyBuiltDependencies so node-pre-gyp (prebuild-install || node-gyp rebuild) runs during pnpm install on Render, compiling the native addon for the target platform.