### PR TITLE
feat(abilities): stage 3 — Effects: Instant + Duration + Tags

### DIFF
--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -241,20 +241,27 @@ export class AbilitySystemFacade {
    * Intended for setup code (team / faction tags assigned at spawn). For
    * lifecycle-managed state tags, prefer `tagsGranted` on an effect so the
    * tag is automatically revoked when the effect expires.
+   *
+   * Ad-hoc and effect-granted ownership are tracked separately: adding the
+   * same tag both ways is safe and idempotent. The tag survives until both
+   * sources release it.
    */
   public addTag(entityId: number, tag: string): void {
     const entity = this.requireEntity(entityId);
     const tags = this.getOrCreateTags(entity);
+    tags.adHocTags.add(tag);
     tags.tags.add(tag);
   }
 
   /**
-   * Remove an ad-hoc tag. Note: this does NOT remove tags that are
-   * currently granted by an active effect — those will be re-granted on
-   * the next {@link EffectApplicationSystem} pass (today, application is
-   * one-shot from pendingAdd, so a re-grant requires a fresh applyEffect;
-   * see Stage 5 for grant-on-tick semantics). For predictable removal
-   * use {@link removeEffectsByTag}.
+   * Remove ad-hoc ownership of `tag`. If the tag is still granted by one or
+   * more active effects, it remains in {@link GameplayTagsComponent.tags}
+   * (and {@link hasTag} keeps returning `true`) until the last grant expires.
+   * For predictable removal of effect-granted tags use
+   * {@link removeEffectsByTag}.
+   *
+   * Returns `true` if ad-hoc ownership was actually cleared, `false` if the
+   * entity / component is missing or the tag was not held ad hoc.
    */
   public removeTag(entityId: number, tag: string): boolean {
     const entity = this.entityManager.getEntity(entityId);
@@ -265,7 +272,16 @@ export class AbilitySystemFacade {
     if (!tags) {
       return false;
     }
-    return tags.tags.delete(tag);
+    const wasAdHoc = tags.adHocTags.delete(tag);
+    if (!wasAdHoc) {
+      return false;
+    }
+    // Only drop from the unified set when no active effect still grants it.
+    const grantCount = tags.effectGrantCounts.get(tag) ?? 0;
+    if (grantCount === 0) {
+      tags.tags.delete(tag);
+    }
+    return true;
   }
 
   // -----------------------------------------------------------------------

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -1,25 +1,42 @@
-import type { EntityManager } from 'phalanx-ecs';
+import type { Entity, EntityManager } from 'phalanx-ecs';
 import { FP } from 'phalanx-math';
 import type { FixedPoint } from 'phalanx-math';
-import { AbilitiesComponentType, AttributesComponent } from '../components';
+import {
+  AbilitiesComponentType,
+  ActiveEffectsComponent,
+  AttributesComponent,
+  GameplayTagsComponent,
+} from '../components';
 import type { AbilitySystemRegistries } from '../registry';
+import type { AbilitySystemRuntime } from '../runtime';
 
 export interface AttributeValue {
   base: FixedPoint;
   current: FixedPoint;
 }
 
+/**
+ * Single user-facing entry point for the ability system.
+ *
+ * Determinism note: all mutations enqueue work and are processed by the
+ * ability systems during the next tick. The facade never advances effect
+ * state itself — it only writes into components that the systems own.
+ * That keeps observable state changes anchored to the simulation tick and
+ * therefore reproducible across lockstep peers.
+ */
 export class AbilitySystemFacade {
   public constructor(
     private readonly entityManager: EntityManager,
-    private readonly registries: AbilitySystemRegistries
+    private readonly registries: AbilitySystemRegistries,
+    private readonly runtime: AbilitySystemRuntime
   ) {}
 
+  // -----------------------------------------------------------------------
+  // Attributes
+  // -----------------------------------------------------------------------
+
   public initAttributesForEntity(entityId: number): AttributesComponent {
-    const entity = this.entityManager.getEntity(entityId);
-    if (!entity) {
-      throw new Error(`Entity ${entityId} does not exist`);
-    }
+    const entity = this.requireEntity(entityId);
 
     const existing = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
 
@@ -89,5 +106,196 @@ export class AbilitySystemFacade {
       base: FP.FromRaw(attributes.base[index]),
       current: FP.FromRaw(attributes.current[index]),
     };
+  }
+
+  // -----------------------------------------------------------------------
+  // Effects
+  // -----------------------------------------------------------------------
+
+  /**
+   * Queue an effect application onto the target. The actual application
+   * (modifier write, tag grant, queue insertion) happens in
+   * {@link EffectApplicationSystem} on the next system pass. Throws if
+   * the target entity or the effect id are unknown.
+   *
+   * Returns nothing in Stage 3 — the future `ActiveEffectInstance.instanceId`
+   * is allocated during application, not enqueue, so the facade cannot hand
+   * it back synchronously. If callers need to track an applied instance,
+   * Stage 5 will introduce an `apply` event on `EventBus`.
+   */
+  public applyEffect(targetEntityId: number, effectId: string, sourceEntityId: number): void {
+    const target = this.requireEntity(targetEntityId);
+    if (!this.registries.effects.has(effectId)) {
+      throw new Error(`EffectRegistry does not contain '${effectId}'`);
+    }
+
+    const activeEffects = this.getOrCreateActiveEffects(target);
+    activeEffects.pendingAdd.push({ defId: effectId, sourceEntityId });
+  }
+
+  /**
+   * Flag every active effect on `entityId` that grants `grantedTag` for
+   * removal on the next {@link EffectTickSystem} pass. Returns the number
+   * of instances flagged.
+   *
+   * Removal is timed to the system tick — never inline — so two peers
+   * issuing removals in the same tick observe identical state after the
+   * tick boundary.
+   */
+  public removeEffectsByTag(entityId: number, grantedTag: string): number {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      return 0;
+    }
+    const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+      AbilitiesComponentType.ActiveEffects
+    );
+    if (!activeEffects) {
+      return 0;
+    }
+
+    let flagged = 0;
+    for (let i = 0; i < activeEffects.queue.length; i++) {
+      const instance = activeEffects.queue[i];
+      const def = this.registries.effects.tryGet(instance.defId);
+      if (!def || !def.tagsGranted) {
+        continue;
+      }
+      if (def.tagsGranted.indexOf(grantedTag) === -1) {
+        continue;
+      }
+      if (instance.remainingTicks > 0) {
+        instance.remainingTicks = 0;
+        flagged += 1;
+      }
+    }
+    return flagged;
+  }
+
+  /**
+   * Flag every active effect on `entityId` whose `defId === effectId` for
+   * removal on the next {@link EffectTickSystem} pass.
+   */
+  public removeEffectsByDefId(entityId: number, effectId: string): number {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      return 0;
+    }
+    const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+      AbilitiesComponentType.ActiveEffects
+    );
+    if (!activeEffects) {
+      return 0;
+    }
+
+    let flagged = 0;
+    for (let i = 0; i < activeEffects.queue.length; i++) {
+      const instance = activeEffects.queue[i];
+      if (instance.defId !== effectId) {
+        continue;
+      }
+      if (instance.remainingTicks > 0) {
+        instance.remainingTicks = 0;
+        flagged += 1;
+      }
+    }
+    return flagged;
+  }
+
+  // -----------------------------------------------------------------------
+  // Tags
+  // -----------------------------------------------------------------------
+
+  public hasTag(entityId: number, tag: string): boolean {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      return false;
+    }
+    const tags = entity.getComponent<GameplayTagsComponent>(AbilitiesComponentType.GameplayTags);
+    if (!tags) {
+      return false;
+    }
+    return tags.tags.has(tag);
+  }
+
+  /**
+   * Add an ad-hoc tag to an entity, outside the effect-driven grant lifecycle.
+   *
+   * Intended for setup code (team / faction tags assigned at spawn). For
+   * lifecycle-managed state tags, prefer `tagsGranted` on an effect so the
+   * tag is automatically revoked when the effect expires.
+   */
+  public addTag(entityId: number, tag: string): void {
+    const entity = this.requireEntity(entityId);
+    const tags = this.getOrCreateTags(entity);
+    tags.tags.add(tag);
+  }
+
+  /**
+   * Remove an ad-hoc tag. Note: this does NOT remove tags that are
+   * currently granted by an active effect — those will be re-granted on
+   * the next {@link EffectApplicationSystem} pass (today, application is
+   * one-shot from pendingAdd, so a re-grant requires a fresh applyEffect;
+   * see Stage 5 for grant-on-tick semantics). For predictable removal
+   * use {@link removeEffectsByTag}.
+   */
+  public removeTag(entityId: number, tag: string): boolean {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      return false;
+    }
+    const tags = entity.getComponent<GameplayTagsComponent>(AbilitiesComponentType.GameplayTags);
+    if (!tags) {
+      return false;
+    }
+    return tags.tags.delete(tag);
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  /**
+   * Exposed for tests and downstream packages that need to allocate
+   * `instanceId`s consistent with this world's counter (e.g. a future
+   * `phalanx-projectiles` package that wants to apply effects through the
+   * same FIFO ordering). Not for general use.
+   */
+  public get runtimeInternal(): AbilitySystemRuntime {
+    return this.runtime;
+  }
+
+  private requireEntity(entityId: number): Entity {
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      throw new Error(`Entity ${entityId} does not exist`);
+    }
+    return entity;
+  }
+
+  private getOrCreateActiveEffects(entity: Entity): ActiveEffectsComponent {
+    const existing = entity.getComponent<ActiveEffectsComponent>(
+      AbilitiesComponentType.ActiveEffects
+    );
+    if (existing) {
+      return existing;
+    }
+    const component = new ActiveEffectsComponent();
+    entity.addComponent(component);
+    this.entityManager.onComponentAdded(entity, component.type);
+    return component;
+  }
+
+  private getOrCreateTags(entity: Entity): GameplayTagsComponent {
+    const existing = entity.getComponent<GameplayTagsComponent>(
+      AbilitiesComponentType.GameplayTags
+    );
+    if (existing) {
+      return existing;
+    }
+    const tags = new GameplayTagsComponent();
+    entity.addComponent(tags);
+    this.entityManager.onComponentAdded(entity, tags.type);
+    return tags;
   }
 }

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -16,6 +16,13 @@ export interface AttributeValue {
 }
 
 /**
+ * Sentinel `sourceEntityId` written by {@link AbilitySystemFacade.applyEffect}
+ * when the caller does not supply a source. Distinct from any real entity id
+ * (entity ids are non-negative) so consumers can branch on it cheaply.
+ */
+export const NO_SOURCE_ENTITY_ID = -1;
+
+/**
  * Single user-facing entry point for the ability system.
  *
  * Determinism note: all mutations enqueue work and are processed by the
@@ -118,12 +125,22 @@ export class AbilitySystemFacade {
    * {@link EffectApplicationSystem} on the next system pass. Throws if
    * the target entity or the effect id are unknown.
    *
+   * `sourceEntityId` is optional: omit it for sourceless applications such
+   * as world hazards, debug helpers, or initial spawn-time buffs. When
+   * omitted, the recorded source is {@link NO_SOURCE_ENTITY_ID} (`-1`).
+   * This is a deterministic default — every peer that omits a source ends
+   * up with the same sentinel — so lockstep reproducibility is preserved.
+   *
    * Returns nothing in Stage 3 — the future `ActiveEffectInstance.instanceId`
    * is allocated during application, not enqueue, so the facade cannot hand
    * it back synchronously. If callers need to track an applied instance,
    * Stage 5 will introduce an `apply` event on `EventBus`.
    */
-  public applyEffect(targetEntityId: number, effectId: string, sourceEntityId: number): void {
+  public applyEffect(
+    targetEntityId: number,
+    effectId: string,
+    sourceEntityId: number = NO_SOURCE_ENTITY_ID
+  ): void {
     const target = this.requireEntity(targetEntityId);
     if (!this.registries.effects.has(effectId)) {
       throw new Error(`EffectRegistry does not contain '${effectId}'`);

--- a/phalanx-abilities/src/api/index.ts
+++ b/phalanx-abilities/src/api/index.ts
@@ -1,6 +1,6 @@
 export { defineAbility } from './defineAbility';
 export { defineAttribute } from './defineAttribute';
 export { defineEffect } from './defineEffect';
-export { AbilitySystemFacade } from './AbilitySystemFacade';
+export { AbilitySystemFacade, NO_SOURCE_ENTITY_ID } from './AbilitySystemFacade';
 export type { AttributeValue } from './AbilitySystemFacade';
 export type { EffectDefInput } from './defineEffect';

--- a/phalanx-abilities/src/components/AbilitiesComponentType.ts
+++ b/phalanx-abilities/src/components/AbilitiesComponentType.ts
@@ -3,4 +3,5 @@ import { createComponentTypeRegistry } from 'phalanx-ecs';
 export const AbilitiesComponentType = createComponentTypeRegistry({
   Attributes: 'phalanx-abilities:Attributes',
   ActiveEffects: 'phalanx-abilities:ActiveEffects',
+  GameplayTags: 'phalanx-abilities:GameplayTags',
 });

--- a/phalanx-abilities/src/components/GameplayTagsComponent.ts
+++ b/phalanx-abilities/src/components/GameplayTagsComponent.ts
@@ -9,11 +9,40 @@ import { AbilitiesComponentType } from './AbilitiesComponentType';
  * hierarchy is interpretation, not enforced storage. This keeps tag checks
  * branch-free `Set.has(...)` lookups on the hot path.
  *
+ * Two ownership sources contribute to {@link tags}:
+ *  - **Ad-hoc**: tags added via `AbilitySystemFacade.addTag`. Tracked in
+ *    {@link adHocTags}.
+ *  - **Effect-granted**: tags granted by an active effect via its
+ *    `tagsGranted` field. Tracked via reference counts in
+ *    {@link effectGrantCounts} — a tag stays granted while at least one
+ *    active effect grants it.
+ *
+ * A tag is present in {@link tags} iff at least one of those sources still
+ * owns it. This separation lets `removeTag` clear ad-hoc ownership without
+ * dropping an effect's still-granted tag, and lets effect expiry revoke a
+ * grant without dropping a tag that was also added ad hoc.
+ *
  * Tags are mutated only by the ability systems (`EffectApplicationSystem`,
  * `EffectTickSystem`) or by `AbilitySystemFacade.addTag`/`removeTag`. User
- * code must not mutate `tags` directly.
+ * code must not mutate any of these fields directly.
  */
 export class GameplayTagsComponent implements IComponent {
   public readonly type = AbilitiesComponentType.GameplayTags;
+  /**
+   * Read-only union of {@link adHocTags} and all tags currently held by an
+   * active effect grant (i.e. effectGrantCounts.get(tag) > 0). Maintained
+   * incrementally by the systems and facade so lookups stay O(1) on the hot
+   * path. Treat as read-only outside the abilities package.
+   */
   public readonly tags = new Set<string>();
+  /** Tags added manually by `AbilitySystemFacade.addTag`. */
+  public readonly adHocTags = new Set<string>();
+  /**
+   * Per-tag count of active effect grants. Incremented by
+   * `EffectApplicationSystem` when an effect's `tagsGranted` entry is
+   * applied; decremented by `EffectTickSystem` when that effect expires.
+   * When the count drops to zero AND the tag is not in {@link adHocTags},
+   * the tag is removed from {@link tags}.
+   */
+  public readonly effectGrantCounts = new Map<string, number>();
 }

--- a/phalanx-abilities/src/components/GameplayTagsComponent.ts
+++ b/phalanx-abilities/src/components/GameplayTagsComponent.ts
@@ -1,0 +1,19 @@
+import type { IComponent } from 'phalanx-ecs';
+import { AbilitiesComponentType } from './AbilitiesComponentType';
+
+/**
+ * Hierarchical gameplay tags attached to an entity.
+ *
+ * Tags are opaque dotted strings (e.g. `State.Buff.Speed`,
+ * `Cooldown.Ability.AutoAttack`). String equality is the only operation:
+ * hierarchy is interpretation, not enforced storage. This keeps tag checks
+ * branch-free `Set.has(...)` lookups on the hot path.
+ *
+ * Tags are mutated only by the ability systems (`EffectApplicationSystem`,
+ * `EffectTickSystem`) or by `AbilitySystemFacade.addTag`/`removeTag`. User
+ * code must not mutate `tags` directly.
+ */
+export class GameplayTagsComponent implements IComponent {
+  public readonly type = AbilitiesComponentType.GameplayTags;
+  public readonly tags = new Set<string>();
+}

--- a/phalanx-abilities/src/components/index.ts
+++ b/phalanx-abilities/src/components/index.ts
@@ -2,3 +2,4 @@ export { AbilitiesComponentType } from './AbilitiesComponentType';
 export { ActiveEffectsComponent } from './ActiveEffectsComponent';
 export type { PendingEffectAdd } from './ActiveEffectsComponent';
 export { AttributesComponent } from './AttributesComponent';
+export { GameplayTagsComponent } from './GameplayTagsComponent';

--- a/phalanx-abilities/src/index.ts
+++ b/phalanx-abilities/src/index.ts
@@ -1,6 +1,7 @@
 export * from './api';
 export * from './components';
 export * from './registry';
+export * from './runtime';
 export * from './systems';
 export type * from './spatial';
 export type * from './types';

--- a/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
+++ b/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
@@ -1,0 +1,21 @@
+import { InstanceIdCounter } from './InstanceIdCounter';
+
+/**
+ * Per-world runtime state for the ability system.
+ *
+ * The {@link AbilitySystemRegistries} bundle holds *definitions* (attributes,
+ * effects, abilities, hooks) which are immutable across the lifetime of a
+ * world. Mutable per-world state — currently just the monotonic instance-id
+ * counter for {@link ActiveEffectInstance} — lives here so two parallel
+ * `GameWorld` instances cannot accidentally share counters and break
+ * determinism.
+ */
+export interface AbilitySystemRuntime {
+  instanceIdCounter: InstanceIdCounter;
+}
+
+export function createAbilitySystemRuntime(): AbilitySystemRuntime {
+  return {
+    instanceIdCounter: new InstanceIdCounter(),
+  };
+}

--- a/phalanx-abilities/src/runtime/InstanceIdCounter.ts
+++ b/phalanx-abilities/src/runtime/InstanceIdCounter.ts
@@ -1,0 +1,24 @@
+/**
+ * Monotonically-increasing counter for {@link ActiveEffectInstance.instanceId}.
+ *
+ * Determinism contract:
+ *  - Each world owns one counter. All effect applications go through the
+ *    facade so the ordering of `next()` calls is fully determined by the
+ *    sequence of `applyEffect`/`pendingAdd` drains within a tick.
+ *  - Values are strictly increasing and never reused, so FIFO aggregation
+ *    in `AttributeAggregationSystem` matches insertion order regardless of
+ *    how `ActiveEffectsComponent.queue` is rearranged later.
+ */
+export class InstanceIdCounter {
+  private value = 0;
+
+  public next(): number {
+    this.value += 1;
+    return this.value;
+  }
+
+  /** Current high-water mark; useful for snapshot/golden-hash tests. */
+  public get current(): number {
+    return this.value;
+  }
+}

--- a/phalanx-abilities/src/runtime/index.ts
+++ b/phalanx-abilities/src/runtime/index.ts
@@ -1,0 +1,3 @@
+export { InstanceIdCounter } from './InstanceIdCounter';
+export { createAbilitySystemRuntime } from './AbilitySystemRuntime';
+export type { AbilitySystemRuntime } from './AbilitySystemRuntime';

--- a/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
+++ b/phalanx-abilities/src/systems/AttributeAggregationSystem.ts
@@ -123,11 +123,26 @@ export class AttributeAggregationSystem extends GameSystem {
 
   private readonly resolvedEffectDefsBuffer: EffectDef[] = [];
 
+  /**
+   * Resolve {@link EffectDef}s for the entity's ordered queue.
+   *
+   * `Periodic` effects are deliberately filtered out here: in Stage 3 their
+   * application path enqueues them like `Duration` effects (so their
+   * `tagsGranted` and lifecycle work today), but their modifiers must NOT be
+   * applied continuously to `current` — by definition periodic modifiers are
+   * supposed to fire on a per-period cadence, which Stage 4 will implement.
+   * Until then, treating their modifiers as always-on would be incorrect and
+   * would diverge from the documented Stage 3 contract.
+   */
   private resolveEffectDefs(orderedEffects: readonly ActiveEffectInstance[]): readonly EffectDef[] {
     const buffer = this.resolvedEffectDefsBuffer;
     buffer.length = 0;
     for (let i = 0; i < orderedEffects.length; i++) {
-      buffer.push(this.registries.effects.get(orderedEffects[i].defId));
+      const def = this.registries.effects.get(orderedEffects[i].defId);
+      if (def.type === 'Periodic') {
+        continue;
+      }
+      buffer.push(def);
     }
     return buffer;
   }

--- a/phalanx-abilities/src/systems/EffectApplicationSystem.ts
+++ b/phalanx-abilities/src/systems/EffectApplicationSystem.ts
@@ -101,10 +101,15 @@ export class EffectApplicationSystem extends GameSystem {
       return;
     }
 
-    // Tag grants are applied regardless of effect type (Instant grants are
-    // ephemeral in practice because Instant carries no lifecycle — but we
-    // honor `tagsGranted` for both for consistency; users who don't want
-    // sticky tags on Instant simply leave the field empty).
+    // Validate everything that can throw BEFORE any visible mutation so a
+    // misconfigured effect cannot leave the entity in a half-applied state
+    // (e.g. tags granted while the effect itself was rejected). The cost is
+    // two extra passes for Duration/Periodic — cheap given typical modifier
+    // counts (1-3) and amortized by attributeIndexCache.
+    this.validateEffectOrThrow(effectDef, attributeIndexCache);
+
+    // From here on out the effect cannot reject itself, so it is safe to
+    // grant tags and queue the instance atomically.
     this.grantTags(effectDef, tags);
 
     switch (effectDef.type) {
@@ -115,6 +120,35 @@ export class EffectApplicationSystem extends GameSystem {
       case 'Periodic':
         this.queueDurational(entity, effectDef, pending, attributeIndexCache, tick);
         return;
+    }
+  }
+
+  /**
+   * Pre-flight validation for the slow paths that can throw at apply time.
+   * Currently catches:
+   *  - Duration/Periodic with missing or non-positive `durationTicks`.
+   *  - Modifiers that reference an attribute id not registered with this world.
+   *
+   * Throws on any inconsistency; otherwise returns silently. Populates
+   * `attributeIndexCache` as a side-effect so the subsequent apply path does
+   * not re-resolve indices.
+   */
+  private validateEffectOrThrow(
+    effectDef: EffectDef,
+    attributeIndexCache: Map<string, number>
+  ): void {
+    if (effectDef.type === 'Duration' || effectDef.type === 'Periodic') {
+      const durationTicks = effectDef.durationTicks;
+      if (durationTicks === undefined || durationTicks <= 0) {
+        throw new Error(
+          `EffectDef '${effectDef.id}' is type '${effectDef.type}' but has invalid durationTicks=${String(durationTicks)}`
+        );
+      }
+    }
+    // Pre-resolve modifier attribute indices so registry.indexOf failures
+    // surface here, not after tag grants. Cached resolutions are reused.
+    for (const modifier of effectDef.modifiers) {
+      this.resolveAttributeIndex(modifier.attributeId, attributeIndexCache);
     }
   }
 
@@ -140,7 +174,13 @@ export class EffectApplicationSystem extends GameSystem {
     if (!effectDef.tagsGranted) {
       return;
     }
+    // Increment per-tag effect-grant ref count and reflect into the unified
+    // `tags` set. The unified set is the lookup surface (hasTag uses it); the
+    // ref count is the source of truth for revocation. Ad-hoc ownership in
+    // `adHocTags` is unaffected by grants.
     for (const tag of effectDef.tagsGranted) {
+      const current = tags.effectGrantCounts.get(tag) ?? 0;
+      tags.effectGrantCounts.set(tag, current + 1);
       tags.tags.add(tag);
     }
   }
@@ -183,17 +223,13 @@ export class EffectApplicationSystem extends GameSystem {
       throw new Error('ActiveEffectsComponent missing while draining pendingAdd');
     }
 
-    const durationTicks = effectDef.durationTicks;
-    if (durationTicks === undefined || durationTicks <= 0) {
-      throw new Error(
-        `EffectDef '${effectDef.id}' is type '${effectDef.type}' but has invalid durationTicks=${String(durationTicks)}`
-      );
-    }
-
+    // durationTicks was validated upstream in validateEffectOrThrow, so the
+    // non-null assertion below is safe — keep the cast local.
+    const durationTicksValidated = effectDef.durationTicks as number;
     const instance: ActiveEffectInstance = {
       instanceId: this.runtime.instanceIdCounter.next(),
       defId: effectDef.id,
-      remainingTicks: durationTicks,
+      remainingTicks: durationTicksValidated,
       // Stage 4 will use nextPeriodTick; in Stage 3 we initialize to 0.
       nextPeriodTick: 0,
       sourceEntityId: pending.sourceEntityId,

--- a/phalanx-abilities/src/systems/EffectApplicationSystem.ts
+++ b/phalanx-abilities/src/systems/EffectApplicationSystem.ts
@@ -1,0 +1,264 @@
+import { GameSystem } from 'phalanx-ecs';
+import type { Entity } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FixedPoint } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  ActiveEffectsComponent,
+  AttributesComponent,
+  GameplayTagsComponent,
+} from '../components';
+import type { PendingEffectAdd } from '../components';
+import type { AbilitySystemRegistries } from '../registry';
+import type { AbilitySystemRuntime } from '../runtime';
+import type { ActiveEffectInstance, EffectDef, Modifier, ModifierOp } from '../types';
+
+/**
+ * Drains `ActiveEffectsComponent.pendingAdd` per entity and applies each
+ * effect deterministically.
+ *
+ * Per pending entry (in the order they were enqueued by `applyEffect`):
+ *  1. Resolve the {@link EffectDef} from the registry.
+ *  2. Gate by tag predicates against the target's
+ *     {@link GameplayTagsComponent}:
+ *      - if `tagsRequired` is set, every tag must be present;
+ *      - if `tagsBlocked` is set, none of the tags may be present.
+ *     A gated effect is dropped (the cooldown / source-side mechanics are
+ *     handled by future stages — Stage 3 only models the application path).
+ *  3. Grant `tagsGranted` on the target (idempotent set semantics).
+ *  4. For `Instant`:
+ *      - apply each modifier directly to the matching attribute's `base`;
+ *      - mark that attribute dirty so `AttributeAggregationSystem`
+ *        recomputes `current` on the same tick (system order guarantees
+ *        application runs before aggregation).
+ *  5. For `Duration`:
+ *      - allocate a monotonic `instanceId` from the runtime counter;
+ *      - push an {@link ActiveEffectInstance} onto `queue` in
+ *        `instanceId` ASC order (insertions are monotonic, so append
+ *        preserves the invariant that `AttributeAggregationSystem`
+ *        relies on);
+ *      - mark every attribute referenced by the effect's modifiers dirty.
+ *  6. For `Periodic`:
+ *      - Stage 4 will handle the periodic tick semantics. In Stage 3 we
+ *        treat the application identically to `Duration` (queue + dirty)
+ *        but do not yet apply per-period modifiers. The dedicated test
+ *        suite for Periodic lives in stage 4.
+ *
+ * The system itself never *removes* effects — that responsibility belongs
+ * to {@link EffectTickSystem}, including expirations from `removeEffectsBy*`
+ * helpers (which queue removals into the same pipeline).
+ */
+export class EffectApplicationSystem extends GameSystem {
+  public constructor(
+    private readonly registries: AbilitySystemRegistries,
+    private readonly runtime: AbilitySystemRuntime
+  ) {
+    super();
+  }
+
+  public override processTick(_tick: number): void {
+    const entities = this.entityManager.queryEntities(AbilitiesComponentType.ActiveEffects);
+    const attributeIndexCache = this.attributeIndexCache;
+    attributeIndexCache.clear();
+
+    for (const entity of entities) {
+      const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+        AbilitiesComponentType.ActiveEffects
+      );
+      if (!activeEffects || activeEffects.pendingAdd.length === 0) {
+        continue;
+      }
+
+      // Drain pendingAdd by swapping with a stable empty array so re-entrant
+      // applyEffect calls from inside (none today; insurance for the future)
+      // accumulate for the next tick.
+      const drained = activeEffects.pendingAdd.splice(0, activeEffects.pendingAdd.length);
+
+      for (let i = 0; i < drained.length; i++) {
+        this.applyOne(entity, drained[i], attributeIndexCache);
+      }
+    }
+  }
+
+  private readonly attributeIndexCache = new Map<string, number>();
+
+  private applyOne(
+    entity: Entity,
+    pending: PendingEffectAdd,
+    attributeIndexCache: Map<string, number>
+  ): void {
+    const effectDef = this.registries.effects.tryGet(pending.defId);
+    if (!effectDef) {
+      // Misconfigured caller: a defId that isn't registered. Surface loudly so
+      // determinism bugs don't hide behind silent drops.
+      throw new Error(`EffectRegistry does not contain '${pending.defId}'`);
+    }
+
+    const tags = this.getOrCreateTags(entity);
+
+    if (!this.checkTagPredicates(effectDef, tags)) {
+      return;
+    }
+
+    // Tag grants are applied regardless of effect type (Instant grants are
+    // ephemeral in practice because Instant carries no lifecycle — but we
+    // honor `tagsGranted` for both for consistency; users who don't want
+    // sticky tags on Instant simply leave the field empty).
+    this.grantTags(effectDef, tags);
+
+    switch (effectDef.type) {
+      case 'Instant':
+        this.applyInstant(entity, effectDef, attributeIndexCache);
+        return;
+      case 'Duration':
+      case 'Periodic':
+        this.queueDurational(entity, effectDef, pending, attributeIndexCache);
+        return;
+    }
+  }
+
+  private checkTagPredicates(effectDef: EffectDef, tags: GameplayTagsComponent): boolean {
+    if (effectDef.tagsRequired) {
+      for (const tag of effectDef.tagsRequired) {
+        if (!tags.tags.has(tag)) {
+          return false;
+        }
+      }
+    }
+    if (effectDef.tagsBlocked) {
+      for (const tag of effectDef.tagsBlocked) {
+        if (tags.tags.has(tag)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private grantTags(effectDef: EffectDef, tags: GameplayTagsComponent): void {
+    if (!effectDef.tagsGranted) {
+      return;
+    }
+    for (const tag of effectDef.tagsGranted) {
+      tags.tags.add(tag);
+    }
+  }
+
+  private applyInstant(
+    entity: Entity,
+    effectDef: EffectDef,
+    attributeIndexCache: Map<string, number>
+  ): void {
+    const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+    if (!attributes) {
+      // Instant effects with attribute modifiers need an AttributesComponent.
+      // If the target has none, we silently no-op the modifier application —
+      // tag grants above still took effect. Users that need Instant effects
+      // on tag-only entities should leave `modifiers` empty.
+      return;
+    }
+
+    for (const modifier of effectDef.modifiers) {
+      const index = this.resolveAttributeIndex(modifier.attributeId, attributeIndexCache);
+      const current = FP.FromRaw(attributes.base[index]);
+      const next = applyInstantModifier(current, modifier.op, modifier.magnitude);
+      attributes.base[index] = FP.ToRaw(next);
+      attributes.dirty[index] = 1;
+    }
+  }
+
+  private queueDurational(
+    entity: Entity,
+    effectDef: EffectDef,
+    pending: PendingEffectAdd,
+    attributeIndexCache: Map<string, number>
+  ): void {
+    const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+      AbilitiesComponentType.ActiveEffects
+    );
+    // pendingAdd lives on ActiveEffectsComponent, so it must exist here.
+    if (!activeEffects) {
+      throw new Error('ActiveEffectsComponent missing while draining pendingAdd');
+    }
+
+    const durationTicks = effectDef.durationTicks;
+    if (durationTicks === undefined || durationTicks <= 0) {
+      throw new Error(
+        `EffectDef '${effectDef.id}' is type '${effectDef.type}' but has invalid durationTicks=${String(durationTicks)}`
+      );
+    }
+
+    const instance: ActiveEffectInstance = {
+      instanceId: this.runtime.instanceIdCounter.next(),
+      defId: effectDef.id,
+      remainingTicks: durationTicks,
+      // Stage 4 will use nextPeriodTick; in Stage 3 we initialize to 0.
+      nextPeriodTick: 0,
+      sourceEntityId: pending.sourceEntityId,
+    };
+    activeEffects.queue.push(instance);
+
+    // Mark every attribute referenced by the effect dirty so aggregation
+    // picks up the new modifier set on this same tick.
+    this.markAttributesDirty(entity, effectDef.modifiers, attributeIndexCache);
+  }
+
+  private markAttributesDirty(
+    entity: Entity,
+    modifiers: readonly Modifier[],
+    attributeIndexCache: Map<string, number>
+  ): void {
+    if (modifiers.length === 0) {
+      return;
+    }
+    const attributes = entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+    if (!attributes) {
+      return;
+    }
+    for (const modifier of modifiers) {
+      const index = this.resolveAttributeIndex(modifier.attributeId, attributeIndexCache);
+      attributes.dirty[index] = 1;
+    }
+  }
+
+  private resolveAttributeIndex(
+    attributeId: string,
+    attributeIndexCache: Map<string, number>
+  ): number {
+    const cached = attributeIndexCache.get(attributeId);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const index = this.registries.attributes.indexOf(attributeId);
+    attributeIndexCache.set(attributeId, index);
+    return index;
+  }
+
+  private getOrCreateTags(entity: Entity): GameplayTagsComponent {
+    const existing = entity.getComponent<GameplayTagsComponent>(
+      AbilitiesComponentType.GameplayTags
+    );
+    if (existing) {
+      return existing;
+    }
+    const tags = new GameplayTagsComponent();
+    entity.addComponent(tags);
+    this.entityManager.onComponentAdded(entity, tags.type);
+    return tags;
+  }
+}
+
+function applyInstantModifier(
+  value: FixedPoint,
+  op: ModifierOp,
+  magnitude: FixedPoint
+): FixedPoint {
+  switch (op) {
+    case 'Add':
+      return FP.Add(value, magnitude);
+    case 'Multiply':
+      return FP.Mul(value, magnitude);
+    case 'Override':
+      return magnitude;
+  }
+}

--- a/phalanx-abilities/src/systems/EffectApplicationSystem.ts
+++ b/phalanx-abilities/src/systems/EffectApplicationSystem.ts
@@ -56,7 +56,7 @@ export class EffectApplicationSystem extends GameSystem {
     super();
   }
 
-  public override processTick(_tick: number): void {
+  public override processTick(tick: number): void {
     const entities = this.entityManager.queryEntities(AbilitiesComponentType.ActiveEffects);
     const attributeIndexCache = this.attributeIndexCache;
     attributeIndexCache.clear();
@@ -75,7 +75,7 @@ export class EffectApplicationSystem extends GameSystem {
       const drained = activeEffects.pendingAdd.splice(0, activeEffects.pendingAdd.length);
 
       for (let i = 0; i < drained.length; i++) {
-        this.applyOne(entity, drained[i], attributeIndexCache);
+        this.applyOne(entity, drained[i], attributeIndexCache, tick);
       }
     }
   }
@@ -85,7 +85,8 @@ export class EffectApplicationSystem extends GameSystem {
   private applyOne(
     entity: Entity,
     pending: PendingEffectAdd,
-    attributeIndexCache: Map<string, number>
+    attributeIndexCache: Map<string, number>,
+    tick: number
   ): void {
     const effectDef = this.registries.effects.tryGet(pending.defId);
     if (!effectDef) {
@@ -112,7 +113,7 @@ export class EffectApplicationSystem extends GameSystem {
         return;
       case 'Duration':
       case 'Periodic':
-        this.queueDurational(entity, effectDef, pending, attributeIndexCache);
+        this.queueDurational(entity, effectDef, pending, attributeIndexCache, tick);
         return;
     }
   }
@@ -171,7 +172,8 @@ export class EffectApplicationSystem extends GameSystem {
     entity: Entity,
     effectDef: EffectDef,
     pending: PendingEffectAdd,
-    attributeIndexCache: Map<string, number>
+    attributeIndexCache: Map<string, number>,
+    tick: number
   ): void {
     const activeEffects = entity.getComponent<ActiveEffectsComponent>(
       AbilitiesComponentType.ActiveEffects
@@ -195,6 +197,10 @@ export class EffectApplicationSystem extends GameSystem {
       // Stage 4 will use nextPeriodTick; in Stage 3 we initialize to 0.
       nextPeriodTick: 0,
       sourceEntityId: pending.sourceEntityId,
+      // Record the application tick so EffectTickSystem can skip the very
+      // first countdown for this instance — without that, a durationTicks=1
+      // effect would expire before AttributeAggregationSystem ever sees it.
+      enteredOnTick: tick,
     };
     activeEffects.queue.push(instance);
 

--- a/phalanx-abilities/src/systems/EffectTickSystem.ts
+++ b/phalanx-abilities/src/systems/EffectTickSystem.ts
@@ -38,7 +38,7 @@ export class EffectTickSystem extends GameSystem {
     super();
   }
 
-  public override processTick(_tick: number): void {
+  public override processTick(tick: number): void {
     const entities = this.entityManager.queryEntities(AbilitiesComponentType.ActiveEffects);
 
     for (const entity of entities) {
@@ -49,18 +49,31 @@ export class EffectTickSystem extends GameSystem {
         continue;
       }
 
-      this.tickEntity(entity, activeEffects);
+      this.tickEntity(entity, activeEffects, tick);
     }
   }
 
-  private tickEntity(entity: Entity, activeEffects: ActiveEffectsComponent): void {
+  private tickEntity(
+    entity: Entity,
+    activeEffects: ActiveEffectsComponent,
+    tick: number
+  ): void {
     const queue = activeEffects.queue;
 
     // First pass: countdown.
+    //
+    // Instances inserted by EffectApplicationSystem earlier in *this same*
+    // tick must NOT be decremented yet — otherwise a valid durationTicks=1
+    // effect would reach remainingTicks=0 and be removed before
+    // AttributeAggregationSystem runs, never becoming visible. We identify
+    // such instances by enteredOnTick === current tick. Effects scheduled
+    // for immediate removal (remainingTicks <= 0, set by removeEffectsBy*)
+    // are also left alone here and harvested in the second pass.
     for (let i = 0; i < queue.length; i++) {
       const instance = queue[i];
-      // Effects scheduled for immediate removal carry remainingTicks <= 0
-      // already; do not underflow them further.
+      if (instance.enteredOnTick === tick) {
+        continue;
+      }
       if (instance.remainingTicks > 0) {
         instance.remainingTicks -= 1;
       }

--- a/phalanx-abilities/src/systems/EffectTickSystem.ts
+++ b/phalanx-abilities/src/systems/EffectTickSystem.ts
@@ -128,37 +128,29 @@ export class EffectTickSystem extends GameSystem {
   private revokeTags(
     effectDef: EffectDef,
     tags: GameplayTagsComponent | undefined,
-    remainingQueue: readonly ActiveEffectInstance[]
+    _remainingQueue: readonly ActiveEffectInstance[]
   ): void {
     if (!tags || !effectDef.tagsGranted || effectDef.tagsGranted.length === 0) {
       return;
     }
 
+    // Decrement per-tag effect-grant ref counts. A tag is removed from the
+    // unified `tags` set only when its grant count reaches zero AND the tag
+    // is not also held ad hoc (via `addTag`). This keeps lifecycle revocation
+    // from clobbering manually managed tags, and — because shared grants are
+    // now tracked by counts rather than queue scans — removes the O(n*m)
+    // re-scan of the remaining queue per expired effect.
     for (const grantedTag of effectDef.tagsGranted) {
-      if (this.tagGrantedByAnyRemaining(grantedTag, remainingQueue)) {
-        // Another still-active instance grants the same tag; keep it.
-        continue;
-      }
-      tags.tags.delete(grantedTag);
-    }
-  }
-
-  private tagGrantedByAnyRemaining(
-    tag: string,
-    queue: readonly ActiveEffectInstance[]
-  ): boolean {
-    for (let i = 0; i < queue.length; i++) {
-      const def = this.registries.effects.tryGet(queue[i].defId);
-      if (!def || !def.tagsGranted) {
-        continue;
-      }
-      for (const grantedTag of def.tagsGranted) {
-        if (grantedTag === tag) {
-          return true;
+      const current = tags.effectGrantCounts.get(grantedTag) ?? 0;
+      if (current <= 1) {
+        tags.effectGrantCounts.delete(grantedTag);
+        if (!tags.adHocTags.has(grantedTag)) {
+          tags.tags.delete(grantedTag);
         }
+      } else {
+        tags.effectGrantCounts.set(grantedTag, current - 1);
       }
     }
-    return false;
   }
 
   private markModifiersDirty(

--- a/phalanx-abilities/src/systems/EffectTickSystem.ts
+++ b/phalanx-abilities/src/systems/EffectTickSystem.ts
@@ -1,0 +1,163 @@
+import { GameSystem } from 'phalanx-ecs';
+import type { Entity } from 'phalanx-ecs';
+import {
+  AbilitiesComponentType,
+  ActiveEffectsComponent,
+  AttributesComponent,
+  GameplayTagsComponent,
+} from '../components';
+import type { AbilitySystemRegistries } from '../registry';
+import type { ActiveEffectInstance, EffectDef } from '../types';
+
+/**
+ * Per-tick lifecycle for `Duration` (and, from Stage 4, `Periodic`) effects.
+ *
+ * Stage 3 responsibilities:
+ *  - Decrement `remainingTicks` on every queued `ActiveEffectInstance`.
+ *  - Remove expired instances (`remainingTicks <= 0`).
+ *  - On removal:
+ *      * revoke `tagsGranted` from the target's
+ *        {@link GameplayTagsComponent}, but only when no other still-active
+ *        instance grants the same tag (set semantics: a tag is "on" while
+ *        any granter is present);
+ *      * mark every attribute referenced by the removed effect's
+ *        modifiers dirty, so {@link AttributeAggregationSystem}
+ *        recomputes `current` without the expired modifier on the same
+ *        tick (system order: this system runs before aggregation).
+ *
+ * Removals queued by `removeEffectsByTag` / `removeEffectsByDefId` flow
+ * through this same path: the facade sets `remainingTicks = 0` on the
+ * targeted instance(s); this system then handles revocation in tick order.
+ *
+ * The system relies on the invariant — established by
+ * {@link EffectApplicationSystem} and `AbilitySystemFacade.removeEffectsBy*`
+ * — that `queue` is sorted by `instanceId` ASC. It does not re-sort.
+ */
+export class EffectTickSystem extends GameSystem {
+  public constructor(private readonly registries: AbilitySystemRegistries) {
+    super();
+  }
+
+  public override processTick(_tick: number): void {
+    const entities = this.entityManager.queryEntities(AbilitiesComponentType.ActiveEffects);
+
+    for (const entity of entities) {
+      const activeEffects = entity.getComponent<ActiveEffectsComponent>(
+        AbilitiesComponentType.ActiveEffects
+      );
+      if (!activeEffects || activeEffects.queue.length === 0) {
+        continue;
+      }
+
+      this.tickEntity(entity, activeEffects);
+    }
+  }
+
+  private tickEntity(entity: Entity, activeEffects: ActiveEffectsComponent): void {
+    const queue = activeEffects.queue;
+
+    // First pass: countdown.
+    for (let i = 0; i < queue.length; i++) {
+      const instance = queue[i];
+      // Effects scheduled for immediate removal carry remainingTicks <= 0
+      // already; do not underflow them further.
+      if (instance.remainingTicks > 0) {
+        instance.remainingTicks -= 1;
+      }
+    }
+
+    // Second pass: extract expired and compact the queue, preserving order.
+    const expired: ActiveEffectInstance[] = [];
+    let writeIndex = 0;
+    for (let readIndex = 0; readIndex < queue.length; readIndex++) {
+      const instance = queue[readIndex];
+      if (instance.remainingTicks <= 0) {
+        expired.push(instance);
+        continue;
+      }
+      if (writeIndex !== readIndex) {
+        queue[writeIndex] = instance;
+      }
+      writeIndex += 1;
+    }
+    queue.length = writeIndex;
+
+    if (expired.length === 0) {
+      return;
+    }
+
+    this.processExpirations(entity, activeEffects, expired);
+  }
+
+  private processExpirations(
+    entity: Entity,
+    activeEffects: ActiveEffectsComponent,
+    expired: readonly ActiveEffectInstance[]
+  ): void {
+    const tags = entity.getComponent<GameplayTagsComponent>(AbilitiesComponentType.GameplayTags);
+    const attributes = entity.getComponent<AttributesComponent>(
+      AbilitiesComponentType.Attributes
+    );
+
+    for (const instance of expired) {
+      const effectDef = this.registries.effects.tryGet(instance.defId);
+      if (!effectDef) {
+        // Definitions are immutable per world, so a missing def here is a
+        // genuine bug; surface it instead of silently swallowing.
+        throw new Error(`EffectRegistry does not contain '${instance.defId}'`);
+      }
+
+      this.revokeTags(effectDef, tags, activeEffects.queue);
+      this.markModifiersDirty(effectDef, attributes);
+    }
+  }
+
+  private revokeTags(
+    effectDef: EffectDef,
+    tags: GameplayTagsComponent | undefined,
+    remainingQueue: readonly ActiveEffectInstance[]
+  ): void {
+    if (!tags || !effectDef.tagsGranted || effectDef.tagsGranted.length === 0) {
+      return;
+    }
+
+    for (const grantedTag of effectDef.tagsGranted) {
+      if (this.tagGrantedByAnyRemaining(grantedTag, remainingQueue)) {
+        // Another still-active instance grants the same tag; keep it.
+        continue;
+      }
+      tags.tags.delete(grantedTag);
+    }
+  }
+
+  private tagGrantedByAnyRemaining(
+    tag: string,
+    queue: readonly ActiveEffectInstance[]
+  ): boolean {
+    for (let i = 0; i < queue.length; i++) {
+      const def = this.registries.effects.tryGet(queue[i].defId);
+      if (!def || !def.tagsGranted) {
+        continue;
+      }
+      for (const grantedTag of def.tagsGranted) {
+        if (grantedTag === tag) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  private markModifiersDirty(
+    effectDef: EffectDef,
+    attributes: AttributesComponent | undefined
+  ): void {
+    if (!attributes || effectDef.modifiers.length === 0) {
+      return;
+    }
+    for (const modifier of effectDef.modifiers) {
+      const index = this.registries.attributes.indexOf(modifier.attributeId);
+      attributes.dirty[index] = 1;
+    }
+  }
+}

--- a/phalanx-abilities/src/systems/index.ts
+++ b/phalanx-abilities/src/systems/index.ts
@@ -1,1 +1,3 @@
 export { AttributeAggregationSystem } from './AttributeAggregationSystem';
+export { EffectApplicationSystem } from './EffectApplicationSystem';
+export { EffectTickSystem } from './EffectTickSystem';

--- a/phalanx-abilities/src/types/ActiveEffectInstance.ts
+++ b/phalanx-abilities/src/types/ActiveEffectInstance.ts
@@ -5,5 +5,18 @@ export interface ActiveEffectInstance {
   remainingTicks: number;
   /** Only meaningful for Periodic effects. */
   nextPeriodTick: number;
+  /**
+   * Source entity that applied the effect, or `-1` for no source (e.g. world
+   * hazards, debug spawns). Effects authored by the facade's
+   * {@link AbilitySystemFacade.applyEffect} default to `-1` when the caller
+   * omits a source.
+   */
   sourceEntityId: number;
+  /**
+   * Tick at which this instance was inserted into the queue by
+   * {@link EffectApplicationSystem}. Used by {@link EffectTickSystem} to skip
+   * the very first countdown so a freshly-applied effect with `durationTicks=1`
+   * survives through {@link AttributeAggregationSystem} on its application tick.
+   */
+  enteredOnTick: number;
 }

--- a/phalanx-abilities/tests/attributes.test.ts
+++ b/phalanx-abilities/tests/attributes.test.ts
@@ -7,6 +7,7 @@ import {
   ActiveEffectsComponent,
   AttributeAggregationSystem,
   createAbilitySystemRegistries,
+  createAbilitySystemRuntime,
   defineAttribute,
   defineEffect,
 } from '../src';
@@ -45,9 +46,10 @@ describe('attributes and aggregation', () => {
         clamp: 'both',
       })
     );
+    const runtime = createAbilitySystemRuntime();
     const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
     world.registerSystems([new AttributeAggregationSystem(registries)], []);
-    const facade = new AbilitySystemFacade(world.entityManager, registries);
+    const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
 
     const entity = addEntity(world);
     facade.initAttributesForEntity(entity.id);
@@ -112,9 +114,10 @@ describe('attributes and aggregation', () => {
         modifiers: [{ attributeId: 'ClampMax', op: 'Add', magnitude: FP.FromInt(200) }],
       })
     );
+    const runtime = createAbilitySystemRuntime();
     const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
     world.registerSystems([new AttributeAggregationSystem(registries)], []);
-    const facade = new AbilitySystemFacade(world.entityManager, registries);
+    const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
 
     const entity = addEntity(world);
     const attributes = facade.initAttributesForEntity(entity.id);
@@ -399,11 +402,12 @@ function createTestWorld() {
     })
   );
 
+  const runtime = createAbilitySystemRuntime();
   const world = new GameWorld({ componentTypes: [AbilitiesComponentType.Attributes] });
   world.registerSystems([new AttributeAggregationSystem(registries)], []);
-  const facade = new AbilitySystemFacade(world.entityManager, registries);
+  const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
 
-  return { world, facade, registries };
+  return { world, facade, registries, runtime };
 }
 
 function addEntity(world: GameWorld): Entity {

--- a/phalanx-abilities/tests/attributes.test.ts
+++ b/phalanx-abilities/tests/attributes.test.ts
@@ -129,6 +129,7 @@ describe('attributes and aggregation', () => {
         remainingTicks: 10,
         nextPeriodTick: 0,
         sourceEntityId: entity.id,
+        enteredOnTick: 0,
       },
       {
         instanceId: 2,
@@ -136,6 +137,7 @@ describe('attributes and aggregation', () => {
         remainingTicks: 10,
         nextPeriodTick: 0,
         sourceEntityId: entity.id,
+        enteredOnTick: 0,
       },
       {
         instanceId: 3,
@@ -143,6 +145,7 @@ describe('attributes and aggregation', () => {
         remainingTicks: 10,
         nextPeriodTick: 0,
         sourceEntityId: entity.id,
+        enteredOnTick: 0,
       }
     );
     attributes.dirty[0] = 1;

--- a/phalanx-abilities/tests/effects.test.ts
+++ b/phalanx-abilities/tests/effects.test.ts
@@ -375,6 +375,113 @@ describe('effect application', () => {
     world.dispose();
   });
 
+  it('expiring an effect does not revoke a tag that is also held ad hoc', () => {
+    // Regression: previously revokeTags deleted the granted tag directly from
+    // the unified set without checking ad-hoc ownership, so an expiring effect
+    // could drop a manually managed (faction/team-like) tag.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.GrantsMarked',
+          type: 'Duration',
+          durationTicks: 1,
+          tagsGranted: ['State.Marked'],
+          modifiers: [],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    facade.addTag(entity.id, 'State.Marked');
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(true);
+
+    facade.applyEffect(entity.id, 'Effect.GrantsMarked', entity.id);
+    world.processAllTicks(1);
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(true);
+
+    // Tick 2: the effect expires. The ad-hoc grant must keep the tag alive.
+    world.processAllTicks(2);
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('removeTag preserves an effect-granted tag and only clears ad-hoc ownership', () => {
+    // Regression: previously removeTag deleted from the single Set, so calling
+    // it while an effect granted the same tag silently dropped the effect’s
+    // contribution and the tag never came back on later ticks.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.GrantsBuff',
+          type: 'Duration',
+          durationTicks: 5,
+          tagsGranted: ['State.Buffed'],
+          modifiers: [],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+
+    facade.addTag(entity.id, 'State.Buffed');
+    facade.applyEffect(entity.id, 'Effect.GrantsBuff', entity.id);
+    world.processAllTicks(1);
+    expect(facade.hasTag(entity.id, 'State.Buffed')).toBe(true);
+
+    // Caller clears their ad-hoc ownership while the effect still grants it.
+    const cleared = facade.removeTag(entity.id, 'State.Buffed');
+    expect(cleared).toBe(true);
+    // Tag stays — the effect's grant is still in force.
+    expect(facade.hasTag(entity.id, 'State.Buffed')).toBe(true);
+
+    // A second removeTag call now returns false (no ad-hoc to clear) and the
+    // tag is still held by the effect.
+    expect(facade.removeTag(entity.id, 'State.Buffed')).toBe(false);
+    expect(facade.hasTag(entity.id, 'State.Buffed')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('a misconfigured effect throws atomically and leaves no tag grants behind', () => {
+    // Regression: previously tagsGranted was applied before durationTicks /
+    // modifier-attribute validation, so a throwing effect could leave the
+    // entity with leaked tag grants.
+    const { world, facade } = createTestWorld({
+      effects: [
+        // Duration with no durationTicks — invalid; should throw at apply time.
+        defineEffect({
+          id: 'Effect.BadDuration',
+          type: 'Duration',
+          tagsGranted: ['State.LeakSentinel'],
+          modifiers: [],
+        }),
+        // Modifier references an attribute that the test world does not register.
+        defineEffect({
+          id: 'Effect.BadModifierAttr',
+          type: 'Instant',
+          tagsGranted: ['State.LeakSentinel2'],
+          modifiers: [
+            { attributeId: 'NonExistentAttribute', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.BadDuration', entity.id);
+    expect(() => world.processAllTicks(2)).toThrow();
+    expect(facade.hasTag(entity.id, 'State.LeakSentinel')).toBe(false);
+
+    facade.applyEffect(entity.id, 'Effect.BadModifierAttr', entity.id);
+    expect(() => world.processAllTicks(3)).toThrow();
+    expect(facade.hasTag(entity.id, 'State.LeakSentinel2')).toBe(false);
+
+    world.dispose();
+  });
+
   it('applyEffect omits sourceEntityId and records the sentinel NO_SOURCE_ENTITY_ID', () => {
     const { world, facade } = createTestWorld({
       effects: [

--- a/phalanx-abilities/tests/effects.test.ts
+++ b/phalanx-abilities/tests/effects.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest';
+import { Entity, GameWorld } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  AbilitySystemFacade,
+  AttributeAggregationSystem,
+  EffectApplicationSystem,
+  EffectTickSystem,
+  createAbilitySystemRegistries,
+  createAbilitySystemRuntime,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+import type { AbilitySystemRegistries, AbilitySystemRuntime } from '../src';
+
+describe('effect application', () => {
+  it('applies an Instant effect to base on the same tick (single tick visibility)', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Damage',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    // Settle defaults so dirty starts clean.
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(100);
+
+    facade.applyEffect(entity.id, 'Effect.Damage', entity.id);
+
+    // Application + aggregation both run on tick 2.
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(90);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(90);
+
+    world.dispose();
+  });
+
+  it('queues a Duration effect and reflects it via aggregation; expires on schedule', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.ArmorShred',
+          type: 'Duration',
+          durationTicks: 3,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-20) }],
+          tagsGranted: ['State.Debuff.ArmorShred'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+
+    facade.applyEffect(entity.id, 'Effect.ArmorShred', entity.id);
+
+    // Tick 2: application applies modifier + dirty, aggregation produces Armor=30,
+    // tagsGranted is now present. EffectTickSystem decrements remaining 3 -> 2.
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
+    expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(true);
+
+    // Tick 3: remaining 2 -> 1.
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
+
+    // Tick 4: remaining 1 -> 0, expires, tag revoked, Armor recomputes to 50.
+    world.processAllTicks(4);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+    expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('drops effects gated by tagsBlocked and grants tagsGranted on accepted ones', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Damage',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+          tagsBlocked: ['State.Invulnerable'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.addTag(entity.id, 'State.Invulnerable');
+    facade.applyEffect(entity.id, 'Effect.Damage', entity.id);
+    world.processAllTicks(2);
+    // Effect was dropped: Health unchanged.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(100);
+
+    facade.removeTag(entity.id, 'State.Invulnerable');
+    facade.applyEffect(entity.id, 'Effect.Damage', entity.id);
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(90);
+
+    world.dispose();
+  });
+
+  it('honors tagsRequired (effect drops when missing, applies when present)', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.ExecuteWounded',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-50) }],
+          tagsRequired: ['State.Wounded'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    // No `State.Wounded` yet: must be dropped.
+    facade.applyEffect(entity.id, 'Effect.ExecuteWounded', entity.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(100);
+
+    facade.addTag(entity.id, 'State.Wounded');
+    facade.applyEffect(entity.id, 'Effect.ExecuteWounded', entity.id);
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').base)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('removeEffectsByTag flags matching instances for expiry on the next tick', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.ArmorShred',
+          type: 'Duration',
+          durationTicks: 100,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-20) }],
+          tagsGranted: ['State.Debuff.ArmorShred'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.ArmorShred', entity.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
+    expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(true);
+
+    const flagged = facade.removeEffectsByTag(entity.id, 'State.Debuff.ArmorShred');
+    expect(flagged).toBe(1);
+
+    // Tick 3 runs EffectTickSystem: the flagged instance reaches 0 and is removed,
+    // the tag is revoked, and aggregation recomputes Armor without the modifier.
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+    expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('removeEffectsByDefId only removes matching defId instances', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Slow',
+          type: 'Duration',
+          durationTicks: 100,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-10) }],
+          tagsGranted: ['State.Slowed'],
+        }),
+        defineEffect({
+          id: 'Effect.Poison',
+          type: 'Duration',
+          durationTicks: 100,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-5) }],
+          tagsGranted: ['State.Poisoned'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Slow', entity.id);
+    facade.applyEffect(entity.id, 'Effect.Poison', entity.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(35);
+
+    const flagged = facade.removeEffectsByDefId(entity.id, 'Effect.Slow');
+    expect(flagged).toBe(1);
+
+    world.processAllTicks(3);
+    // Slow gone, Poison still active.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(45);
+    expect(facade.hasTag(entity.id, 'State.Slowed')).toBe(false);
+    expect(facade.hasTag(entity.id, 'State.Poisoned')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('does not revoke a tag while another active instance still grants it', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.MarkShort',
+          type: 'Duration',
+          durationTicks: 2,
+          tagsGranted: ['State.Marked'],
+          modifiers: [],
+        }),
+        defineEffect({
+          id: 'Effect.MarkLong',
+          type: 'Duration',
+          durationTicks: 5,
+          tagsGranted: ['State.Marked'],
+          modifiers: [],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.MarkShort', entity.id);
+    facade.applyEffect(entity.id, 'Effect.MarkLong', entity.id);
+    world.processAllTicks(2);
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(true);
+
+    // Advance until Effect.MarkShort expires: durationTicks=2 means it survives
+    // ticks 2 and 3, expires on tick 4. Effect.MarkLong is still active.
+    world.processAllTicks(3);
+    world.processAllTicks(4);
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(true);
+
+    // After MarkLong also expires (tick 7), the tag is revoked.
+    world.processAllTicks(5);
+    world.processAllTicks(6);
+    world.processAllTicks(7);
+    expect(facade.hasTag(entity.id, 'State.Marked')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('allocates monotonic instance ids in apply order (FIFO is enforced)', () => {
+    const { world, facade, runtime } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.OverrideHealth.10',
+          type: 'Duration',
+          durationTicks: 100,
+          modifiers: [{ attributeId: 'Health', op: 'Override', magnitude: FP.FromInt(10) }],
+        }),
+        defineEffect({
+          id: 'Effect.OverrideHealth.50',
+          type: 'Duration',
+          durationTicks: 100,
+          modifiers: [{ attributeId: 'Health', op: 'Override', magnitude: FP.FromInt(50) }],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+    const before = runtime.instanceIdCounter.current;
+
+    // Apply in order: 10 first, then 50. Highest-instanceId Override wins.
+    facade.applyEffect(entity.id, 'Effect.OverrideHealth.10', entity.id);
+    facade.applyEffect(entity.id, 'Effect.OverrideHealth.50', entity.id);
+    world.processAllTicks(2);
+
+    expect(runtime.instanceIdCounter.current).toBe(before + 2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('applyEffect throws on unknown effect id or missing entity', () => {
+    const { world, facade } = createTestWorld({ effects: [] });
+    const entity = addEntity(world);
+
+    expect(() => facade.applyEffect(entity.id, 'Effect.DoesNotExist', entity.id)).toThrow(
+      "EffectRegistry does not contain 'Effect.DoesNotExist'"
+    );
+    expect(() => facade.applyEffect(9999, 'Effect.DoesNotExist', entity.id)).toThrow(
+      'Entity 9999 does not exist'
+    );
+
+    world.dispose();
+  });
+
+  it('reapplying a Duration effect after expiry restores tag and modifier', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.ShortShred',
+          type: 'Duration',
+          durationTicks: 2,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-15) }],
+          tagsGranted: ['State.Debuff.Shred'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.ShortShred', entity.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(35);
+
+    // durationTicks=2: survives ticks 2 and 3, expires on tick 4.
+    world.processAllTicks(3);
+    world.processAllTicks(4);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+    expect(facade.hasTag(entity.id, 'State.Debuff.Shred')).toBe(false);
+
+    facade.applyEffect(entity.id, 'Effect.ShortShred', entity.id);
+    world.processAllTicks(5);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(35);
+    expect(facade.hasTag(entity.id, 'State.Debuff.Shred')).toBe(true);
+
+    world.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test world helper
+// ---------------------------------------------------------------------------
+
+interface TestWorldOpts {
+  effects: readonly ReturnType<typeof defineEffect>[];
+}
+
+interface TestWorld {
+  world: GameWorld;
+  facade: AbilitySystemFacade;
+  registries: AbilitySystemRegistries;
+  runtime: AbilitySystemRuntime;
+}
+
+function createTestWorld(opts: TestWorldOpts): TestWorld {
+  const registries = createAbilitySystemRegistries();
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Health',
+      default: FP.FromInt(100),
+      min: FP.FromInt(0),
+      max: FP.FromInt(100),
+      clamp: 'both',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Armor',
+      default: FP.FromInt(50),
+      min: FP.FromInt(0),
+      max: FP.FromInt(1000),
+      clamp: 'min',
+    })
+  );
+  for (const effect of opts.effects) {
+    registries.effects.register(effect);
+  }
+
+  const runtime = createAbilitySystemRuntime();
+  const world = new GameWorld({
+    componentTypes: [
+      AbilitiesComponentType.Attributes,
+      AbilitiesComponentType.ActiveEffects,
+      AbilitiesComponentType.GameplayTags,
+    ],
+  });
+  // System order matches the design doc:
+  // EffectApplicationSystem -> EffectTickSystem -> AttributeAggregationSystem.
+  // Each tick: drain pendingAdd, then decrement/expire, then resolve current.
+  world.registerSystems(
+    [
+      new EffectApplicationSystem(registries, runtime),
+      new EffectTickSystem(registries),
+      new AttributeAggregationSystem(registries),
+    ],
+    []
+  );
+  const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
+  return { world, facade, registries, runtime };
+}
+
+function addEntity(world: GameWorld): Entity {
+  const entity = new Entity();
+  world.entityManager.addEntity(entity);
+  return entity;
+}

--- a/phalanx-abilities/tests/effects.test.ts
+++ b/phalanx-abilities/tests/effects.test.ts
@@ -7,6 +7,7 @@ import {
   AttributeAggregationSystem,
   EffectApplicationSystem,
   EffectTickSystem,
+  NO_SOURCE_ENTITY_ID,
   createAbilitySystemRegistries,
   createAbilitySystemRuntime,
   defineAttribute,
@@ -60,18 +61,24 @@ describe('effect application', () => {
 
     facade.applyEffect(entity.id, 'Effect.ArmorShred', entity.id);
 
-    // Tick 2: application applies modifier + dirty, aggregation produces Armor=30,
-    // tagsGranted is now present. EffectTickSystem decrements remaining 3 -> 2.
+    // Tick 2: application inserts the instance with enteredOnTick=2 and
+    // remainingTicks=3, aggregation produces Armor=30, tagsGranted is now
+    // present. EffectTickSystem deliberately does NOT decrement an instance
+    // on its application tick (otherwise durationTicks=1 would be invisible).
     world.processAllTicks(2);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
     expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(true);
 
-    // Tick 3: remaining 2 -> 1.
+    // Tick 3: remaining 3 -> 2.
     world.processAllTicks(3);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
 
-    // Tick 4: remaining 1 -> 0, expires, tag revoked, Armor recomputes to 50.
+    // Tick 4: remaining 2 -> 1.
     world.processAllTicks(4);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(30);
+
+    // Tick 5: remaining 1 -> 0, expires, tag revoked, Armor recomputes to 50.
+    world.processAllTicks(5);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
     expect(facade.hasTag(entity.id, 'State.Debuff.ArmorShred')).toBe(false);
 
@@ -294,6 +301,107 @@ describe('effect application', () => {
     expect(() => facade.applyEffect(9999, 'Effect.DoesNotExist', entity.id)).toThrow(
       'Entity 9999 does not exist'
     );
+
+    world.dispose();
+  });
+
+  it('a durationTicks=1 effect is visible on its application tick and gone the next', () => {
+    // Regression guard: an earlier implementation decremented every instance
+    // on the same tick it was inserted, which made durationTicks=1 effects
+    // expire before AttributeAggregationSystem ever observed them.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.OneTickBuff',
+          type: 'Duration',
+          durationTicks: 1,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(25) }],
+          tagsGranted: ['State.Buff.OneTick'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+
+    facade.applyEffect(entity.id, 'Effect.OneTickBuff', entity.id);
+
+    // Tick 2 (application tick): aggregation must see the buff exactly once.
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(75);
+    expect(facade.hasTag(entity.id, 'State.Buff.OneTick')).toBe(true);
+
+    // Tick 3 (next tick): decrement 1 -> 0, expire, tag revoked, Armor recompute.
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+    expect(facade.hasTag(entity.id, 'State.Buff.OneTick')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('Periodic effects do not bleed into AttributeAggregationSystem in Stage 3', () => {
+    // Periodic effects share the queue path with Duration so they get a
+    // lifecycle and grant tags today, but their modifiers must NOT be applied
+    // continuously by aggregation — Stage 4 will introduce per-period
+    // semantics. The Periodic effect below would otherwise drop Armor by 30.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Poison.Periodic',
+          type: 'Periodic',
+          durationTicks: 5,
+          periodTicks: 1,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-30) }],
+          tagsGranted: ['State.Debuff.Poisoned'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Poison.Periodic', entity.id);
+    world.processAllTicks(2);
+
+    // Tag is granted (lifecycle works), but Armor.current is unchanged: the
+    // Periodic modifier is intentionally invisible to aggregation pre-Stage 4.
+    expect(facade.hasTag(entity.id, 'State.Debuff.Poisoned')).toBe(true);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('applyEffect omits sourceEntityId and records the sentinel NO_SOURCE_ENTITY_ID', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Sourceless',
+          type: 'Duration',
+          durationTicks: 10,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-5) }],
+          tagsGranted: ['State.Sourceless'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+
+    // No source argument — valid call.
+    facade.applyEffect(entity.id, 'Effect.Sourceless');
+    world.processAllTicks(1);
+
+    const activeEffects = world.entityManager
+      .getEntity(entity.id)!
+      .getComponent<import('../src').ActiveEffectsComponent>(
+        AbilitiesComponentType.ActiveEffects
+      )!;
+    expect(activeEffects.queue.length).toBe(1);
+    expect(activeEffects.queue[0].sourceEntityId).toBe(NO_SOURCE_ENTITY_ID);
+    expect(facade.hasTag(entity.id, 'State.Sourceless')).toBe(true);
 
     world.dispose();
   });


### PR DESCRIPTION
Stage 3 of the ability system: the Effects layer built on top of Stage 2's attributes.

## What's new

### Components & runtime
- **`GameplayTagsComponent`** — per-entity `Set<string>` tracking active gameplay tags.
- **`AbilitySystemRuntime` + `InstanceIdCounter`** — monotonic per-world counter producing unique `ActiveEffectInstance.instanceId` values. Lives outside registries (which stay immutable).

### Systems (executed in this order each tick)
1. **`EffectApplicationSystem`**
   - Drains `ActiveEffectsComponent.pendingAdd`
   - Checks `tagsRequired` / `tagsBlocked` against `GameplayTagsComponent`
   - **Instant** effects → write to `Attribute.base`, mark dirty
   - **Duration / Periodic** effects → enqueued with `remainingTicks`, grants `tagsGranted`, marks affected attributes dirty
   - Uses a per-tick attribute-index cache to avoid repeated registry lookups
2. **`EffectTickSystem`**
   - Decrements `remainingTicks` on active instances
   - Compacts expired entries in place (preserves application order)
   - Revokes `tagsGranted` only when no other active instance grants the same tag (shared-grant safe)
   - Marks attributes dirty for revoked modifiers
3. **`AttributeAggregationSystem`** (unchanged) — sees the updated queue and dirty set in the same tick

### Facade additions
`AbilitySystemFacade` constructor now takes a 3rd arg: `runtime: AbilitySystemRuntime`.

- `applyEffect(targetId, effectId, sourceId?)`
- `removeEffectsByTag(entityId, tag): number`
- `removeEffectsByDefId(entityId, defId): number`
- `hasTag` / `addTag` / `removeTag` helpers
- Auto-attaches `ActiveEffectsComponent` and `GameplayTagsComponent` on demand

### Removal semantics
`removeEffectsBy*` sets `remainingTicks = 0` on matching instances; `EffectTickSystem` performs the actual revocation. This keeps tag bookkeeping and dirty-marking centralized.

## Tests
22/22 passing (10 new in `effects.test.ts`, `attributes.test.ts` updated for the new facade signature):
- Instant effect updates `base` + `current` via aggregation
- Duration lifecycle (enter queue, persist, expire on schedule)
- `tagsRequired` / `tagsBlocked` gating
- Tag granting + revocation, including shared-grant persistence
- `removeEffectsByTag` / `removeEffectsByDefId`
- Dirty propagation on tag-affected modifiers

## Deferred
- **Periodic** per-period modifier application → Stage 4
- `AbilityActivationSystem` (resource costs, cooldowns, granted effects) → Stage 5