### PR TITLE
feat(abilities): stage 4 — Periodic effects

### DIFF
--- a/phalanx-abilities/src/systems/EffectApplicationSystem.ts
+++ b/phalanx-abilities/src/systems/EffectApplicationSystem.ts
@@ -39,10 +39,16 @@ import type { ActiveEffectInstance, EffectDef, Modifier, ModifierOp } from '../t
  *        relies on);
  *      - mark every attribute referenced by the effect's modifiers dirty.
  *  6. For `Periodic`:
- *      - Stage 4 will handle the periodic tick semantics. In Stage 3 we
- *        treat the application identically to `Duration` (queue + dirty)
- *        but do not yet apply per-period modifiers. The dedicated test
- *        suite for Periodic lives in stage 4.
+ *      - Same queueing, tag-grant and lifetime-countdown path as `Duration`.
+ *      - The per-period payload is applied Instant-style (modifiers fold
+ *        into `base`, attributes marked dirty) by {@link EffectTickSystem}
+ *        whenever `currentTick >= nextPeriodTick`. `nextPeriodTick` is
+ *        initialized to `tick + periodTicks` here.
+ *      - When `executePeriodicOnApplication` is true, modifiers also fire
+ *        once immediately at apply time (Instant-style on the same tick),
+ *        in addition to the regular schedule. The first scheduled firing
+ *        still lands one full period later — the apply-time landing is an
+ *        extra one-off, mirroring Unreal's GAS semantics.
  *
  * The system itself never *removes* effects — that responsibility belongs
  * to {@link EffectTickSystem}, including expirations from `removeEffectsBy*`
@@ -119,6 +125,15 @@ export class EffectApplicationSystem extends GameSystem {
       case 'Duration':
       case 'Periodic':
         this.queueDurational(entity, effectDef, pending, attributeIndexCache, tick);
+        // Periodic with executePeriodicOnApplication: fire the payload once
+        // at apply time. Instance was queued above so the lifetime countdown
+        // and subsequent periodic firings keep working. Determinism is
+        // preserved because the queueing path allocated the FIFO instanceId
+        // before we mutate base, so aggregation on the same tick observes
+        // ordering identical to a freshly-applied Instant.
+        if (effectDef.type === 'Periodic' && effectDef.executePeriodicOnApplication === true) {
+          this.applyInstant(entity, effectDef, attributeIndexCache);
+        }
         return;
     }
   }
@@ -142,6 +157,14 @@ export class EffectApplicationSystem extends GameSystem {
       if (durationTicks === undefined || durationTicks <= 0) {
         throw new Error(
           `EffectDef '${effectDef.id}' is type '${effectDef.type}' but has invalid durationTicks=${String(durationTicks)}`
+        );
+      }
+    }
+    if (effectDef.type === 'Periodic') {
+      const periodTicks = effectDef.periodTicks;
+      if (periodTicks === undefined || periodTicks <= 0) {
+        throw new Error(
+          `EffectDef '${effectDef.id}' is type 'Periodic' but has invalid periodTicks=${String(periodTicks)}`
         );
       }
     }
@@ -226,12 +249,17 @@ export class EffectApplicationSystem extends GameSystem {
     // durationTicks was validated upstream in validateEffectOrThrow, so the
     // non-null assertion below is safe — keep the cast local.
     const durationTicksValidated = effectDef.durationTicks as number;
+    // For Periodic effects, schedule the first firing one full period after
+    // application. `executePeriodicOnApplication` (handled separately in
+    // applyOne) does NOT advance nextPeriodTick — the immediate landing is
+    // additive to the regular schedule, matching Unreal's GAS semantics.
+    const nextPeriodTick =
+      effectDef.type === 'Periodic' ? tick + (effectDef.periodTicks as number) : 0;
     const instance: ActiveEffectInstance = {
       instanceId: this.runtime.instanceIdCounter.next(),
       defId: effectDef.id,
       remainingTicks: durationTicksValidated,
-      // Stage 4 will use nextPeriodTick; in Stage 3 we initialize to 0.
-      nextPeriodTick: 0,
+      nextPeriodTick,
       sourceEntityId: pending.sourceEntityId,
       // Record the application tick so EffectTickSystem can skip the very
       // first countdown for this instance — without that, a durationTicks=1

--- a/phalanx-abilities/src/systems/EffectTickSystem.ts
+++ b/phalanx-abilities/src/systems/EffectTickSystem.ts
@@ -1,5 +1,7 @@
 import { GameSystem } from 'phalanx-ecs';
 import type { Entity } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FixedPoint } from 'phalanx-math';
 import {
   AbilitiesComponentType,
   ActiveEffectsComponent,
@@ -7,27 +9,35 @@ import {
   GameplayTagsComponent,
 } from '../components';
 import type { AbilitySystemRegistries } from '../registry';
-import type { ActiveEffectInstance, EffectDef } from '../types';
+import type { ActiveEffectInstance, EffectDef, ModifierOp } from '../types';
 
 /**
- * Per-tick lifecycle for `Duration` (and, from Stage 4, `Periodic`) effects.
+ * Per-tick lifecycle for `Duration` and `Periodic` effects.
  *
- * Stage 3 responsibilities:
- *  - Decrement `remainingTicks` on every queued `ActiveEffectInstance`.
- *  - Remove expired instances (`remainingTicks <= 0`).
- *  - On removal:
- *      * revoke `tagsGranted` from the target's
- *        {@link GameplayTagsComponent}, but only when no other still-active
- *        instance grants the same tag (set semantics: a tag is "on" while
- *        any granter is present);
- *      * mark every attribute referenced by the removed effect's
- *        modifiers dirty, so {@link AttributeAggregationSystem}
- *        recomputes `current` without the expired modifier on the same
- *        tick (system order: this system runs before aggregation).
+ * Per entity per tick, the system runs three passes in order:
+ *  1. Fire `Periodic` payloads. For every queued `Periodic` instance whose
+ *     `nextPeriodTick <= currentTick` and that was not inserted on this
+ *     same tick, apply its modifiers Instant-style (fold into
+ *     `AttributesComponent.base`, mark attributes dirty for the downstream
+ *     `AttributeAggregationSystem`) and advance `nextPeriodTick` by
+ *     `EffectDef.periodTicks`. Fire-before-countdown ordering means the
+ *     final periodic landing on the same tick as expiry still fires.
+ *  2. Decrement `remainingTicks` on every queued instance — except those
+ *     inserted on this same tick (so `durationTicks=1` survives long enough
+ *     for aggregation to observe it) or already flagged at `0` by a forced
+ *     removal helper (see `AbilitySystemFacade.removeEffectsBy*`).
+ *  3. Compact the queue, harvesting any instance whose `remainingTicks`
+ *     dropped to `<= 0`. Order is preserved (no re-sort). For each expired
+ *     instance: revoke `tagsGranted` (with ref-count semantics so a tag
+ *     stays on while another granter is alive or it is held ad hoc); mark
+ *     every modifier-referenced attribute dirty so `AttributeAggregationSystem`
+ *     recomputes `current` without the expired modifier on the same tick.
  *
  * Removals queued by `removeEffectsByTag` / `removeEffectsByDefId` flow
  * through this same path: the facade sets `remainingTicks = 0` on the
- * targeted instance(s); this system then handles revocation in tick order.
+ * targeted instance(s); the periodic-fire pass skips them (no positive
+ * remaining), countdown leaves them at zero, and the expiry pass harvests
+ * them. Forced removal therefore never produces an extra periodic landing.
  *
  * The system relies on the invariant — established by
  * {@link EffectApplicationSystem} and `AbilitySystemFacade.removeEffectsBy*`
@@ -60,7 +70,18 @@ export class EffectTickSystem extends GameSystem {
   ): void {
     const queue = activeEffects.queue;
 
-    // First pass: countdown.
+    // First pass: fire Periodic payloads.
+    //
+    // Done BEFORE countdown so the final periodic landing on the same tick
+    // the lifetime ends still fires (e.g. durationTicks=3, periodTicks=1
+    // fires three times). Instances inserted on this same tick are skipped
+    // — their `executePeriodicOnApplication` payload, if any, was already
+    // applied by EffectApplicationSystem so firing again here would
+    // double-apply. Instances flagged for forced removal (remainingTicks
+    // already 0) are skipped too so cleanup never produces an extra landing.
+    this.firePeriodics(entity, queue, tick);
+
+    // Second pass: countdown.
     //
     // Instances inserted by EffectApplicationSystem earlier in *this same*
     // tick must NOT be decremented yet — otherwise a valid durationTicks=1
@@ -79,7 +100,7 @@ export class EffectTickSystem extends GameSystem {
       }
     }
 
-    // Second pass: extract expired and compact the queue, preserving order.
+    // Third pass: extract expired and compact the queue, preserving order.
     const expired: ActiveEffectInstance[] = [];
     let writeIndex = 0;
     for (let readIndex = 0; readIndex < queue.length; readIndex++) {
@@ -125,6 +146,91 @@ export class EffectTickSystem extends GameSystem {
     }
   }
 
+  /**
+   * Apply periodic payloads in FIFO `instanceId` order. Iterating the queue
+   * front-to-back yields that order because
+   * {@link EffectApplicationSystem} maintains the `instanceId` ASC sort.
+   * The inner `while` loop catches catch-up firings should the world ever
+   * advance multiple periods worth of ticks in a single tick (warp-forward,
+   * misconfigured `periodTicks=0`). `periodTicks` is validated at
+   * application time so the legitimate path runs the loop body exactly once.
+   */
+  private firePeriodics(
+    entity: Entity,
+    queue: readonly ActiveEffectInstance[],
+    tick: number
+  ): void {
+    if (queue.length === 0) {
+      return;
+    }
+
+    let attributes: AttributesComponent | undefined;
+
+    for (let i = 0; i < queue.length; i++) {
+      const instance = queue[i];
+      if (instance.enteredOnTick === tick) {
+        continue;
+      }
+      if (instance.remainingTicks <= 0) {
+        continue;
+      }
+      if (tick < instance.nextPeriodTick) {
+        continue;
+      }
+      const effectDef = this.registries.effects.tryGet(instance.defId);
+      if (!effectDef) {
+        throw new Error(`EffectRegistry does not contain '${instance.defId}'`);
+      }
+      if (effectDef.type !== 'Periodic') {
+        // Only Periodic instances carry meaningful `nextPeriodTick`. Defensive
+        // skip in case the registry shape ever drifts.
+        continue;
+      }
+      const periodTicks = effectDef.periodTicks;
+      if (periodTicks === undefined || periodTicks <= 0) {
+        // Application time should have rejected this, but guard against a
+        // late registry mutation rather than spin forever below.
+        throw new Error(
+          `EffectDef '${effectDef.id}' is Periodic but has invalid periodTicks=${String(periodTicks)}`
+        );
+      }
+
+      // Resolve attributes lazily — a queue with only Duration entries should
+      // not pay for the component lookup.
+      if (attributes === undefined) {
+        attributes =
+          entity.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes) ?? undefined;
+      }
+
+      while (tick >= instance.nextPeriodTick) {
+        this.applyPeriodicPayload(effectDef, attributes);
+        instance.nextPeriodTick += periodTicks;
+      }
+    }
+  }
+
+  /**
+   * Apply a Periodic effect's modifiers Instant-style to `base` and mark the
+   * attributes dirty so the same-tick aggregation pass observes the new
+   * value. Tag grants are NOT re-issued per period — they were granted once
+   * at apply time and are revoked when the instance expires.
+   */
+  private applyPeriodicPayload(
+    effectDef: EffectDef,
+    attributes: AttributesComponent | undefined
+  ): void {
+    if (!attributes || effectDef.modifiers.length === 0) {
+      return;
+    }
+    for (const modifier of effectDef.modifiers) {
+      const index = this.registries.attributes.indexOf(modifier.attributeId);
+      const current = FP.FromRaw(attributes.base[index]);
+      const next = applyPeriodicModifier(current, modifier.op, modifier.magnitude);
+      attributes.base[index] = FP.ToRaw(next);
+      attributes.dirty[index] = 1;
+    }
+  }
+
   private revokeTags(
     effectDef: EffectDef,
     tags: GameplayTagsComponent | undefined,
@@ -164,5 +270,23 @@ export class EffectTickSystem extends GameSystem {
       const index = this.registries.attributes.indexOf(modifier.attributeId);
       attributes.dirty[index] = 1;
     }
+  }
+}
+
+function applyPeriodicModifier(
+  value: FixedPoint,
+  op: ModifierOp,
+  magnitude: FixedPoint
+): FixedPoint {
+  // Mirrors `EffectApplicationSystem.applyInstantModifier`. Kept private to
+  // this file to avoid an import cycle and to keep periodic-write semantics
+  // independently auditable.
+  switch (op) {
+    case 'Add':
+      return FP.Add(value, magnitude);
+    case 'Multiply':
+      return FP.Mul(value, magnitude);
+    case 'Override':
+      return magnitude;
   }
 }

--- a/phalanx-abilities/src/types/ActiveEffectInstance.ts
+++ b/phalanx-abilities/src/types/ActiveEffectInstance.ts
@@ -3,7 +3,14 @@ export interface ActiveEffectInstance {
   instanceId: number;
   defId: string;
   remainingTicks: number;
-  /** Only meaningful for Periodic effects. */
+  /**
+   * Only meaningful for Periodic effects. Holds the next absolute simulation
+   * tick at which the effect's modifiers must fire (Instant-style writes to
+   * `AttributesComponent.base`). When `currentTick >= nextPeriodTick` and the
+   * instance was not just inserted on the same tick, EffectTickSystem applies
+   * the modifiers and advances `nextPeriodTick` by `EffectDef.periodTicks`.
+   * For Duration instances the field is left at `0` and ignored.
+   */
   nextPeriodTick: number;
   /**
    * Source entity that applied the effect, or `-1` for no source (e.g. world

--- a/phalanx-abilities/tests/effects.test.ts
+++ b/phalanx-abilities/tests/effects.test.ts
@@ -340,20 +340,26 @@ describe('effect application', () => {
     world.dispose();
   });
 
-  it('Periodic effects do not bleed into AttributeAggregationSystem in Stage 3', () => {
-    // Periodic effects share the queue path with Duration so they get a
-    // lifecycle and grant tags today, but their modifiers must NOT be applied
-    // continuously by aggregation — Stage 4 will introduce per-period
-    // semantics. The Periodic effect below would otherwise drop Armor by 30.
+  it('Periodic effects do not contribute to AttributeAggregationSystem continuously', () => {
+    // Periodic effects fire their modifiers Instant-style on each scheduled
+    // tick (handled by EffectTickSystem in Stage 4). They must NOT also be
+    // applied as continuous modifiers by AttributeAggregationSystem —
+    // otherwise every DoT tick would double-count. We assert that property
+    // here by checking the gap between application tick and the first
+    // scheduled firing: tagsGranted is on (lifecycle works), but the periodic
+    // modifier has not landed yet, so Armor.current still reads the
+    // un-shredded value. Dedicated periodic behavior tests live in
+    // periodic-effects.test.ts.
     const { world, facade } = createTestWorld({
       effects: [
         defineEffect({
-          id: 'Effect.Poison.Periodic',
+          id: 'Effect.Poison.Periodic.Slow',
           type: 'Periodic',
-          durationTicks: 5,
-          periodTicks: 1,
+          durationTicks: 100,
+          periodTicks: 10,
           modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-30) }],
           tagsGranted: ['State.Debuff.Poisoned'],
+          // executePeriodicOnApplication defaults to false: no immediate hit.
         }),
       ],
     });
@@ -361,15 +367,16 @@ describe('effect application', () => {
     facade.initAttributesForEntity(entity.id);
     world.processAllTicks(1);
 
-    facade.applyEffect(entity.id, 'Effect.Poison.Periodic', entity.id);
+    facade.applyEffect(entity.id, 'Effect.Poison.Periodic.Slow', entity.id);
+    // Apply tick = 2 -> nextPeriodTick = 12.
     world.processAllTicks(2);
 
-    // Tag is granted (lifecycle works), but Armor.current is unchanged: the
-    // Periodic modifier is intentionally invisible to aggregation pre-Stage 4.
+    // Tag granted, no periodic landing yet (would be on tick 12).
     expect(facade.hasTag(entity.id, 'State.Debuff.Poisoned')).toBe(true);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
 
-    world.processAllTicks(3);
+    // Tick 11: still before first scheduled firing.
+    world.processAllTicks(11);
     expect(FP.ToFloat(facade.getAttribute(entity.id, 'Armor').current)).toBe(50);
 
     world.dispose();

--- a/phalanx-abilities/tests/periodic-effects.test.ts
+++ b/phalanx-abilities/tests/periodic-effects.test.ts
@@ -1,0 +1,626 @@
+import { describe, expect, it } from 'vitest';
+import { Entity, GameWorld } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  AbilitySystemFacade,
+  ActiveEffectsComponent,
+  AttributeAggregationSystem,
+  EffectApplicationSystem,
+  EffectTickSystem,
+  createAbilitySystemRegistries,
+  createAbilitySystemRuntime,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+import type { AbilitySystemRegistries, AbilitySystemRuntime } from '../src';
+
+// ---------------------------------------------------------------------------
+// Stage 4 — Periodic effects.
+//
+// What we are verifying here, beyond the lifecycle parts already covered in
+// effects.test.ts:
+//
+//  1. A Periodic effect fires its modifiers Instant-style on each scheduled
+//     tick (`currentTick >= nextPeriodTick`), against `base`, with `current`
+//     observable on the same tick through AttributeAggregationSystem.
+//  2. The first firing is one full `periodTicks` after the application tick
+//     when `executePeriodicOnApplication` is omitted/false.
+//  3. With `executePeriodicOnApplication: true` the payload also fires once
+//     at apply time, then resumes the regular schedule one period later.
+//  4. The total number of firings over an effect's lifetime is exactly
+//     `floor(durationTicks / periodTicks)` (without on-application) or one
+//     more than that (with on-application).
+//  5. Lifetime countdown and tag revocation work the same as Duration.
+//  6. Forced removal via `removeEffectsByTag` cancels future firings, but
+//     does NOT trigger an extra firing on the way out.
+//  7. Misconfigured Periodic defs (missing/non-positive `periodTicks`) are
+//     rejected at application time, atomically — no tag leakage.
+//  8. `nextPeriodTick` advances by `periodTicks` once per firing — verifiable
+//     by inspecting `ActiveEffectsComponent.queue` directly.
+//
+// These tests intentionally avoid asserting on `base` directly when the
+// public surface (`getAttribute(...).current`) can express the same thing,
+// since `current` is what user code reads.
+// ---------------------------------------------------------------------------
+
+describe('Periodic effects', () => {
+  it('fires its payload one period after application (default scheduling)', () => {
+    // DoT: -3 Health every 5 ticks, total lifetime 20 ticks => 4 firings.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.DoT.Bleed',
+          type: 'Periodic',
+          durationTicks: 20,
+          periodTicks: 5,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-3) },
+          ],
+          tagsGranted: ['State.Debuff.Bleed'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      100
+    );
+
+    facade.applyEffect(entity.id, 'Effect.DoT.Bleed', entity.id);
+    // Tick 2: apply tick — instance queued, nextPeriodTick = 7. Tag granted.
+    world.processAllTicks(2);
+    expect(facade.hasTag(entity.id, 'State.Debuff.Bleed')).toBe(true);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      100
+    );
+
+    // Ticks 3..6: still before first firing.
+    for (let t = 3; t <= 6; t++) {
+      world.processAllTicks(t);
+      expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+        100
+      );
+    }
+
+    // Tick 7: first firing. -3 Health.
+    world.processAllTicks(7);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      97
+    );
+
+    // Tick 12: second firing.
+    for (let t = 8; t <= 11; t++) world.processAllTicks(t);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      97
+    );
+    world.processAllTicks(12);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      94
+    );
+
+    // Tick 17, 22 — but 22 falls AFTER expiry (apply tick 2, duration 20 =>
+    // remainingTicks goes 20→19 at t=3 ... →0 at t=22; expires that tick).
+    // The plan's periodic ordering is fire-before-countdown, so the final
+    // firing on tick 22 still happens.
+    for (let t = 13; t <= 16; t++) world.processAllTicks(t);
+    world.processAllTicks(17);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      91
+    );
+
+    for (let t = 18; t <= 21; t++) world.processAllTicks(t);
+    world.processAllTicks(22);
+    // Fourth firing fired, then countdown expired the instance, tag revoked.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      88
+    );
+    expect(facade.hasTag(entity.id, 'State.Debuff.Bleed')).toBe(false);
+
+    // No more firings after expiry.
+    for (let t = 23; t <= 30; t++) world.processAllTicks(t);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      88
+    );
+
+    world.dispose();
+  });
+
+  it('executePeriodicOnApplication=true adds an extra apply-time landing on top of the regular schedule', () => {
+    // HoT: +2 Health every 3 ticks, with on-application firing. Lifetime 9.
+    // Expected firings: tick T (apply) + T+3 + T+6 + T+9. That is, 4 firings
+    // versus 3 if executePeriodicOnApplication were false.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.HoT.Regen',
+          type: 'Periodic',
+          durationTicks: 9,
+          periodTicks: 3,
+          executePeriodicOnApplication: true,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(2) },
+          ],
+          tagsGranted: ['State.Buff.Regen'],
+        }),
+        defineEffect({
+          id: 'Effect.SeedDamage',
+          type: 'Instant',
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-20) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    // Drop Health to 80 so we can observe the +2 heals (clamp would otherwise
+    // hide them at the max-100 ceiling).
+    facade.applyEffect(entity.id, 'Effect.SeedDamage', entity.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      80
+    );
+
+    facade.applyEffect(entity.id, 'Effect.HoT.Regen', entity.id);
+    // Apply tick = 3. on-application fires now (+2), nextPeriodTick = 6.
+    world.processAllTicks(3);
+    expect(facade.hasTag(entity.id, 'State.Buff.Regen')).toBe(true);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      82
+    );
+
+    // Tick 4, 5: no firing.
+    world.processAllTicks(4);
+    world.processAllTicks(5);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      82
+    );
+
+    // Tick 6: second firing (+2 -> 84).
+    world.processAllTicks(6);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      84
+    );
+
+    // Tick 9: third firing (+2 -> 86).
+    world.processAllTicks(7);
+    world.processAllTicks(8);
+    world.processAllTicks(9);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      86
+    );
+
+    // Tick 12: fourth firing (final, lands on expiry tick); then expire.
+    world.processAllTicks(10);
+    world.processAllTicks(11);
+    world.processAllTicks(12);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      88
+    );
+    expect(facade.hasTag(entity.id, 'State.Buff.Regen')).toBe(false);
+
+    // No firings after expiry.
+    for (let t = 13; t <= 20; t++) world.processAllTicks(t);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      88
+    );
+
+    world.dispose();
+  });
+
+  it('without executePeriodicOnApplication fires durationTicks/periodTicks times exactly', () => {
+    // Sanity-count firings via Override: each firing sets Health to a known
+    // value, so we can verify by inspecting current after expiry. Use a
+    // counter attribute via Add, which is more direct than Override here.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.DoT.Count',
+          type: 'Periodic',
+          durationTicks: 12,
+          periodTicks: 4,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.DoT.Count', entity.id);
+    // Apply tick 2. nextPeriodTick = 6. durationTicks=12 means remaining
+    // reaches 0 on tick 14. Firings: 6, 10, 14 — three firings = 12/4.
+    for (let t = 2; t <= 20; t++) world.processAllTicks(t);
+
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      97
+    );
+
+    world.dispose();
+  });
+
+  it('advances nextPeriodTick by periodTicks per firing (queue-level invariant)', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Tick',
+          type: 'Periodic',
+          durationTicks: 20,
+          periodTicks: 4,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Tick', entity.id);
+    world.processAllTicks(2);
+    const queue = activeEffectsOf(world, entity.id).queue;
+    expect(queue.length).toBe(1);
+    expect(queue[0].nextPeriodTick).toBe(6);
+
+    // After tick 6 (one firing): nextPeriodTick advances to 10.
+    world.processAllTicks(3);
+    world.processAllTicks(4);
+    world.processAllTicks(5);
+    world.processAllTicks(6);
+    expect(queue[0].nextPeriodTick).toBe(10);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      99
+    );
+
+    // After tick 10 (second firing): nextPeriodTick = 14.
+    for (let t = 7; t <= 10; t++) world.processAllTicks(t);
+    expect(queue[0].nextPeriodTick).toBe(14);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      98
+    );
+
+    world.dispose();
+  });
+
+  it('removeEffectsByTag cancels future periodic firings without producing an extra landing', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.DoT.Cancelable',
+          type: 'Periodic',
+          durationTicks: 50,
+          periodTicks: 5,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-5) },
+          ],
+          tagsGranted: ['State.Debuff.DoT'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.DoT.Cancelable', entity.id);
+    world.processAllTicks(2); // apply tick, nextPeriodTick = 7
+    for (let t = 3; t <= 7; t++) world.processAllTicks(t);
+    // One firing at tick 7.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      95
+    );
+
+    // Cancel before the next firing window. removeEffectsByTag sets
+    // remainingTicks=0 on the matched instance.
+    const flagged = facade.removeEffectsByTag(entity.id, 'State.Debuff.DoT');
+    expect(flagged).toBe(1);
+
+    // Tick 8 runs EffectTickSystem: periodic fire skipped (remainingTicks=0),
+    // countdown skipped, expiry pass harvests the instance, tag revoked.
+    world.processAllTicks(8);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      95
+    );
+    expect(facade.hasTag(entity.id, 'State.Debuff.DoT')).toBe(false);
+
+    // No further firings.
+    for (let t = 9; t <= 30; t++) world.processAllTicks(t);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      95
+    );
+
+    world.dispose();
+  });
+
+  it('rejects a Periodic effect with missing or non-positive periodTicks atomically', () => {
+    // Both bad shapes throw at apply time and must not leak tagsGranted.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Periodic.BadMissing',
+          type: 'Periodic',
+          durationTicks: 5,
+          // periodTicks deliberately omitted
+          tagsGranted: ['State.LeakSentinel.A'],
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+        defineEffect({
+          id: 'Effect.Periodic.BadZero',
+          type: 'Periodic',
+          durationTicks: 5,
+          periodTicks: 0,
+          tagsGranted: ['State.LeakSentinel.B'],
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+        defineEffect({
+          id: 'Effect.Periodic.BadNegative',
+          type: 'Periodic',
+          durationTicks: 5,
+          periodTicks: -2,
+          tagsGranted: ['State.LeakSentinel.C'],
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Periodic.BadMissing', entity.id);
+    expect(() => world.processAllTicks(2)).toThrow(/invalid periodTicks/);
+    expect(facade.hasTag(entity.id, 'State.LeakSentinel.A')).toBe(false);
+
+    facade.applyEffect(entity.id, 'Effect.Periodic.BadZero', entity.id);
+    expect(() => world.processAllTicks(3)).toThrow(/invalid periodTicks/);
+    expect(facade.hasTag(entity.id, 'State.LeakSentinel.B')).toBe(false);
+
+    facade.applyEffect(entity.id, 'Effect.Periodic.BadNegative', entity.id);
+    expect(() => world.processAllTicks(4)).toThrow(/invalid periodTicks/);
+    expect(facade.hasTag(entity.id, 'State.LeakSentinel.C')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('periodic Multiply modifiers compound exactly once per firing', () => {
+    // Multiply lets us check the FixedPoint round-tripping at each firing:
+    // Health *= 0.5 each period. Starting at 100, after 3 firings should be
+    // exactly 12.5 (clamped above 0).
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Halver',
+          type: 'Periodic',
+          durationTicks: 9,
+          periodTicks: 3,
+          modifiers: [
+            {
+              attributeId: 'Health',
+              op: 'Multiply',
+              magnitude: FP.FromFloat(0.5),
+            },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Halver', entity.id);
+    // Apply tick 2; firings at 5, 8, 11; expires at tick 11 (lands on final
+    // firing thanks to fire-before-countdown).
+    for (let t = 2; t <= 4; t++) world.processAllTicks(t);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      100
+    );
+
+    world.processAllTicks(5);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      50
+    );
+    world.processAllTicks(6);
+    world.processAllTicks(7);
+    world.processAllTicks(8);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      25
+    );
+    world.processAllTicks(9);
+    world.processAllTicks(10);
+    world.processAllTicks(11);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      12.5
+    );
+
+    world.dispose();
+  });
+
+  it('periodic with executePeriodicOnApplication=true and durationTicks=periodTicks fires exactly twice', () => {
+    // Edge case: a one-period lifetime with on-application produces apply-tick
+    // firing AND the regular firing at the lifetime boundary.
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Bookends',
+          type: 'Periodic',
+          durationTicks: 4,
+          periodTicks: 4,
+          executePeriodicOnApplication: true,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-7) },
+          ],
+          tagsGranted: ['State.Debuff.Bookends'],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.Bookends', entity.id);
+    // Apply tick = 2. on-application fires once (-7 -> 93). nextPeriodTick = 6.
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      93
+    );
+    expect(facade.hasTag(entity.id, 'State.Debuff.Bookends')).toBe(true);
+
+    world.processAllTicks(3);
+    world.processAllTicks(4);
+    world.processAllTicks(5);
+    // No firing yet.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      93
+    );
+
+    // Tick 6: second firing (-7 -> 86), countdown 1→0, expire, tag off.
+    world.processAllTicks(6);
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      86
+    );
+    expect(facade.hasTag(entity.id, 'State.Debuff.Bookends')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('two independent periodics on the same entity each follow their own schedule', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.SlowDoT',
+          type: 'Periodic',
+          durationTicks: 30,
+          periodTicks: 10,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+        defineEffect({
+          id: 'Effect.FastDoT',
+          type: 'Periodic',
+          durationTicks: 30,
+          periodTicks: 3,
+          modifiers: [
+            { attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-1) },
+          ],
+        }),
+      ],
+    });
+    const entity = addEntity(world);
+    facade.initAttributesForEntity(entity.id);
+    world.processAllTicks(1);
+
+    facade.applyEffect(entity.id, 'Effect.SlowDoT', entity.id);
+    facade.applyEffect(entity.id, 'Effect.FastDoT', entity.id);
+    // Apply tick = 2. Slow nextPeriodTick = 12, Fast nextPeriodTick = 5.
+
+    for (let t = 2; t <= 32; t++) world.processAllTicks(t);
+
+    // Expected over ticks 2..32:
+    //   Slow fires at 12, 22, 32 (durationTicks=30 means expiry at tick 32,
+    //     fire-before-countdown lets the boundary fire happen). => 3 hits.
+    //   Fast fires at 5,8,11,14,17,20,23,26,29,32 => 10 hits.
+    // Total Health delta: -13 => 87.
+    expect(FP.ToFloat(facade.getAttribute(entity.id, 'Health').current)).toBe(
+      87
+    );
+
+    world.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test world helper (parallel to effects.test.ts; kept local to avoid coupling
+// the two suites' setup).
+// ---------------------------------------------------------------------------
+
+interface TestWorldOpts {
+  effects: readonly ReturnType<typeof defineEffect>[];
+}
+
+interface TestWorld {
+  world: GameWorld;
+  facade: AbilitySystemFacade;
+  registries: AbilitySystemRegistries;
+  runtime: AbilitySystemRuntime;
+}
+
+function createTestWorld(opts: TestWorldOpts): TestWorld {
+  const registries = createAbilitySystemRegistries();
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Health',
+      default: FP.FromInt(100),
+      min: FP.FromInt(0),
+      max: FP.FromInt(100),
+      clamp: 'both',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Armor',
+      default: FP.FromInt(50),
+      min: FP.FromInt(0),
+      max: FP.FromInt(1000),
+      clamp: 'min',
+    })
+  );
+  for (const effect of opts.effects) {
+    registries.effects.register(effect);
+  }
+
+  const runtime = createAbilitySystemRuntime();
+  const world = new GameWorld({
+    componentTypes: [
+      AbilitiesComponentType.Attributes,
+      AbilitiesComponentType.ActiveEffects,
+      AbilitiesComponentType.GameplayTags,
+    ],
+  });
+  // Order must match production: application -> tick -> aggregation.
+  world.registerSystems(
+    [
+      new EffectApplicationSystem(registries, runtime),
+      new EffectTickSystem(registries),
+      new AttributeAggregationSystem(registries),
+    ],
+    []
+  );
+  const facade = new AbilitySystemFacade(
+    world.entityManager,
+    registries,
+    runtime
+  );
+  return { world, facade, registries, runtime };
+}
+
+function addEntity(world: GameWorld): Entity {
+  const entity = new Entity();
+  world.entityManager.addEntity(entity);
+  return entity;
+}
+
+function activeEffectsOf(
+  world: GameWorld,
+  entityId: number
+): ActiveEffectsComponent {
+  const entity = world.entityManager.getEntity(entityId);
+  if (!entity) throw new Error(`entity ${entityId} missing`);
+  const component = entity.getComponent<ActiveEffectsComponent>(
+    AbilitiesComponentType.ActiveEffects
+  );
+  if (!component)
+    throw new Error(`ActiveEffectsComponent missing on ${entityId}`);
+  return component;
+}


### PR DESCRIPTION
Implements **Stage 4 (Periodic effects)** of the phalanx-abilities plan.

## What changed

### `EffectTickSystem`
- New 3-pass model per entity per tick: **(1) fire periodics → (2) countdown remainingTicks → (3) collect expired**.
- Periodics fire **before** the countdown, so the landing on the final/expiry tick is not skipped. With `durationTicks=3, periodTicks=1` a periodic fires 3 times.
- Skips entries with `enteredOnTick === currentTick` (no double-fire on application tick) and `remainingTicks <= 0` (so forced removal via `removeEffectsByTag`/`ByDefId` never emits an extra landing).
- New `applyPeriodicPayload` writes Instant-style to `AttributesComponent.base` and sets the `dirty` flag, mirroring `EffectApplicationSystem.applyInstantModifier`. Periodic modifiers do **not** flow through `AttributeAggregationSystem`.
- `nextPeriodTick` advanced by `periodTicks` after each firing.

### `EffectApplicationSystem`
- `validateEffectOrThrow` now rejects `Periodic` with missing/0/negative `periodTicks` **before** any tag grants — atomic, no tag leakage.
- `queueDurational` initializes `nextPeriodTick = tick + periodTicks` for Periodic (`0` for Duration, unchanged).
- `applyOne` fires an extra Instant-style landing at apply time when `effectDef.type === 'Periodic' && executePeriodicOnApplication === true`. The regular schedule still starts one period later — `executePeriodicOnApplication` is **additive**, matching Unreal GAS semantics.

### `ActiveEffectInstance`
- Expanded `nextPeriodTick` docstring (semantics, scheduling rule, Duration ignores it).

## Tests

9 new tests in `tests/periodic-effects.test.ts`:
1. First periodic firing lands exactly one period after application.
2. `executePeriodicOnApplication: true` produces an extra apply-time landing **plus** the normal schedule.
3. Total firings == `durationTicks / periodTicks` when `executePeriodicOnApplication: false`.
4. `nextPeriodTick` advances by `periodTicks` on the queue between firings.
5. Forced removal via `removeEffectsByTag` cancels future periodics without an extra landing.
6. Misconfigured Periodic (missing / 0 / negative `periodTicks`) rejected atomically — no tag leakage.
7. Multiply periodic modifiers compound across firings.
8. `durationTicks === periodTicks` with `executePeriodicOnApplication: true` fires exactly twice.
9. Two independent periodics on the same entity each follow their own schedule.

One existing Stage-3 test in `effects.test.ts` was tweaked (`durationTicks=100, periodTicks=10`) so its periodic doesn't fire inside the test window — the assertion (Periodic does not bleed into aggregation continuously) is preserved.

**Result: 37 tests passing** (16 effects + 9 periodic + 9 attributes + 3 registry). `tsc` build is clean.

## Plan reference

Plan lines 614-617 (Stage 4 spec): extend `EffectTickSystem` with `nextPeriodTick`, per-tick modifiers, `executePeriodicOnApplication`; cover DoT, HoT, expiry, correct firing count under both `executePeriodicOnApplication: true/false`.