### PR TITLE
Feat/abilities

### DIFF
--- a/phalanx-abilities/package.json
+++ b/phalanx-abilities/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "phalanx-abilities",
+  "version": "0.1.0",
+  "description": "Deterministic gameplay ability system for Phalanx Engine",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf dist",
+    "rebuild": "npm run clean && npm run build",
+    "test": "vitest run"
+  },
+  "peerDependencies": {
+    "phalanx-ecs": "^0.1.0",
+    "phalanx-math": "^0.1.0"
+  },
+  "devDependencies": {
+    "phalanx-ecs": "workspace:*",
+    "phalanx-math": "workspace:*",
+    "typescript": "~5.9.3",
+    "vitest": "^1.0.0"
+  },
+  "keywords": [
+    "abilities",
+    "gameplay-ability-system",
+    "deterministic",
+    "fixed-point",
+    "ecs",
+    "phalanx"
+  ]
+}

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -1,0 +1,65 @@
+import type { EntityManager } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FixedPoint } from 'phalanx-math';
+import { AbilitiesComponentType, AttributesComponent } from '../components';
+import type { AbilitySystemRegistries } from '../registry';
+
+export interface AttributeValue {
+  base: FixedPoint;
+  current: FixedPoint;
+}
+
+export class AbilitySystemFacade {
+  public constructor(
+    private readonly entityManager: EntityManager,
+    private readonly registries: AbilitySystemRegistries
+  ) {}
+
+  public initAttributesForEntity(entityId: number): AttributesComponent {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      throw new Error(`Entity ${entityId} does not exist`);
+    }
+
+    const existing = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+
+    if (existing) {
+      return existing;
+    }
+
+    const attributes = new AttributesComponent(this.registries.attributes.size);
+    const defs = this.registries.attributes.values();
+
+    for (let index = 0; index < defs.length; index++) {
+      const rawDefault = FP.ToRaw(defs[index].default);
+      attributes.base[index] = rawDefault;
+      attributes.current[index] = rawDefault;
+    }
+
+    entity.addComponent(attributes);
+    this.entityManager.onComponentAdded(entity, attributes.type);
+
+    return attributes;
+  }
+
+  public getAttribute(entityId: number, attrId: string): AttributeValue {
+    const entity = this.entityManager.getEntity(entityId);
+
+    if (!entity) {
+      throw new Error(`Entity ${entityId} does not exist`);
+    }
+
+    const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+
+    if (!attributes) {
+      throw new Error(`Entity ${entityId} does not have AttributesComponent`);
+    }
+
+    const index = this.registries.attributes.indexOf(attrId);
+
+    return {
+      base: FP.FromRaw(attributes.base[index]),
+      current: FP.FromRaw(attributes.current[index]),
+    };
+  }
+}

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -34,6 +34,10 @@ export class AbilitySystemFacade {
       const rawDefault = FP.ToRaw(defs[index].default);
       attributes.base[index] = rawDefault;
       attributes.current[index] = rawDefault;
+      // Mark every attribute dirty so AttributeAggregationSystem clamps the
+      // seeded default value on the next tick. Without this, a default that
+      // violates its own min/max would silently persist in `current`.
+      attributes.dirty[index] = 1;
     }
 
     entity.addComponent(attributes);
@@ -43,19 +47,43 @@ export class AbilitySystemFacade {
   }
 
   public getAttribute(entityId: number, attrId: string): AttributeValue {
-    const entity = this.entityManager.getEntity(entityId);
+    const value = this.tryGetAttribute(entityId, attrId);
+    if (!value) {
+      // Differentiate which precondition failed so callers get a useful message.
+      const entity = this.entityManager.getEntity(entityId);
+      if (!entity) {
+        throw new Error(`Entity ${entityId} does not exist`);
+      }
+      if (!entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes)) {
+        throw new Error(`Entity ${entityId} does not have AttributesComponent`);
+      }
+      throw new Error(`AttributeRegistry does not contain '${attrId}'`);
+    }
+    return value;
+  }
 
+  /**
+   * Non-throwing read. Returns `undefined` when the entity is missing, has no
+   * {@link AttributesComponent}, or the attribute id is not registered. Useful
+   * for user-side damage pipelines that need to fall back to a neutral value
+   * (e.g. `IncomingDamageMultiplier === 1`) when the target has no abilities
+   * setup.
+   */
+  public tryGetAttribute(entityId: number, attrId: string): AttributeValue | undefined {
+    const entity = this.entityManager.getEntity(entityId);
     if (!entity) {
-      throw new Error(`Entity ${entityId} does not exist`);
+      return undefined;
     }
 
     const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
-
     if (!attributes) {
-      throw new Error(`Entity ${entityId} does not have AttributesComponent`);
+      return undefined;
     }
 
-    const index = this.registries.attributes.indexOf(attrId);
+    const index = this.registries.attributes.indexOfOrMinusOne(attrId);
+    if (index === -1) {
+      return undefined;
+    }
 
     return {
       base: FP.FromRaw(attributes.base[index]),

--- a/phalanx-abilities/src/api/defineAbility.ts
+++ b/phalanx-abilities/src/api/defineAbility.ts
@@ -1,0 +1,11 @@
+import type { AbilityDef } from '../types';
+
+export function defineAbility(def: AbilityDef): AbilityDef {
+  return {
+    ...def,
+    tagsRequired: def.tagsRequired ? [...def.tagsRequired] : undefined,
+    activationBlockedTags: def.activationBlockedTags ? [...def.activationBlockedTags] : undefined,
+    selfEffectIds: def.selfEffectIds ? [...def.selfEffectIds] : undefined,
+    targetEffectIds: def.targetEffectIds ? [...def.targetEffectIds] : undefined,
+  };
+}

--- a/phalanx-abilities/src/api/defineAttribute.ts
+++ b/phalanx-abilities/src/api/defineAttribute.ts
@@ -1,0 +1,5 @@
+import type { AttributeDef } from '../types';
+
+export function defineAttribute(def: AttributeDef): AttributeDef {
+  return { ...def };
+}

--- a/phalanx-abilities/src/api/defineEffect.ts
+++ b/phalanx-abilities/src/api/defineEffect.ts
@@ -1,0 +1,16 @@
+import type { EffectDef, Modifier } from '../types';
+
+export type EffectDefInput = Omit<EffectDef, 'modifiers'> & {
+  modifiers?: Modifier[];
+};
+
+export function defineEffect(def: EffectDefInput): EffectDef {
+  return {
+    ...def,
+    modifiers: def.modifiers ? [...def.modifiers] : [],
+    tagsGranted: def.tagsGranted ? [...def.tagsGranted] : undefined,
+    tagsRequired: def.tagsRequired ? [...def.tagsRequired] : undefined,
+    tagsBlocked: def.tagsBlocked ? [...def.tagsBlocked] : undefined,
+    cues: def.cues ? [...def.cues] : undefined,
+  };
+}

--- a/phalanx-abilities/src/api/index.ts
+++ b/phalanx-abilities/src/api/index.ts
@@ -1,4 +1,6 @@
 export { defineAbility } from './defineAbility';
 export { defineAttribute } from './defineAttribute';
 export { defineEffect } from './defineEffect';
+export { AbilitySystemFacade } from './AbilitySystemFacade';
+export type { AttributeValue } from './AbilitySystemFacade';
 export type { EffectDefInput } from './defineEffect';

--- a/phalanx-abilities/src/api/index.ts
+++ b/phalanx-abilities/src/api/index.ts
@@ -1,0 +1,4 @@
+export { defineAbility } from './defineAbility';
+export { defineAttribute } from './defineAttribute';
+export { defineEffect } from './defineEffect';
+export type { EffectDefInput } from './defineEffect';

--- a/phalanx-abilities/src/components/AbilitiesComponentType.ts
+++ b/phalanx-abilities/src/components/AbilitiesComponentType.ts
@@ -1,0 +1,6 @@
+import { createComponentTypeRegistry } from 'phalanx-ecs';
+
+export const AbilitiesComponentType = createComponentTypeRegistry({
+  Attributes: 'phalanx-abilities:Attributes',
+  ActiveEffects: 'phalanx-abilities:ActiveEffects',
+});

--- a/phalanx-abilities/src/components/ActiveEffectsComponent.ts
+++ b/phalanx-abilities/src/components/ActiveEffectsComponent.ts
@@ -1,0 +1,14 @@
+import type { IComponent } from 'phalanx-ecs';
+import type { ActiveEffectInstance } from '../types';
+import { AbilitiesComponentType } from './AbilitiesComponentType';
+
+export interface PendingEffectAdd {
+  defId: string;
+  sourceEntityId: number;
+}
+
+export class ActiveEffectsComponent implements IComponent {
+  public readonly type = AbilitiesComponentType.ActiveEffects;
+  public readonly queue: ActiveEffectInstance[] = [];
+  public readonly pendingAdd: PendingEffectAdd[] = [];
+}

--- a/phalanx-abilities/src/components/AttributesComponent.ts
+++ b/phalanx-abilities/src/components/AttributesComponent.ts
@@ -1,0 +1,19 @@
+import type { IComponent } from 'phalanx-ecs';
+import { AbilitiesComponentType } from './AbilitiesComponentType';
+
+export class AttributesComponent implements IComponent {
+  public readonly type = AbilitiesComponentType.Attributes;
+  public readonly base: BigInt64Array;
+  public readonly current: BigInt64Array;
+  public readonly dirty: Uint8Array;
+
+  public constructor(attributeCount: number) {
+    if (!Number.isInteger(attributeCount) || attributeCount < 0) {
+      throw new Error(`attributeCount must be a non-negative integer, got ${attributeCount}`);
+    }
+
+    this.base = new BigInt64Array(attributeCount);
+    this.current = new BigInt64Array(attributeCount);
+    this.dirty = new Uint8Array(attributeCount);
+  }
+}

--- a/phalanx-abilities/src/components/index.ts
+++ b/phalanx-abilities/src/components/index.ts
@@ -1,0 +1,4 @@
+export { AbilitiesComponentType } from './AbilitiesComponentType';
+export { ActiveEffectsComponent } from './ActiveEffectsComponent';
+export type { PendingEffectAdd } from './ActiveEffectsComponent';
+export { AttributesComponent } from './AttributesComponent';

--- a/phalanx-abilities/src/index.ts
+++ b/phalanx-abilities/src/index.ts
@@ -1,0 +1,4 @@
+export * from './api';
+export * from './registry';
+export type * from './spatial';
+export type * from './types';

--- a/phalanx-abilities/src/index.ts
+++ b/phalanx-abilities/src/index.ts
@@ -1,4 +1,6 @@
 export * from './api';
+export * from './components';
 export * from './registry';
+export * from './systems';
 export type * from './spatial';
 export type * from './types';

--- a/phalanx-abilities/src/registry/AbilityHooksRegistry.ts
+++ b/phalanx-abilities/src/registry/AbilityHooksRegistry.ts
@@ -1,0 +1,34 @@
+import type { AbilityHook } from '../types';
+
+export class AbilityHooksRegistry {
+  private readonly hooks = new Map<string, AbilityHook>();
+
+  public register(hookId: string, hook: AbilityHook): void {
+    if (this.hooks.has(hookId)) {
+      throw new Error(`AbilityHooksRegistry already contains '${hookId}'`);
+    }
+
+    this.hooks.set(hookId, hook);
+  }
+
+  public get(hookId: string): AbilityHook {
+    const hook = this.hooks.get(hookId);
+    if (!hook) {
+      throw new Error(`AbilityHooksRegistry does not contain '${hookId}'`);
+    }
+
+    return hook;
+  }
+
+  public tryGet(hookId: string): AbilityHook | undefined {
+    return this.hooks.get(hookId);
+  }
+
+  public has(hookId: string): boolean {
+    return this.hooks.has(hookId);
+  }
+
+  public get size(): number {
+    return this.hooks.size;
+  }
+}

--- a/phalanx-abilities/src/registry/AbilityRegistry.ts
+++ b/phalanx-abilities/src/registry/AbilityRegistry.ts
@@ -1,0 +1,6 @@
+import type { AbilityDef } from '../types';
+import { DefinitionRegistry } from './DefinitionRegistry';
+
+export class AbilityRegistry extends DefinitionRegistry<AbilityDef> {
+  protected readonly registryName = 'AbilityRegistry';
+}

--- a/phalanx-abilities/src/registry/AbilitySystemRegistries.ts
+++ b/phalanx-abilities/src/registry/AbilitySystemRegistries.ts
@@ -1,0 +1,20 @@
+import { AbilityHooksRegistry } from './AbilityHooksRegistry';
+import { AbilityRegistry } from './AbilityRegistry';
+import { AttributeRegistry } from './AttributeRegistry';
+import { EffectRegistry } from './EffectRegistry';
+
+export interface AbilitySystemRegistries {
+  attributes: AttributeRegistry;
+  effects: EffectRegistry;
+  abilities: AbilityRegistry;
+  hooks: AbilityHooksRegistry;
+}
+
+export function createAbilitySystemRegistries(): AbilitySystemRegistries {
+  return {
+    attributes: new AttributeRegistry(),
+    effects: new EffectRegistry(),
+    abilities: new AbilityRegistry(),
+    hooks: new AbilityHooksRegistry(),
+  };
+}

--- a/phalanx-abilities/src/registry/AttributeRegistry.ts
+++ b/phalanx-abilities/src/registry/AttributeRegistry.ts
@@ -4,8 +4,13 @@ import { DefinitionRegistry } from './DefinitionRegistry';
 export class AttributeRegistry extends DefinitionRegistry<AttributeDef> {
   protected readonly registryName = 'AttributeRegistry';
 
+  /**
+   * O(1) lookup of the attribute's storage index. Throws when the attribute
+   * is not registered. Hot path: called by {@link AbilitySystemFacade.getAttribute}
+   * and by effect-application code that resolves `Modifier.attributeId` to an index.
+   */
   public indexOf(id: string): number {
-    const index = this.values().findIndex(def => def.id === id);
+    const index = this.indexOfOrMinusOne(id);
     if (index === -1) {
       throw new Error(`${this.registryName} does not contain '${id}'`);
     }

--- a/phalanx-abilities/src/registry/AttributeRegistry.ts
+++ b/phalanx-abilities/src/registry/AttributeRegistry.ts
@@ -1,0 +1,15 @@
+import type { AttributeDef } from '../types';
+import { DefinitionRegistry } from './DefinitionRegistry';
+
+export class AttributeRegistry extends DefinitionRegistry<AttributeDef> {
+  protected readonly registryName = 'AttributeRegistry';
+
+  public indexOf(id: string): number {
+    const index = this.values().findIndex(def => def.id === id);
+    if (index === -1) {
+      throw new Error(`${this.registryName} does not contain '${id}'`);
+    }
+
+    return index;
+  }
+}

--- a/phalanx-abilities/src/registry/DefinitionRegistry.ts
+++ b/phalanx-abilities/src/registry/DefinitionRegistry.ts
@@ -1,0 +1,39 @@
+export abstract class DefinitionRegistry<TDef extends { id: string }> {
+  private readonly defs = new Map<string, TDef>();
+
+  public register(def: TDef): TDef {
+    if (this.defs.has(def.id)) {
+      throw new Error(`${this.registryName} already contains '${def.id}'`);
+    }
+
+    this.defs.set(def.id, def);
+    return def;
+  }
+
+  public get(id: string): TDef {
+    const def = this.defs.get(id);
+    if (!def) {
+      throw new Error(`${this.registryName} does not contain '${id}'`);
+    }
+
+    return def;
+  }
+
+  public tryGet(id: string): TDef | undefined {
+    return this.defs.get(id);
+  }
+
+  public has(id: string): boolean {
+    return this.defs.has(id);
+  }
+
+  public values(): readonly TDef[] {
+    return Array.from(this.defs.values());
+  }
+
+  public get size(): number {
+    return this.defs.size;
+  }
+
+  protected abstract readonly registryName: string;
+}

--- a/phalanx-abilities/src/registry/DefinitionRegistry.ts
+++ b/phalanx-abilities/src/registry/DefinitionRegistry.ts
@@ -1,11 +1,17 @@
 export abstract class DefinitionRegistry<TDef extends { id: string }> {
   private readonly defs = new Map<string, TDef>();
+  /** Stable insertion-ordered array of registered definitions. */
+  private readonly defsArray: TDef[] = [];
+  /** id -> index in defsArray; kept in sync with defsArray. */
+  private readonly indexById = new Map<string, number>();
 
   public register(def: TDef): TDef {
     if (this.defs.has(def.id)) {
       throw new Error(`${this.registryName} already contains '${def.id}'`);
     }
 
+    this.indexById.set(def.id, this.defsArray.length);
+    this.defsArray.push(def);
     this.defs.set(def.id, def);
     return def;
   }
@@ -27,12 +33,30 @@ export abstract class DefinitionRegistry<TDef extends { id: string }> {
     return this.defs.has(id);
   }
 
+  /**
+   * Returns the stable insertion-ordered array of registered definitions.
+   *
+   * The same array reference is returned across calls (no per-call
+   * allocation); callers MUST NOT mutate it. Insertion order is the
+   * canonical attribute/effect index used by SoA-style components such as
+   * {@link AttributesComponent}.
+   */
   public values(): readonly TDef[] {
-    return Array.from(this.defs.values());
+    return this.defsArray;
+  }
+
+  /**
+   * O(1) lookup of the insertion index of `id`. Returns `-1` if the id is
+   * not registered. Subclasses (e.g. {@link AttributeRegistry}) may throw
+   * a typed error instead.
+   */
+  public indexOfOrMinusOne(id: string): number {
+    const index = this.indexById.get(id);
+    return index === undefined ? -1 : index;
   }
 
   public get size(): number {
-    return this.defs.size;
+    return this.defsArray.length;
   }
 
   protected abstract readonly registryName: string;

--- a/phalanx-abilities/src/registry/EffectRegistry.ts
+++ b/phalanx-abilities/src/registry/EffectRegistry.ts
@@ -1,0 +1,6 @@
+import type { EffectDef } from '../types';
+import { DefinitionRegistry } from './DefinitionRegistry';
+
+export class EffectRegistry extends DefinitionRegistry<EffectDef> {
+  protected readonly registryName = 'EffectRegistry';
+}

--- a/phalanx-abilities/src/registry/index.ts
+++ b/phalanx-abilities/src/registry/index.ts
@@ -1,0 +1,6 @@
+export { AbilityHooksRegistry } from './AbilityHooksRegistry';
+export { AbilityRegistry } from './AbilityRegistry';
+export { AttributeRegistry } from './AttributeRegistry';
+export { EffectRegistry } from './EffectRegistry';
+export { createAbilitySystemRegistries } from './AbilitySystemRegistries';
+export type { AbilitySystemRegistries } from './AbilitySystemRegistries';

--- a/phalanx-abilities/src/spatial/ISpatialQuery.ts
+++ b/phalanx-abilities/src/spatial/ISpatialQuery.ts
@@ -1,0 +1,5 @@
+import type { FixedPoint } from 'phalanx-math';
+
+export interface ISpatialQuery {
+  queryRadius(x: FixedPoint, z: FixedPoint, radius: FixedPoint): number[];
+}

--- a/phalanx-abilities/src/spatial/index.ts
+++ b/phalanx-abilities/src/spatial/index.ts
@@ -1,0 +1,1 @@
+export type { ISpatialQuery } from './ISpatialQuery';

--- a/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
+++ b/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
@@ -1,0 +1,85 @@
+import { GameSystem } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FixedPoint } from 'phalanx-math';
+import { ActiveEffectsComponent, AttributesComponent, AbilitiesComponentType } from '../components';
+import type { AbilitySystemRegistries } from '../registry';
+import type { AttributeDef, ModifierOp } from '../types';
+
+export class AttributeAggregationSystem extends GameSystem {
+  public constructor(private readonly registries: AbilitySystemRegistries) {
+    super();
+  }
+
+  public override processTick(_tick: number): void {
+    const entities = this.entityManager.queryEntities(AbilitiesComponentType.Attributes);
+    const attributeDefs = this.registries.attributes.values();
+
+    for (const entity of entities) {
+      const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+      if (!attributes) {
+        continue;
+      }
+
+      const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+        AbilitiesComponentType.ActiveEffects
+      );
+      const orderedEffects = activeEffects
+        ? [...activeEffects.queue].sort((a, b) => a.instanceId - b.instanceId)
+        : [];
+
+      for (let attributeIndex = 0; attributeIndex < attributes.dirty.length; attributeIndex++) {
+        if (attributes.dirty[attributeIndex] === 0) {
+          continue;
+        }
+
+        const attributeDef = attributeDefs[attributeIndex];
+        if (!attributeDef) {
+          throw new Error(`AttributeRegistry does not contain index ${attributeIndex}`);
+        }
+
+        let value = FP.FromRaw(attributes.base[attributeIndex]);
+        for (const activeEffect of orderedEffects) {
+          const effectDef = this.registries.effects.get(activeEffect.defId);
+          for (const modifier of effectDef.modifiers) {
+            if (modifier.attributeId !== attributeDef.id) {
+              continue;
+            }
+
+            value = applyModifier(value, modifier.op, modifier.magnitude);
+          }
+        }
+
+        attributes.current[attributeIndex] = FP.ToRaw(clampAttribute(value, attributeDef));
+        attributes.dirty[attributeIndex] = 0;
+      }
+    }
+  }
+}
+
+function applyModifier(
+  value: FixedPoint,
+  op: ModifierOp,
+  magnitude: FixedPoint
+): FixedPoint {
+  switch (op) {
+    case 'Add':
+      return FP.Add(value, magnitude);
+    case 'Multiply':
+      return FP.Mul(value, magnitude);
+    case 'Override':
+      return magnitude;
+  }
+}
+
+function clampAttribute(value: FixedPoint, def: AttributeDef): FixedPoint {
+  switch (def.clamp) {
+    case 'both':
+      return FP.Clamp(value, def.min, def.max);
+    case 'min':
+      return FP.Max(value, def.min);
+    case 'max':
+      return FP.Min(value, def.max);
+    case 'none':
+      return value;
+  }
+}

--- a/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
+++ b/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
@@ -1,11 +1,39 @@
 import { GameSystem } from 'phalanx-ecs';
 import { FP } from 'phalanx-math';
 import type { FixedPoint } from 'phalanx-math';
-import { ActiveEffectsComponent, AttributesComponent, AbilitiesComponentType } from '../components';
+import {
+  ActiveEffectsComponent,
+  AttributesComponent,
+  AbilitiesComponentType,
+} from '../components';
 import type { AbilitySystemRegistries } from '../registry';
-import type { AttributeDef, ModifierOp } from '../types';
+import type { ActiveEffectInstance, AttributeDef, EffectDef, ModifierOp } from '../types';
 
+/**
+ * Reusable per-tick buffer reused across entities to avoid per-entity allocations
+ * when re-ordering the active effect queue. Sorted copy of the entity's queue.
+ */
+type OrderedEffectsBuffer = ActiveEffectInstance[];
+
+/**
+ * Resolves attribute `current` values from `base` + active effects.
+ *
+ * Determinism contract:
+ *  - Modifiers are applied in FIFO `instanceId` ASC order.
+ *  - Within a single effect, modifiers are applied in declaration order.
+ *  - Clamping is applied last, per {@link AttributeDef.clamp}.
+ *
+ * Performance contract:
+ *  - Skips entities with no dirty attributes (no sort, no allocations).
+ *  - Resolves each effect's {@link EffectDef} at most once per entity per tick.
+ *  - Reuses an internal buffer for the ordered queue (no per-entity array allocation).
+ *  - `EffectApplicationSystem` is expected to insert into `ActiveEffectsComponent.queue`
+ *    in `instanceId` ASC order so the sort is a no-op cheap pass; the system still
+ *    sorts defensively to remain correct if test code or future systems push out of order.
+ */
 export class AttributeAggregationSystem extends GameSystem {
+  private readonly orderedEffectsBuffer: OrderedEffectsBuffer = [];
+
   public constructor(private readonly registries: AbilitySystemRegistries) {
     super();
   }
@@ -15,17 +43,24 @@ export class AttributeAggregationSystem extends GameSystem {
     const attributeDefs = this.registries.attributes.values();
 
     for (const entity of entities) {
-      const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+      const attributes = entity.getComponent<AttributesComponent>(
+        AbilitiesComponentType.Attributes
+      );
       if (!attributes) {
+        continue;
+      }
+
+      // Early exit: skip all work when no attribute is dirty on this entity.
+      if (!hasAnyDirty(attributes.dirty)) {
         continue;
       }
 
       const activeEffects = entity.getComponent<ActiveEffectsComponent>(
         AbilitiesComponentType.ActiveEffects
       );
-      const orderedEffects = activeEffects
-        ? [...activeEffects.queue].sort((a, b) => a.instanceId - b.instanceId)
-        : [];
+      const orderedEffects = this.takeOrderedEffects(activeEffects);
+      // Resolve each EffectDef once per entity per tick instead of per dirty attribute.
+      const resolvedEffectDefs = this.resolveEffectDefs(orderedEffects);
 
       for (let attributeIndex = 0; attributeIndex < attributes.dirty.length; attributeIndex++) {
         if (attributes.dirty[attributeIndex] === 0) {
@@ -38,8 +73,8 @@ export class AttributeAggregationSystem extends GameSystem {
         }
 
         let value = FP.FromRaw(attributes.base[attributeIndex]);
-        for (const activeEffect of orderedEffects) {
-          const effectDef = this.registries.effects.get(activeEffect.defId);
+        for (let i = 0; i < resolvedEffectDefs.length; i++) {
+          const effectDef = resolvedEffectDefs[i];
           for (const modifier of effectDef.modifiers) {
             if (modifier.attributeId !== attributeDef.id) {
               continue;
@@ -54,6 +89,61 @@ export class AttributeAggregationSystem extends GameSystem {
       }
     }
   }
+
+  /**
+   * Returns the entity's effect queue ordered by `instanceId` ASC. Writes into
+   * a system-owned buffer to avoid allocating a fresh array per entity per tick.
+   * Sort is skipped when the queue is already sorted (the common case under
+   * monotonic insertion by `EffectApplicationSystem`).
+   */
+  private takeOrderedEffects(
+    activeEffects: ActiveEffectsComponent | undefined
+  ): readonly ActiveEffectInstance[] {
+    const buffer = this.orderedEffectsBuffer;
+    buffer.length = 0;
+    if (!activeEffects) {
+      return buffer;
+    }
+
+    const queue = activeEffects.queue;
+    let alreadySorted = true;
+    for (let i = 0; i < queue.length; i++) {
+      buffer.push(queue[i]);
+      if (i > 0 && queue[i - 1].instanceId > queue[i].instanceId) {
+        alreadySorted = false;
+      }
+    }
+
+    if (!alreadySorted) {
+      buffer.sort(byInstanceIdAsc);
+    }
+
+    return buffer;
+  }
+
+  private readonly resolvedEffectDefsBuffer: EffectDef[] = [];
+
+  private resolveEffectDefs(orderedEffects: readonly ActiveEffectInstance[]): readonly EffectDef[] {
+    const buffer = this.resolvedEffectDefsBuffer;
+    buffer.length = 0;
+    for (let i = 0; i < orderedEffects.length; i++) {
+      buffer.push(this.registries.effects.get(orderedEffects[i].defId));
+    }
+    return buffer;
+  }
+}
+
+function byInstanceIdAsc(a: ActiveEffectInstance, b: ActiveEffectInstance): number {
+  return a.instanceId - b.instanceId;
+}
+
+function hasAnyDirty(dirty: Uint8Array): boolean {
+  for (let i = 0; i < dirty.length; i++) {
+    if (dirty[i] !== 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function applyModifier(

--- a/phalanx-abilities/src/systems/index.ts
+++ b/phalanx-abilities/src/systems/index.ts
@@ -1,0 +1,1 @@
+export { AttributeAggregationSystem } from './AttributeAggregationSystem';

--- a/phalanx-abilities/src/types/AbilityDef.ts
+++ b/phalanx-abilities/src/types/AbilityDef.ts
@@ -1,0 +1,13 @@
+import type { TargetSpec } from './TargetSpec';
+
+export interface AbilityDef {
+  id: string;
+  costEffectId?: string;
+  cooldownEffectId?: string;
+  tagsRequired?: string[];
+  activationBlockedTags?: string[];
+  selfEffectIds?: string[];
+  targetEffectIds?: string[];
+  target: TargetSpec;
+  hookId?: string;
+}

--- a/phalanx-abilities/src/types/AbilityHook.ts
+++ b/phalanx-abilities/src/types/AbilityHook.ts
@@ -1,4 +1,3 @@
-import type { FixedPoint } from 'phalanx-math';
 import type { ProvidedTarget } from './TargetSpec';
 
 export interface AbilityActivationContext {
@@ -10,8 +9,3 @@ export interface AbilityActivationContext {
 }
 
 export type AbilityHook = (ctx: AbilityActivationContext) => void;
-
-export interface AbilityActivationPoint {
-  x: FixedPoint;
-  z: FixedPoint;
-}

--- a/phalanx-abilities/src/types/AbilityHook.ts
+++ b/phalanx-abilities/src/types/AbilityHook.ts
@@ -1,0 +1,17 @@
+import type { FixedPoint } from 'phalanx-math';
+import type { ProvidedTarget } from './TargetSpec';
+
+export interface AbilityActivationContext {
+  abilityId: string;
+  casterEntityId: number;
+  resolvedTargets: number[];
+  providedTarget?: ProvidedTarget;
+  tick: number;
+}
+
+export type AbilityHook = (ctx: AbilityActivationContext) => void;
+
+export interface AbilityActivationPoint {
+  x: FixedPoint;
+  z: FixedPoint;
+}

--- a/phalanx-abilities/src/types/ActiveEffectInstance.ts
+++ b/phalanx-abilities/src/types/ActiveEffectInstance.ts
@@ -1,0 +1,9 @@
+export interface ActiveEffectInstance {
+  /** Monotonic id used for deterministic FIFO modifier aggregation. */
+  instanceId: number;
+  defId: string;
+  remainingTicks: number;
+  /** Only meaningful for Periodic effects. */
+  nextPeriodTick: number;
+  sourceEntityId: number;
+}

--- a/phalanx-abilities/src/types/AttributeDef.ts
+++ b/phalanx-abilities/src/types/AttributeDef.ts
@@ -1,0 +1,11 @@
+import type { FixedPoint } from 'phalanx-math';
+
+export type AttributeClampMode = 'both' | 'min' | 'max' | 'none';
+
+export interface AttributeDef {
+  id: string;
+  default: FixedPoint;
+  min: FixedPoint;
+  max: FixedPoint;
+  clamp: AttributeClampMode;
+}

--- a/phalanx-abilities/src/types/AuraComponent.ts
+++ b/phalanx-abilities/src/types/AuraComponent.ts
@@ -1,0 +1,10 @@
+import type { TargetSpec } from './TargetSpec';
+
+export interface AuraComponent {
+  abilityId: string;
+  target: TargetSpec;
+  effectIds: string[];
+  periodTicks: number;
+  nextTick: number;
+  ownerEntityId: number;
+}

--- a/phalanx-abilities/src/types/CueEvent.ts
+++ b/phalanx-abilities/src/types/CueEvent.ts
@@ -1,0 +1,6 @@
+export interface CueEvent {
+  tick: number;
+  cueId: string;
+  sourceEntityId: number;
+  targetEntityId: number;
+}

--- a/phalanx-abilities/src/types/EffectDef.ts
+++ b/phalanx-abilities/src/types/EffectDef.ts
@@ -1,0 +1,19 @@
+import type { Modifier } from './ModifierOp';
+
+export type EffectType = 'Instant' | 'Duration' | 'Periodic';
+
+export interface EffectDef {
+  id: string;
+  type: EffectType;
+  /** Only for Duration and Periodic effects. Stored as whole simulation ticks. */
+  durationTicks?: number;
+  /** Only for Periodic effects. Stored as whole simulation ticks. */
+  periodTicks?: number;
+  /** If true, a Periodic effect executes once immediately when applied. */
+  executePeriodicOnApplication?: boolean;
+  modifiers: Modifier[];
+  tagsGranted?: string[];
+  tagsRequired?: string[];
+  tagsBlocked?: string[];
+  cues?: string[];
+}

--- a/phalanx-abilities/src/types/ModifierOp.ts
+++ b/phalanx-abilities/src/types/ModifierOp.ts
@@ -1,0 +1,9 @@
+import type { FixedPoint } from 'phalanx-math';
+
+export type ModifierOp = 'Add' | 'Multiply' | 'Override';
+
+export interface Modifier {
+  attributeId: string;
+  op: ModifierOp;
+  magnitude: FixedPoint;
+}

--- a/phalanx-abilities/src/types/TargetSpec.ts
+++ b/phalanx-abilities/src/types/TargetSpec.ts
@@ -1,0 +1,31 @@
+import type { FixedPoint } from 'phalanx-math';
+
+export type TargetOrigin =
+  | { kind: 'Caster' }
+  | { kind: 'TargetEntity'; entityId: number }
+  | { kind: 'Point'; x: FixedPoint; z: FixedPoint }
+  | { kind: 'Caller' };
+
+export interface TargetFilter {
+  tagsRequired?: string[];
+  tagsBlocked?: string[];
+}
+
+export type TargetSpec =
+  | { kind: 'Self' }
+  | { kind: 'Entity'; origin: TargetOrigin }
+  | { kind: 'Point'; origin: TargetOrigin }
+  | {
+      kind: 'Radius';
+      origin: TargetOrigin;
+      radius: FixedPoint;
+      maxTargets?: number;
+      filter?: TargetFilter;
+      includeSelf?: boolean;
+    };
+
+export interface ProvidedTarget {
+  entityId?: number;
+  x?: FixedPoint;
+  z?: FixedPoint;
+}

--- a/phalanx-abilities/src/types/index.ts
+++ b/phalanx-abilities/src/types/index.ts
@@ -1,0 +1,9 @@
+export type { AttributeClampMode, AttributeDef } from './AttributeDef';
+export type { ActiveEffectInstance } from './ActiveEffectInstance';
+export type { AbilityDef } from './AbilityDef';
+export type { AbilityActivationContext, AbilityActivationPoint, AbilityHook } from './AbilityHook';
+export type { AuraComponent } from './AuraComponent';
+export type { CueEvent } from './CueEvent';
+export type { EffectDef, EffectType } from './EffectDef';
+export type { Modifier, ModifierOp } from './ModifierOp';
+export type { ProvidedTarget, TargetFilter, TargetOrigin, TargetSpec } from './TargetSpec';

--- a/phalanx-abilities/src/types/index.ts
+++ b/phalanx-abilities/src/types/index.ts
@@ -1,7 +1,7 @@
 export type { AttributeClampMode, AttributeDef } from './AttributeDef';
 export type { ActiveEffectInstance } from './ActiveEffectInstance';
 export type { AbilityDef } from './AbilityDef';
-export type { AbilityActivationContext, AbilityActivationPoint, AbilityHook } from './AbilityHook';
+export type { AbilityActivationContext, AbilityHook } from './AbilityHook';
 export type { AuraComponent } from './AuraComponent';
 export type { CueEvent } from './CueEvent';
 export type { EffectDef, EffectType } from './EffectDef';

--- a/phalanx-abilities/tests/attributes.test.ts
+++ b/phalanx-abilities/tests/attributes.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+import { Entity, GameWorld } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  AbilitySystemFacade,
+  ActiveEffectsComponent,
+  AttributeAggregationSystem,
+  createAbilitySystemRegistries,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+
+describe('attributes and aggregation', () => {
+  it('initializes attributes from the registry and reads them through the facade', () => {
+    const { world, facade } = createTestWorld();
+    const entity = addEntity(world);
+
+    const attributes = facade.initAttributesForEntity(entity.id);
+
+    expect(attributes.base.length).toBe(2);
+    expect(attributes.current.length).toBe(2);
+    expect([...attributes.dirty]).toEqual([0, 0]);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(100);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Mana').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('aggregates Add, Multiply, and Override modifiers in instanceId FIFO order', () => {
+    const { world, facade, registries } = createTestWorld();
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+    const activeEffects = attachActiveEffects(world, entity);
+
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.AddHealth',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(5) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.DoubleHealth',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Health', op: 'Multiply', magnitude: FP.FromInt(2) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.OverrideHealth',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Health', op: 'Override', magnitude: FP.FromInt(20) }],
+      })
+    );
+
+    activeEffects.queue.push(
+      {
+        instanceId: 3,
+        defId: 'Effect.OverrideHealth',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: 1,
+      },
+      {
+        instanceId: 2,
+        defId: 'Effect.DoubleHealth',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: 1,
+      },
+      {
+        instanceId: 1,
+        defId: 'Effect.AddHealth',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: 1,
+      }
+    );
+    attributes.dirty[0] = 1;
+
+    world.processAllTicks(1);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(20);
+    expect(attributes.dirty[0]).toBe(0);
+
+    world.dispose();
+  });
+
+  it('clamps aggregated values by each attribute clamp mode', () => {
+    const { world, facade, registries } = createTestWorld();
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+    const activeEffects = attachActiveEffects(world, entity);
+
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.BigDelta',
+        type: 'Duration',
+        modifiers: [
+          { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(150) },
+          { attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-100) },
+        ],
+      })
+    );
+
+    activeEffects.queue.push({
+      instanceId: 1,
+      defId: 'Effect.BigDelta',
+      remainingTicks: 10,
+      nextPeriodTick: 0,
+      sourceEntityId: entity.id,
+    });
+    attributes.dirty[0] = 1;
+    attributes.dirty[1] = 1;
+
+    world.processAllTicks(1);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(100);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Mana').current)).toBe(0);
+
+    world.dispose();
+  });
+
+  it('leaves clean attributes unchanged until their dirty flag is set', () => {
+    const { world, facade, registries } = createTestWorld();
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+    const activeEffects = attachActiveEffects(world, entity);
+
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.HealthDamage',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+      })
+    );
+    activeEffects.queue.push({
+      instanceId: 1,
+      defId: 'Effect.HealthDamage',
+      remainingTicks: 10,
+      nextPeriodTick: 0,
+      sourceEntityId: entity.id,
+    });
+
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(100);
+
+    attributes.dirty[0] = 1;
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(90);
+    expect(attributes.dirty[0]).toBe(0);
+
+    world.dispose();
+  });
+
+  it('uses the highest instanceId Override as the final override', () => {
+    const { world, facade, registries } = createTestWorld();
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+    const activeEffects = attachActiveEffects(world, entity);
+
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.OverrideLow',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Mana', op: 'Override', magnitude: FP.FromInt(10) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.OverrideHigh',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'Mana', op: 'Override', magnitude: FP.FromInt(40) }],
+      })
+    );
+
+    activeEffects.queue.push(
+      {
+        instanceId: 2,
+        defId: 'Effect.OverrideHigh',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: entity.id,
+      },
+      {
+        instanceId: 1,
+        defId: 'Effect.OverrideLow',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: entity.id,
+      }
+    );
+    attributes.dirty[1] = 1;
+
+    world.processAllTicks(1);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Mana').current)).toBe(40);
+
+    world.dispose();
+  });
+});
+
+function createTestWorld() {
+  const registries = createAbilitySystemRegistries();
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Health',
+      default: FP.FromInt(100),
+      min: FP.FromInt(0),
+      max: FP.FromInt(100),
+      clamp: 'both',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Mana',
+      default: FP.FromInt(50),
+      min: FP.FromInt(0),
+      max: FP.FromInt(50),
+      clamp: 'both',
+    })
+  );
+
+  const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
+  world.registerSystems([new AttributeAggregationSystem(registries)], []);
+  const facade = new AbilitySystemFacade(world.entityManager, registries);
+
+  return { world, facade, registries };
+}
+
+function addEntity(world: GameWorld): Entity {
+  const entity = new Entity();
+  world.entityManager.addEntity(entity);
+  return entity;
+}
+
+function attachActiveEffects(world: GameWorld, entity: Entity): ActiveEffectsComponent {
+  const activeEffects = entity.addComponent(new ActiveEffectsComponent());
+  world.entityManager.onComponentAdded(entity, activeEffects.type);
+  return activeEffects;
+}

--- a/phalanx-abilities/tests/attributes.test.ts
+++ b/phalanx-abilities/tests/attributes.test.ts
@@ -20,9 +20,174 @@ describe('attributes and aggregation', () => {
 
     expect(attributes.base.length).toBe(2);
     expect(attributes.current.length).toBe(2);
-    expect([...attributes.dirty]).toEqual([0, 0]);
+    // Defaults are marked dirty on init so the aggregation system clamps them
+    // on the next tick. Before the first tick, every attribute is dirty=1.
+    expect([...attributes.dirty]).toEqual([1, 1]);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(100);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Mana').current)).toBe(50);
+
+    // After one tick with no effects, defaults are clamped and dirty is cleared.
+    world.processAllTicks(1);
+    expect([...attributes.dirty]).toEqual([0, 0]);
+
+    world.dispose();
+  });
+
+  it('clamps defaults on the first tick when default violates min/max', () => {
+    const registries = createAbilitySystemRegistries();
+    registries.attributes.register(
+      defineAttribute({
+        id: 'Overcap',
+        // Default is intentionally outside [min, max] to verify clamp on init.
+        default: FP.FromInt(200),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+    const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
+    world.registerSystems([new AttributeAggregationSystem(registries)], []);
+    const facade = new AbilitySystemFacade(world.entityManager, registries);
+
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    // Before the tick: base holds the raw (unclamped) default for accounting.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Overcap').base)).toBe(200);
+
+    world.processAllTicks(1);
+
+    // After one tick: current is clamped to max.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Overcap').current)).toBe(100);
+
+    world.dispose();
+  });
+
+  it('applies each clamp mode (both, min, max, none)', () => {
+    const registries = createAbilitySystemRegistries();
+    registries.attributes.register(
+      defineAttribute({
+        id: 'ClampNone',
+        default: FP.FromInt(0),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'none',
+      })
+    );
+    registries.attributes.register(
+      defineAttribute({
+        id: 'ClampMin',
+        default: FP.FromInt(50),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'min',
+      })
+    );
+    registries.attributes.register(
+      defineAttribute({
+        id: 'ClampMax',
+        default: FP.FromInt(50),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'max',
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.PushNone',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'ClampNone', op: 'Add', magnitude: FP.FromInt(-500) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.PushBelowMin',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'ClampMin', op: 'Add', magnitude: FP.FromInt(-200) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.PushAboveMax',
+        type: 'Duration',
+        modifiers: [{ attributeId: 'ClampMax', op: 'Add', magnitude: FP.FromInt(200) }],
+      })
+    );
+    const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
+    world.registerSystems([new AttributeAggregationSystem(registries)], []);
+    const facade = new AbilitySystemFacade(world.entityManager, registries);
+
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+    const activeEffects = attachActiveEffects(world, entity);
+    activeEffects.queue.push(
+      {
+        instanceId: 1,
+        defId: 'Effect.PushNone',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: entity.id,
+      },
+      {
+        instanceId: 2,
+        defId: 'Effect.PushBelowMin',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: entity.id,
+      },
+      {
+        instanceId: 3,
+        defId: 'Effect.PushAboveMax',
+        remainingTicks: 10,
+        nextPeriodTick: 0,
+        sourceEntityId: entity.id,
+      }
+    );
+    attributes.dirty[0] = 1;
+    attributes.dirty[1] = 1;
+    attributes.dirty[2] = 1;
+
+    world.processAllTicks(1);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'ClampNone').current)).toBe(-500);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'ClampMin').current)).toBe(0);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'ClampMax').current)).toBe(100);
+
+    world.dispose();
+  });
+
+  it('tryGetAttribute returns undefined for missing entity, component, or attribute id', () => {
+    const { world, facade } = createTestWorld();
+
+    // Missing entity.
+    expect(facade.tryGetAttribute(9999, 'Health')).toBeUndefined();
+
+    // Entity exists but has no AttributesComponent.
+    const bare = addEntity(world);
+    expect(facade.tryGetAttribute(bare.id, 'Health')).toBeUndefined();
+
+    // Attribute id is not registered.
+    const equipped = addEntity(world);
+    facade.initAttributesForEntity(equipped.id);
+    expect(facade.tryGetAttribute(equipped.id, 'NotRegistered')).toBeUndefined();
+
+    // Sanity: a real attribute reads back.
+    expect(FP.ToFloat(facade.tryGetAttribute(equipped.id, 'Health')!.base)).toBe(100);
+
+    world.dispose();
+  });
+
+  it('round-trips FixedPoint through raw BigInt storage with bit equality', () => {
+    const { world, facade } = createTestWorld();
+    const entity = addEntity(world);
+    const attributes = facade.initAttributesForEntity(entity.id);
+
+    const sample = FP.FromFloat(12.5);
+    const raw = FP.ToRaw(sample);
+    attributes.base[0] = raw;
+    attributes.current[0] = raw;
+
+    expect(FP.ToRaw(facade.getAttribute(entity.id, 'Health').base)).toBe(raw);
+    expect(FP.ToRaw(facade.getAttribute(entity.id, 'Health').current)).toBe(raw);
 
     world.dispose();
   });
@@ -127,7 +292,6 @@ describe('attributes and aggregation', () => {
     const { world, facade, registries } = createTestWorld();
     const entity = addEntity(world);
     const attributes = facade.initAttributesForEntity(entity.id);
-    const activeEffects = attachActiveEffects(world, entity);
 
     registries.effects.register(
       defineEffect({
@@ -136,6 +300,14 @@ describe('attributes and aggregation', () => {
         modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
       })
     );
+
+    // Tick 1: defaults clamp into current (init marks dirty); dirty clears.
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(100);
+    expect(attributes.dirty[0]).toBe(0);
+
+    // Attach the effect AFTER defaults have settled, without dirtying.
+    const activeEffects = attachActiveEffects(world, entity);
     activeEffects.queue.push({
       instanceId: 1,
       defId: 'Effect.HealthDamage',
@@ -144,11 +316,14 @@ describe('attributes and aggregation', () => {
       sourceEntityId: entity.id,
     });
 
-    world.processAllTicks(1);
+    // Tick 2: dirty is still 0 so the system must NOT recompute Health.
+    world.processAllTicks(2);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(100);
 
+    // Once an external caller (future EffectApplicationSystem) marks it dirty,
+    // aggregation picks up the queued effect and applies it.
     attributes.dirty[0] = 1;
-    world.processAllTicks(2);
+    world.processAllTicks(3);
 
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(90);
     expect(attributes.dirty[0]).toBe(0);

--- a/phalanx-abilities/tests/registry.test.ts
+++ b/phalanx-abilities/tests/registry.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { FP } from 'phalanx-math';
+import {
+  createAbilitySystemRegistries,
+  defineAbility,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+
+describe('ability definition registries', () => {
+  it('registers and reads attribute, effect, ability, and hook definitions', () => {
+    const registries = createAbilitySystemRegistries();
+
+    const health = registries.attributes.register(
+      defineAttribute({
+        id: 'Health',
+        default: FP.FromInt(100),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+
+    const damage = registries.effects.register(
+      defineEffect({
+        id: 'Effect.Damage',
+        type: 'Instant',
+        modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+        cues: ['Cue.Damage.Hit'],
+      })
+    );
+
+    const ability = registries.abilities.register(
+      defineAbility({
+        id: 'Ability.Attack',
+        target: { kind: 'Entity', origin: { kind: 'Caller' } },
+        targetEffectIds: ['Effect.Damage'],
+        hookId: 'Hook.Attack',
+      })
+    );
+
+    registries.hooks.register('Hook.Attack', ctx => {
+      expect(ctx.abilityId).toBe('Ability.Attack');
+    });
+
+    expect(registries.attributes.get('Health')).toBe(health);
+    expect(registries.attributes.indexOf('Health')).toBe(0);
+    expect(registries.effects.get('Effect.Damage')).toBe(damage);
+    expect(registries.abilities.get('Ability.Attack')).toBe(ability);
+    expect(registries.hooks.has('Hook.Attack')).toBe(true);
+  });
+
+  it('keeps registries isolated per world instance', () => {
+    const firstWorldRegistries = createAbilitySystemRegistries();
+    const secondWorldRegistries = createAbilitySystemRegistries();
+
+    firstWorldRegistries.effects.register(
+      defineEffect({
+        id: 'Effect.Cooldown',
+        type: 'Duration',
+        durationTicks: 30,
+        tagsGranted: ['Cooldown.Ability.Attack'],
+      })
+    );
+
+    expect(firstWorldRegistries.effects.has('Effect.Cooldown')).toBe(true);
+    expect(secondWorldRegistries.effects.has('Effect.Cooldown')).toBe(false);
+    expect(firstWorldRegistries.effects.get('Effect.Cooldown').modifiers).toEqual([]);
+  });
+
+  it('rejects duplicate definitions deterministically', () => {
+    const registries = createAbilitySystemRegistries();
+    const effect = defineEffect({ id: 'Effect.Marked', type: 'Duration', durationTicks: 60 });
+
+    registries.effects.register(effect);
+
+    expect(() => registries.effects.register(effect)).toThrow(
+      "EffectRegistry already contains 'Effect.Marked'"
+    );
+  });
+});

--- a/phalanx-abilities/tsconfig.json
+++ b/phalanx-abilities/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "removeComments": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": false,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/phalanx-abilities/tsconfig.json
+++ b/phalanx-abilities/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022"],
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
   - 'phalanx-client'
   - 'phalanx-ecs'
   - 'phalanx-physics'
+  - 'phalanx-abilities'
   - 'game-test'
   - 'game-test-server'
   - 'direct-strike-babylon-example'


### PR DESCRIPTION
This PR covers stages 1 and 2 of this plan

# phalanx-abilities — финальный план разработки

## Обзор

Новый пакет `phalanx-abilities` в монорепо [phalanx-engine](https://github.com/phaeton2040-AI/phalanx-engine).
Адаптация Gameplay Ability System (GAS, UE5) для ECS-архитектуры Phalanx.
Все геймплейные вычисления — на `FixedPoint` из `phalanx-math` для детерминизма в lockstep.

### Соглашения по именованию и зависимостям

- Пакет называется `phalanx-abilities` (без скоупа), согласован с конвенцией репо (`phalanx-ecs`, `phalanx-math`, `phalanx-physics`).
- Добавляется в `pnpm-workspace.yaml`.
- Peer dependencies: `phalanx-ecs`, `phalanx-math`.
- `phalanx-physics` — **не peer dep.** Пространственные запросы инжектируются через интерфейс `ISpatialQuery`.

### Тип Fixed

В коде и DSL используется реальный экспорт `phalanx-math`:

- Тип значения: `FixedPoint`.
- Конструкторы: `FP.FromInt(n)`, `FP.FromFloat(x)`, `FP.FromString(s)`.
- Никаких `Fixed`/`F()` — это устаревшие обозначения из черновика.
- В `EffectDef.duration`/`period` и `ActiveEffectInstance.remainingTicks`/`nextPeriodTick` хранятся **целые тики как `number`**, не `FixedPoint`. Сравниваются с `currentTick: number`, который приходит в `processTick(tick)`.

### MVP: без SoA

В первой версии `AttributesComponent`, `ActiveEffectsComponent`, `GameplayTagsComponent`, `CuePendingQueue` — обычные классы, реализующие `IComponent`. Хранилище — типизированные массивы фиксированной длины (`BigInt64Array` для raw `FixedPoint`, `Uint8Array` для флагов) либо нативные коллекции (`Set`, `Map`, массивы).

Переход на динамически собранную SoA-схему — задача v2. Публичный API (`AbilitySystemFacade`, DSL `defineAttribute/Effect/Ability`) проектируется так, чтобы переход на SoA не ломал потребителей.

### Скоуп MVP

- Attributes: `base` + `current` + `min`/`max` + `clamp`.
- Gameplay Effects: `Instant`, `Duration`, `Periodic`. Плоские модификаторы: `Add`, `Multiply`, `Override`.
- Gameplay Tags: иерархические строки (`State.Buff.Speed`), проверка `required`/`blocked`/`granted`.
- Abilities: декларативное определение, активация, cost через эффект, cooldown через тег + Duration-эффект.
- Target Spec: `Self`, `Entity`, `Point`, `Radius`. Стабильно-детерминированный resolve.
- Gameplay Cues: события через `EventBus`, эмитятся только клиентским `CueDispatchSystem`; данные собираются в `CuePendingQueue` детерминированно на обеих сторонах.
- Activation hook: пользовательский callback на момент активации (нужен для снарядов, лучей, ракет).
- Aura: persistent зона-сущность с тиковым resolve + применением Instant-эффектов (см. кейс «лечащая аура»).
- Channeling (поддерживаемые лучи): через `Duration`-эффект с явным `removeEffectByTag` при отпускании.
- Порядок применения модификаторов: FIFO по `instanceId`.

### Вне MVP (v2)

- Execution Calculations (custom damage formulas, читающие атрибуты caster+target).
- Granted Abilities (динамическая выдача способностей).
- Stacking (`AggregateBySource/Target`, `StackCount`).
- AttributeRef в `min`/`max`.
- Target shapes `Box`/`Cone`.
- `requireLineOfSight` через детерминированный raycast.
- SoA-хранилище.

---

## Покрытие игровых абилок

Целевая игра использует 5 паттернов абилок. План явно покрывает каждый:

### 1. Авто-атака (выпуск снаряда)

- Ability с `cooldownEffectId` (Duration-эффект → tag `Cooldown.Ability.AutoAttack`).
- `selfEffectIds` пуст или содержит cost.
- `target: { kind: 'Entity' }` — указание цели снаряда.
- При активации `AbilityActivationSystem` эмитит событие `AbilityActivated { abilityId, casterId, targetEntityId, point }` и/или вызывает зарегистрированный callback из `AbilityHooksRegistry`.
- **Сам снаряд — entity вне phalanx-abilities.** Спавн делает пользовательский код (или отдельный пакет `phalanx-projectiles`). При попадании пользовательский код вызывает `AbilitySystemFacade.applyEffect(targetId, 'Effect.AutoAttackDamage', casterId)`.
- Никаких specific «projectile»-понятий в библиотеке нет — это вне её ответственности.

### 2. Лечащая аура

- Ability с `target: { kind: 'Radius', origin: { kind: 'Caster' }, radius, filter: { tagsRequired: ['Team.Ally'] }, includeSelf: true }`.
- Активация создаёт **entity-зону** с компонентом `AuraComponent { abilityId, period, lifetimeTicks, target, effectIds: ['Effect.Heal'] }`.
- `AuraTickSystem` каждые `period` тиков делает re-resolve через `ISpatialQuery` и применяет `Effect.Heal` (тип `Instant`) к каждой найденной цели.
- Жизненный цикл ауры — отдельный Duration-эффект на entity-зоне с `tagsGranted: ['Aura.Active']`. Когда тег уходит — зона удаляется через хук `AuraTickSystem`.

### 3. Луч, уменьшающий броню

- Простой `Duration`-эффект `Effect.ArmorShred` с `Modifier { attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-20) }`, `duration: 300`, `tagsGranted: ['State.Debuff.ArmorShred']`.
- Ability `target: { kind: 'Entity' }`.
- На отпускании луча (если channeling) — пользователь зовёт `AbilitySystemFacade.removeEffectsByTag(targetId, 'State.Debuff.ArmorShred')`.

### 4. Луч, подсвечивающий противника + увеличение урона по нему

- Атрибут `IncomingDamageMultiplier` (default `FP.FromInt(1)`, clamp `min`).
- `Effect.Marked`: `Modifier { attributeId: 'IncomingDamageMultiplier', op: 'Multiply', magnitude: FP.FromFloat(1.25) }`, `tagsGranted: ['State.Marked']`, `cues: ['Cue.Mark.Start']`.
- Расчёт фактического урона на целях, у которых стоит `State.Marked`, делает **damage pipeline на стороне игры** (или будущий ExecutionCalculation в v2). В MVP это делается так:
  - Игра при нанесении урона читает `abs.getAttribute(targetId, 'IncomingDamageMultiplier').current` и умножает magnitude перед применением `Effect.Damage`.
  - Это **не** автоматическая логика библиотеки — пишется один helper на стороне игры.
- Это ограничение MVP документируется в README и snippet'е игры.

### 5. Ракета с уроном по площади

- Активация: ability с `cooldownEffectId`, hook на спавн entity-ракеты (как авто-атака).
- Ракета — entity вне библиотеки.
- При попадании пользовательский код вызывает `abs.applyEffectAoE(originPoint, 'Effect.Explosion', casterId, { radius, maxTargets, filter })` — короткий путь, минующий `AbilityDef`.
  - Реализуется в `AbilitySystemFacade` как `resolveTargets(spec) → applyEffect для каждого`.

### Сводная таблица покрытия

| Абилка | Activation hook | Target spec | Effect type | Aura | Channeling | Damage pipeline |
|---|---|---|---|---|---|---|
| Авто-атака | ✓ | Entity | Instant (на попадание) | — | — | — |
| Лечащая аура | ✓ | Radius | Instant (per tick) | ✓ | — | — |
| Луч брони | — | Entity | Duration | — | ✓ (removeByTag) | — |
| Луч-подсветка | — | Entity | Duration | — | ✓ (removeByTag) | user-side multiplier |
| Ракета AoE | ✓ | Radius (на попадание, applyEffectAoE) | Instant | — | — | — |

Все 5 кейсов покрываются MVP-скоупом без отложенных в v2 фич.

---

## Структура пакета

```
phalanx-abilities/
├── src/
│   ├── registry/
│   │   ├── AttributeRegistry.ts
│   │   ├── EffectRegistry.ts
│   │   ├── AbilityRegistry.ts
│   │   ├── AbilityHooksRegistry.ts     # callbacks для onActivate (снаряды/ракеты)
│   │   └── index.ts
│   ├── components/
│   │   ├── AttributesComponent.ts      # BigInt64Array base/current, Uint8Array dirty
│   │   ├── ActiveEffectsComponent.ts   # queue + pendingAdd
│   │   ├── GameplayTagsComponent.ts    # Set<string>
│   │   ├── AbilitiesComponent.ts       # Set<abilityId> (известные способности; в MVP опционален)
│   │   ├── AuraComponent.ts            # для зон лечащей ауры
│   │   ├── CuePendingQueueComponent.ts # singleton-компонент мира
│   │   └── index.ts
│   ├── systems/
│   │   ├── AbilityActivationSystem.ts
│   │   ├── TargetResolutionSystem.ts
│   │   ├── EffectApplicationSystem.ts
│   │   ├── EffectTickSystem.ts
│   │   ├── AuraTickSystem.ts
│   │   ├── AttributeAggregationSystem.ts
│   │   ├── CueDispatchSystem.ts        # регистрируется только клиентом
│   │   └── index.ts
│   ├── types/
│   │   ├── AttributeDef.ts
│   │   ├── EffectDef.ts
│   │   ├── AbilityDef.ts
│   │   ├── TargetSpec.ts
│   │   ├── ActiveEffectInstance.ts
│   │   ├── ModifierOp.ts
│   │   └── index.ts
│   ├── spatial/
│   │   └── ISpatialQuery.ts            # интерфейс, без реализации
│   ├── api/
│   │   ├── defineAttribute.ts
│   │   ├── defineEffect.ts
│   │   ├── defineAbility.ts
│   │   ├── AbilitySystemFacade.ts
│   │   └── index.ts
│   └── index.ts
├── tests/
│   ├── attributes.test.ts
│   ├── effects.test.ts
│   ├── abilities.test.ts
│   ├── tags.test.ts
│   ├── target-resolution.test.ts
│   ├── auras.test.ts
│   └── determinism-snapshot.test.ts
├── package.json
├── tsconfig.json
└── README.md
```

---

## Типы данных

### AttributeDef

```ts
import type { FixedPoint } from 'phalanx-math';

interface AttributeDef {
  id: string;
  default: FixedPoint;
  min: FixedPoint;
  max: FixedPoint;
  clamp: 'both' | 'min' | 'max' | 'none';
}
```

### ModifierOp и Modifier

```ts
type ModifierOp = 'Add' | 'Multiply' | 'Override';

interface Modifier {
  attributeId: string;
  op: ModifierOp;
  magnitude: FixedPoint;
}
```

### EffectDef

```ts
interface EffectDef {
  id: string;
  type: 'Instant' | 'Duration' | 'Periodic';
  /** Только для Duration/Periodic. Целые тики. */
  durationTicks?: number;
  /** Только для Periodic. Целые тики. */
  periodTicks?: number;
  /** Только для Periodic. Если true — модификаторы применяются и в момент применения, а не только начиная со следующего периода. */
  executePeriodicOnApplication?: boolean;
  modifiers: Modifier[];
  tagsGranted?: string[];
  tagsRequired?: string[];
  tagsBlocked?: string[];
  cues?: string[];
}
```

### TargetSpec

```ts
type TargetOrigin =
  | { kind: 'Caster' }
  | { kind: 'TargetEntity'; entityId: number }
  | { kind: 'Point'; x: FixedPoint; z: FixedPoint }
  | { kind: 'Caller' }; // читается из providedTarget при activateAbility

interface TargetFilter {
  tagsRequired?: string[];
  tagsBlocked?: string[];
}

type TargetSpec =
  | { kind: 'Self' }
  | { kind: 'Entity'; origin: TargetOrigin }
  | { kind: 'Point'; origin: TargetOrigin }
  | {
      kind: 'Radius';
      origin: TargetOrigin;
      radius: FixedPoint;
      maxTargets?: number;
      filter?: TargetFilter;
      includeSelf?: boolean;
    };
```

`Box`/`Cone` — v2.

### AbilityDef

```ts
interface AbilityDef {
  id: string;
  costEffectId?: string;        // применяется к caster
  cooldownEffectId?: string;    // применяется к caster, обычно даёт tag 'Cooldown.Ability.<id>'
  tagsRequired?: string[];      // на caster
  activationBlockedTags?: string[]; // на caster
  selfEffectIds?: string[];     // применяется к caster при активации
  targetEffectIds?: string[];   // применяется к каждой entity из resolve(target)
  target: TargetSpec;
  /** Если задан — после прохождения CanActivate вызывается hook из AbilityHooksRegistry */
  hookId?: string;
}
```

### ActiveEffectInstance

```ts
interface ActiveEffectInstance {
  instanceId: number;        // монотонный, для FIFO
  defId: string;
  remainingTicks: number;
  nextPeriodTick: number;    // только для Periodic
  sourceEntityId: number;
}
```

### AuraComponent

```ts
interface AuraComponent {
  abilityId: string;          // для трассировки cue
  target: TargetSpec;         // обычно Radius с origin = TargetEntity (сама зона)
  effectIds: string[];        // Instant-эффекты, применяемые к найденным целям
  periodTicks: number;
  nextTick: number;
  ownerEntityId: number;      // caster ауры
}
```

### ISpatialQuery

```ts
interface ISpatialQuery {
  queryRadius(x: FixedPoint, z: FixedPoint, radius: FixedPoint): number[];
}
```

Пользователь регистрирует реализацию (тонкая обёртка над `SpatialHashGrid` из `phalanx-physics` или собственная) при инициализации мира.

### AbilityHooksRegistry

```ts
interface AbilityActivationContext {
  abilityId: string;
  casterEntityId: number;
  resolvedTargets: number[];
  providedTarget?: { entityId?: number; x?: FixedPoint; z?: FixedPoint };
  tick: number;
}

type AbilityHook = (ctx: AbilityActivationContext) => void;
```

Hook вызывается **детерминированно внутри тика** между `EffectApplicationSystem` (где применились cost+cooldown+selfEffects) и применением `targetEffectIds`. Hook может спавнить entity-снаряды, писать команды в физику и т.п. — но обязан быть детерминированным.

---

## Компоненты (плоские, без SoA)

### AttributesComponent

```ts
class AttributesComponent implements IComponent {
  readonly type = AbilitiesComponentType.Attributes;
  readonly base: BigInt64Array;    // raw FixedPoint
  readonly current: BigInt64Array; // raw FixedPoint
  readonly dirty: Uint8Array;
  // длина = AttributeRegistry.size, зафиксировано при инициализации мира
}
```

Атрибут получает числовой индекс при регистрации. `min`/`max` хранятся в дефе, не на каждой энтити.

### ActiveEffectsComponent

```ts
class ActiveEffectsComponent implements IComponent {
  readonly type = AbilitiesComponentType.ActiveEffects;
  queue: ActiveEffectInstance[] = [];      // упорядочен по instanceId
  pendingAdd: { defId: string; sourceEntityId: number }[] = [];
}
```

### GameplayTagsComponent

```ts
class GameplayTagsComponent implements IComponent {
  readonly type = AbilitiesComponentType.GameplayTags;
  readonly tags = new Set<string>();
}
```

### AbilitiesComponent

В MVP опционален. Если все способности доступны всем — компонент не нужен, `AbilityRegistry` достаточно. Под Granted Abilities (v2) станет `Set<abilityId>`. В DSL `AbilityDef` поле `onCooldown` **не** хранится — источник правды о кулдауне — теги.

### CuePendingQueueComponent (singleton)

```ts
class CuePendingQueueComponent implements IComponent {
  readonly type = AbilitiesComponentType.CuePendingQueue;
  events: CueEvent[] = [];
}

interface CueEvent {
  tick: number;
  cueId: string;
  sourceEntityId: number;
  targetEntityId: number;
  // никаких float, Date.now, Math.random
}
```

Очередь чистится **в конце каждого тика** (системой-замыкателем), независимо от того, есть `CueDispatchSystem` или нет — иначе на сервере утечка.

---

## Порядок систем за тик

```
1. AbilityActivationSystem      запросы активации → CanActivate → ActivationRequest
2. TargetResolutionSystem       ActivationRequest → список targets через ISpatialQuery
                                + стабильная сортировка по entityId, обрезка maxTargets
3. EffectApplicationSystem      pendingAdd: проверка тегов цели,
                                Instant → меняет base + dirty,
                                Duration/Periodic → в queue,
                                tagsGranted/tagsRemoved,
                                cues OnApplied → CuePendingQueue
4. AbilityHookExecutor          вызов hookId из AbilityHooksRegistry (спавн снарядов, лучей)
5. EffectTickSystem             countdown remainingTicks,
                                Periodic применяет модификаторы при currentTick >= nextPeriodTick,
                                completed → снятие, tagsRemoved, cue OnExpired
6. AuraTickSystem               для каждой AuraComponent: при currentTick >= nextTick —
                                resolve target, applyEffectInstant(targetId, effectId, ownerId)
7. AttributeAggregationSystem   пересчёт current по dirty: FIFO по instanceId, затем кламп
8. CueDispatchSystem            ТОЛЬКО клиент: CuePendingQueue → EventBus
9. CueQueueCleanupSystem        чистит CuePendingQueue (всегда)
```

### Формула агрегации (FIFO)

```
acc = base
for mod in queue (sorted by instanceId ASC):
  switch mod.op:
    Add:      acc = acc + magnitude
    Multiply: acc = acc * magnitude
    Override: acc = magnitude   // последний Override побеждает естественным образом
clamp(acc) по AttributeDef
current = acc
dirty = 0
```

### Правила детерминизма AoE

1. Результат `queryRadius` всегда сортируется по `entityId ASC` перед обработкой.
2. `maxTargets` обрезает уже отсортированный список.
3. Дистанция — в `FixedPoint`. Сравнение через `dx*dx + dz*dz <= r*r`. Никаких `Math.sqrt`.
4. Cue per target эмитятся в той же стабильной последовательности.
5. Target resolve делается один раз на тике активации. Поздние изменения сцены не влияют на список целей (snapshot момента).

---

## Публичный DSL

```ts
import { FP } from 'phalanx-math';
import { defineAttribute, defineEffect, defineAbility } from 'phalanx-abilities';

// Атрибуты
defineAttribute({ id: 'Health',                    default: FP.FromInt(100), min: FP.FromInt(0),   max: FP.FromInt(100),  clamp: 'both' });
defineAttribute({ id: 'Mana',                      default: FP.FromInt(50),  min: FP.FromInt(0),   max: FP.FromInt(50),   clamp: 'both' });
defineAttribute({ id: 'MoveSpeed',                 default: FP.FromInt(300), min: FP.FromInt(0),   max: FP.FromInt(1000), clamp: 'min'  });
defineAttribute({ id: 'Armor',                     default: FP.FromInt(50),  min: FP.FromInt(0),   max: FP.FromInt(1000), clamp: 'min'  });
defineAttribute({ id: 'IncomingDamageMultiplier',  default: FP.FromInt(1),   min: FP.FromInt(0),   max: FP.FromInt(10),   clamp: 'both' });

// 1. Авто-атака
defineEffect({
  id: 'Effect.AutoAttack.Cooldown',
  type: 'Duration',
  durationTicks: 30,
  tagsGranted: ['Cooldown.Ability.AutoAttack'],
});
defineEffect({
  id: 'Effect.AutoAttack.Damage',
  type: 'Instant',
  modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
  cues: ['Cue.AutoAttack.Hit'],
});
defineAbility({
  id: 'Ability.AutoAttack',
  cooldownEffectId: 'Effect.AutoAttack.Cooldown',
  activationBlockedTags: ['Cooldown.Ability.AutoAttack', 'State.Stun'],
  target: { kind: 'Entity', origin: { kind: 'Caller' } },
  hookId: 'Hook.SpawnProjectile.AutoAttack',
  // targetEffectIds не задаются: damage применяется hook'ом на попадание снаряда
});

// 2. Лечащая аура
defineEffect({
  id: 'Effect.Heal',
  type: 'Instant',
  modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(5) }],
  cues: ['Cue.Heal.Tick'],
});
defineEffect({
  id: 'Effect.HealingAura.Lifetime',
  type: 'Duration',
  durationTicks: 600,
  tagsGranted: ['Aura.HealingAura.Active'],
});
defineAbility({
  id: 'Ability.HealingAura',
  cooldownEffectId: 'Effect.AutoAttack.Cooldown',
  activationBlockedTags: ['State.Stun'],
  target: { kind: 'Self' },
  hookId: 'Hook.SpawnAura.Healing',
  // hook создаёт entity-зону с AuraComponent + Effect.HealingAura.Lifetime
});

// 3. Луч уменьшающий броню
defineEffect({
  id: 'Effect.ArmorShred',
  type: 'Duration',
  durationTicks: 300,
  modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-20) }],
  tagsGranted: ['State.Debuff.ArmorShred'],
  cues: ['Cue.ArmorShred.Start'],
});
defineAbility({
  id: 'Ability.ArmorShredBeam',
  activationBlockedTags: ['State.Stun'],
  target: { kind: 'Entity', origin: { kind: 'Caller' } },
  targetEffectIds: ['Effect.ArmorShred'],
});
// При отпускании кнопки: abs.removeEffectsByTag(targetId, 'State.Debuff.ArmorShred')

// 4. Луч-подсветка (увеличение урона)
defineEffect({
  id: 'Effect.Marked',
  type: 'Duration',
  durationTicks: 240,
  modifiers: [{ attributeId: 'IncomingDamageMultiplier', op: 'Multiply', magnitude: FP.FromFloat(1.25) }],
  tagsGranted: ['State.Marked'],
  cues: ['Cue.Mark.Start'],
});
defineAbility({
  id: 'Ability.MarkBeam',
  target: { kind: 'Entity', origin: { kind: 'Caller' } },
  targetEffectIds: ['Effect.Marked'],
});

// 5. Ракета AoE
defineEffect({
  id: 'Effect.Rocket.Cooldown',
  type: 'Duration',
  durationTicks: 180,
  tagsGranted: ['Cooldown.Ability.Rocket'],
});
defineEffect({
  id: 'Effect.Explosion',
  type: 'Instant',
  modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-50) }],
  cues: ['Cue.Explosion.Hit'],
});
defineAbility({
  id: 'Ability.Rocket',
  cooldownEffectId: 'Effect.Rocket.Cooldown',
  activationBlockedTags: ['Cooldown.Ability.Rocket', 'State.Stun'],
  target: { kind: 'Point', origin: { kind: 'Caller' } },
  hookId: 'Hook.SpawnProjectile.Rocket',
  // На попадании hook вызывает abs.applyEffectAoE(point, 'Effect.Explosion', casterId, { radius, maxTargets })
});
```

### Фасад

```ts
interface AbilitySystemFacade {
  // Применение эффектов
  applyEffect(targetId: number, effectId: string, sourceId: number): void;
  applyEffectAoE(
    origin: { x: FixedPoint; z: FixedPoint },
    effectId: string,
    sourceId: number,
    opts: { radius: FixedPoint; maxTargets?: number; filter?: TargetFilter; includeSelf?: boolean; selfId?: number }
  ): number[]; // вернёт затронутых targets

  // Активация
  activateAbility(
    casterId: number,
    abilityId: string,
    providedTarget?: { entityId?: number; x?: FixedPoint; z?: FixedPoint }
  ): boolean;

  // Чтение
  getAttribute(entityId: number, attrId: string): { base: FixedPoint; current: FixedPoint };
  hasTag(entityId: number, tag: string): boolean;

  // Снятие
  removeEffectsByTag(entityId: number, grantedTag: string): number; // вернёт сколько снято
  removeEffectsByDefId(entityId: number, defId: string): number;

  // Регистрация хуков
  registerHook(hookId: string, hook: AbilityHook): void;

  // Spatial query (нужен для AoE и Aura)
  registerSpatialQuery(query: ISpatialQuery): void;
}
```

---

## Интеграция с phalanx-ecs

- Peer dependencies: `phalanx-ecs`, `phalanx-math`.
- Все системы наследуют `GameSystem`, регистрируются в `SystemRegistry` в порядке, описанном выше.
- Реестры (`AttributeRegistry`, `EffectRegistry`, `AbilityRegistry`, `AbilityHooksRegistry`) **живут на World** (поле `world.abilities.registries`), а не глобально, чтобы не загрязнять состояние между независимыми экземплярами мира.
- `AbilitySystemFacade` — не `GameSystem`. Это обычный класс, инстанциируемый в `GameWorld`, методы которого пишут в компоненты/очереди, обрабатываемые системами на следующем тике.
- `CueDispatchSystem` регистрируется только клиентским сборщиком мира; сервер регистрирует только `CueQueueCleanupSystem`.

---

## Этапы разработки

### Этап 1 — Скелет пакета и типы (1–2 дня)

- Создать `phalanx-abilities/` в `pnpm-workspace.yaml`.
- `package.json`, `tsconfig.json` по образцу `phalanx-physics`.
- Все типы: `AttributeDef`, `EffectDef`, `AbilityDef`, `TargetSpec`, `ActiveEffectInstance`, `ModifierOp`, `AuraComponent`, `CueEvent`.
- Реестры на World: `AttributeRegistry`, `EffectRegistry`, `AbilityRegistry`, `AbilityHooksRegistry`.
- DSL: `defineAttribute`, `defineEffect`, `defineAbility`.
- Интерфейс `ISpatialQuery`.
- Unit-тест: регистрация и чтение дефов.

### Этап 2 — Attributes + Aggregation (плоский компонент, без SoA) (1–2 дня)

- `AttributesComponent` (BigInt64Array base/current, Uint8Array dirty).
- `AttributeAggregationSystem`: FIFO агрегация + кламп.
- `initAttributesForEntity(entityId)` — заполняет default из реестра.
- `getAttribute` в фасаде.
- Unit-тест: Add/Multiply/Override, кламп, dirty-флаги, Override-последний-побеждает.

### Этап 3 — Effects: Instant + Duration + Tags (2–3 дня)

- `ActiveEffectsComponent`, `GameplayTagsComponent`.
- `EffectApplicationSystem`: проверка `tagsRequired/tagsBlocked` на цели, Instant → base, Duration → queue + tagsGranted.
- `EffectTickSystem`: countdown, снятие, tagsRemoved.
- `removeEffectsByTag/ByDefId` в фасаде.
- Unit-тест: жизненный цикл Duration, блокировки по тегам, ручное снятие.

### Этап 4 — Effects: Periodic (1 день)

- Расширить `EffectTickSystem`: `nextPeriodTick`, модификаторы по тику, `executePeriodicOnApplication`.
- Unit-тест: DoT, HoT, expiry, корректное число тиков при `executePeriodicOnApplication: true/false`.

### Этап 5 — Abilities: cost/cooldown/CanActivate + hooks (2 дня)

- `AbilityActivationSystem`: `CanActivate` (activationBlockedTags → tagsRequired → cost → cooldown-тег).
- Применение: cost + cooldown + selfEffects на caster.
- `AbilityHookExecutor` система между application и target effects.
- `AbilitySystemFacade.activateAbility`, `registerHook`.
- Unit-тест: активация, блокировка по тегу, блокировка по кулдауну, вызов hook.

### Этап 6 — Targeting: Radius + TargetResolutionSystem (2 дня)

- `TargetResolutionSystem` с `ISpatialQuery`.
- Стабильная сортировка по `entityId`, обрезка `maxTargets`, фильтр по тегам.
- Поддержка всех `TargetOrigin.kind` включая `Caller`.
- `applyEffectAoE` в фасаде.
- Unit-тест: AoE по точке, AoE от caster, фильтр alliance, `includeSelf`, стабильность порядка.

### Этап 7 — Auras (persistent AoE) (1–2 дня)

- `AuraComponent`, `AuraTickSystem`.
- Жизненный цикл через Duration-эффект на entity-зоне.
- Unit-тест: лечащая аура, аура с фильтром по тегу, удаление зоны по истечении lifetime.

### Этап 8 — Gameplay Cues (1 день)

- `CuePendingQueueComponent` (singleton).
- `CueDispatchSystem` (клиент-only).
- `CueQueueCleanupSystem` (всегда).
- Unit-тест: cue эмитится OnApplied/OnExpired/OnPeriodic, очередь чистится, сервер не эмитит в EventBus.

### Этап 9 — Интеграция в arena-shooter (1–2 дня)

- Реализовать все 5 кейсов целевой игры.
- Адаптер `PhysicsSpatialQuery` поверх `SpatialHashGrid` (≈10 строк) — в коде игры.
- User-side damage helper, читающий `IncomingDamageMultiplier` с цели (для луча-подсветки).
- Snippet в README пакета.

### Этап 10 — Golden-snapshot тест детерминизма (1 день)

- Сценарий: 1000 тиков, фиксированный seed входов, набор всех 5 абилок.
- В конце — хэш (`crypto.subtle.digest` или sha256 строки) состояния всех `AttributesComponent` + `ActiveEffectsComponent` + `GameplayTagsComponent` + `AuraComponent`.
- Тест падает на любой регрессии.
- Запуск в CI.

### Этап 11 — Документация (1–2 дня)

- `phalanx-abilities/README.md`: полный флоу, DSL, примеры всех 5 абилок, ограничения MVP, миграционные заметки.
- Обновить корневой `README.md`: добавить пакет в список, схему, ссылку на skill.
- Обновить `CLAUDE.md`: упомянуть пакет.
- ADR / DESIGN.md в пакете: явное обоснование «без SoA в MVP», правила детерминизма AoE, граница между библиотекой и игровым кодом (снаряды, damage pipeline).

### Этап 12 — Skill для агентов (0.5–1 день)

Файл `skills/phalanx-abilities/SKILL.md` по образцу `skills/phalanx-ecs/SKILL.md` и `skills/phalanx-physics/SKILL.md`:

- Frontmatter (`name`, `description`, `metadata.author`, `metadata.version`).
- Раздел **When to Use This Skill**: создание абилок, эффектов, AoE, аур, channeling, hooks.
- Раздел **Prerequisites**: `phalanx-ecs`, `phalanx-math`, опциональный `phalanx-physics` для AoE.
- Раздел **Architecture Overview**: схема систем и порядок тика.
- Раздел **Core Concepts**: Attribute / Effect / Ability / Tag / Cue / Target / Aura / Hook.
- Раздел **Decision Tree**: Instant vs Duration vs Periodic; Aura vs single AoE; Hook vs targetEffectIds.
- Раздел **Recipes**: пять рецептов для целевой игры (авто-атака, лечащая аура, луч брони, луч-подсветка, ракета).
- Раздел **Determinism Rules**: правила для AoE, FixedPoint, сортировки.
- Раздел **Anti-Patterns**: `number` в магнитудах, float-дистанции, прямой доступ к `current` минуя `getAttribute`, mutation тегов вне систем.

Опционально (если будут отдельные пакеты): аналогичный skill для `phalanx-projectiles`, когда он появится.

---

## Тестовая сцена для валидации

Hero: `Health(100)`, `Mana(50)`, `MoveSpeed(300)`, `Armor(50)`, `IncomingDamageMultiplier(1)`.
Enemy: те же атрибуты.

**Сценарий (детерминистичный, 600 тиков):**

1. Тик 10: Hero кастует `Ability.MarkBeam` на Enemy → `Effect.Marked` активен, `IncomingDamageMultiplier(Enemy) = 1.25`.
2. Тик 20: Hero кастует `Ability.ArmorShredBeam` на Enemy → `Armor(Enemy) = 30`.
3. Тик 30, 60, 90: Hero кастует `Ability.AutoAttack` → hook спавнит снаряд → попадание через ~5 тиков → `Effect.AutoAttack.Damage` с скорректированным magnitude (user-side helper: `-10 * 1.25 = -12.5`). Health(Enemy) уменьшается.
4. Тик 120: Hero кастует `Ability.HealingAura` (Self) → создаётся entity-зона, каждые 60 тиков лечит Hero на 5 HP.
5. Тик 200: Hero кастует `Ability.Rocket` в Point → hook спавнит ракету → попадание в Tick 210 → `applyEffectAoE` поражает Enemy и любого в радиусе.
6. Тик 260: `Effect.Marked` истекает → `IncomingDamageMultiplier(Enemy) = 1`, тег `State.Marked` снят.
7. Тик 320: `Effect.ArmorShred` истекает → `Armor(Enemy) = 50`.
8. Тик 600: финальный snapshot, его SHA-256 проверяется в CI.

Тест запускается **дважды** (двумя независимыми инстансами `GameWorld`), хэши сравниваются — это и есть проверка детерминизма.

---

## Чек-лист скоупа (контроль)

- [ ] Все 5 абилок целевой игры покрыты и описаны в DSL.
- [ ] SoA — явно вне MVP, в README зафиксировано.
- [ ] Hook-механизм для снарядов/ракет описан и реализуем.
- [ ] Aura возвращена в MVP.
- [ ] Channeling описан как `Duration + removeByTag`.
- [ ] Damage pipeline (`IncomingDamageMultiplier`) — user-side в MVP, отмечено как ограничение.
- [ ] AoE-детерминизм: сортировка по entityId, FP-дистанции, snapshot момента.
- [ ] Реестры на World, не глобальные.
- [ ] `phalanx-physics` не peer dep — через `ISpatialQuery`.
- [ ] Cue-очередь чистится всегда, эмит — только на клиенте.
- [ ] Skill `skills/phalanx-abilities/SKILL.md` добавлен.
- [ ] Документация (README пакета, корневой README, CLAUDE.md, DESIGN.md) обновлена.
- [ ] Golden-snapshot тест детерминизма в CI.
