### PR TITLE
feat(abilities): stage 5 — Abilities: cost/cooldown/CanActivate + hooks

### DIFF
--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -263,10 +263,23 @@ export class AbilitySystemFacade {
     if (!this.registries.abilities.has(abilityId)) {
       return false;
     }
+    // Snapshot `providedTarget` so callers that reuse or mutate their
+    // target object between this call and the next tick cannot retroactively
+    // change an already-enqueued activation. `ProvidedTarget` is a flat
+    // record of primitives + bigint FixedPoint values, so a shallow copy is
+    // sufficient to make the request immutable.
+    const snapshotTarget: ProvidedTarget | undefined =
+      providedTarget === undefined
+        ? undefined
+        : {
+            entityId: providedTarget.entityId,
+            x: providedTarget.x,
+            z: providedTarget.z,
+          };
     this.runtime.activationRequests.push({
       casterEntityId,
       abilityId,
-      providedTarget,
+      providedTarget: snapshotTarget,
       enqueueTick: this.runtime.currentTick,
     });
     return true;

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -9,6 +9,7 @@ import {
 } from '../components';
 import type { AbilitySystemRegistries } from '../registry';
 import type { AbilitySystemRuntime } from '../runtime';
+import type { AbilityHook, ProvidedTarget } from '../types';
 
 export interface AttributeValue {
   base: FixedPoint;
@@ -217,6 +218,76 @@ export class AbilitySystemFacade {
       }
     }
     return flagged;
+  }
+
+  // -----------------------------------------------------------------------
+  // Abilities
+  // -----------------------------------------------------------------------
+
+  /**
+   * Enqueue an ability activation request. The actual `CanActivate` check
+   * (tag predicates, cost, cooldown) and the application of caster-side
+   * effects (cost, cooldown, `selfEffectIds`) are performed by
+   * `AbilityActivationSystem` on the next tick. Target-side effects
+   * (`targetEffectIds`) and the hook (if any) follow on the same tick as
+   * activation.
+   *
+   * Returns `true` if the request was accepted and queued; `false` only if
+   * the caster or ability id are unknown. A return value of `true` does
+   * NOT mean the activation will succeed — the verdict is delivered
+   * asynchronously via the `AbilityActivatedEvent` on the world event bus,
+   * and observable through side effects (cooldown tag granted, cost
+   * deducted). This mirrors UE5's GAS where `TryActivateAbility` accepts
+   * the input but the server-authoritative side decides whether the
+   * ability actually fires.
+   *
+   * `providedTarget` is required for abilities whose `TargetSpec.origin` is
+   * `{ kind: 'Caller' }` — it carries the target the user clicked on (an
+   * entity id, a point, or both). It is ignored for `Self`-targeted
+   * abilities and abilities resolving target from the registry.
+   *
+   * Deterministic enqueue order: requests are appended to a single FIFO
+   * queue on the runtime. Multiple casters racing the same ability on the
+   * same tick are resolved in the strict order their `activateAbility`
+   * calls arrived. In lockstep games this order is the input-replay order,
+   * which every peer reconstructs identically.
+   */
+  public activateAbility(
+    casterEntityId: number,
+    abilityId: string,
+    providedTarget?: ProvidedTarget
+  ): boolean {
+    if (!this.entityManager.getEntity(casterEntityId)) {
+      return false;
+    }
+    if (!this.registries.abilities.has(abilityId)) {
+      return false;
+    }
+    this.runtime.activationRequests.push({
+      casterEntityId,
+      abilityId,
+      providedTarget,
+      enqueueTick: this.runtime.currentTick,
+    });
+    return true;
+  }
+
+  /**
+   * Register a callback for `AbilityDef.hookId`. The callback fires inside
+   * `AbilityHookExecutorSystem` after `EffectApplicationSystem` has run on
+   * the activation tick, so the hook observes freshly-applied
+   * cost/cooldown/self-effects on the caster.
+   *
+   * Hooks MUST be deterministic — no `Date.now`, no `Math.random`, no
+   * non-replayable floating-point math. They may spawn entities (e.g.
+   * projectiles, aura zones) and write into the physics package; the
+   * resulting state is observable on the next tick.
+   *
+   * Throws if `hookId` is already registered. Registration is a one-shot
+   * setup step done at world boot.
+   */
+  public registerHook(hookId: string, hook: AbilityHook): void {
+    this.registries.hooks.register(hookId, hook);
   }
 
   // -----------------------------------------------------------------------

--- a/phalanx-abilities/src/events/AbilityEvents.ts
+++ b/phalanx-abilities/src/events/AbilityEvents.ts
@@ -11,9 +11,11 @@ import type { ProvidedTarget } from '../types';
  * `processTick` callback ordered after the abilities pipeline.
  *
  * Determinism notes:
- *  - `resolvedTargets` is empty in Stage 5: target resolution is the job of
- *    Stage 6's `TargetResolutionSystem`. It is included in the payload so
- *    later stages can populate it without changing the event shape.
+ *  - `resolvedTargets` may already contain resolved entity IDs in Stage 5 for
+ *    target kinds handled by {@link AbilityActivationSystem}, including
+ *    `Self` and direct `Entity` targets. Later stages such as Stage 6's
+ *    `TargetResolutionSystem` may still resolve additional target kinds
+ *    without changing the event shape.
  *  - Non-deterministic side effects (audio, Date.now, Math.random) MUST NOT
  *    be triggered from synchronous subscribers running inside the tick.
  *    Visual cues belong on the cue queue, dispatched only by clients.

--- a/phalanx-abilities/src/events/AbilityEvents.ts
+++ b/phalanx-abilities/src/events/AbilityEvents.ts
@@ -5,10 +5,11 @@ import type { ProvidedTarget } from '../types';
  * activation request has cleared `CanActivate` and the caster-side effects
  * (cost, cooldown, `selfEffectIds`) have been queued for application.
  *
- * The event fires from a deterministic point in the tick (see system order in
- * the package README), so subscribers may use it to drive deterministic game
- * logic — for example, a projectile-spawn system that also runs as a
- * `processTick` callback ordered after the abilities pipeline.
+ * The event fires from a deterministic point in the tick: after activation
+ * has been accepted and caster-side effects have been queued, but before
+ * Stage 6 target resolution populates `resolvedTargets`. Subscribers may use
+ * it to drive deterministic game logic — for example, a projectile-spawn
+ * system that runs later in the same tick, after the abilities pipeline.
  *
  * Determinism notes:
  *  - `resolvedTargets` may already contain resolved entity IDs in Stage 5 for

--- a/phalanx-abilities/src/events/AbilityEvents.ts
+++ b/phalanx-abilities/src/events/AbilityEvents.ts
@@ -1,0 +1,33 @@
+import type { ProvidedTarget } from '../types';
+
+/**
+ * Emitted on the world `EventBus` by {@link AbilityActivationSystem} after an
+ * activation request has cleared `CanActivate` and the caster-side effects
+ * (cost, cooldown, `selfEffectIds`) have been queued for application.
+ *
+ * The event fires from a deterministic point in the tick (see system order in
+ * the package README), so subscribers may use it to drive deterministic game
+ * logic — for example, a projectile-spawn system that also runs as a
+ * `processTick` callback ordered after the abilities pipeline.
+ *
+ * Determinism notes:
+ *  - `resolvedTargets` is empty in Stage 5: target resolution is the job of
+ *    Stage 6's `TargetResolutionSystem`. It is included in the payload so
+ *    later stages can populate it without changing the event shape.
+ *  - Non-deterministic side effects (audio, Date.now, Math.random) MUST NOT
+ *    be triggered from synchronous subscribers running inside the tick.
+ *    Visual cues belong on the cue queue, dispatched only by clients.
+ */
+export interface AbilityActivatedEvent {
+  abilityId: string;
+  casterEntityId: number;
+  resolvedTargets: readonly number[];
+  providedTarget?: ProvidedTarget;
+  tick: number;
+}
+
+/**
+ * Event-bus key for {@link AbilityActivatedEvent}. Namespaced under the
+ * package so consumers won't collide with unrelated subsystems.
+ */
+export const ABILITY_ACTIVATED_EVENT = 'phalanx-abilities:AbilityActivated';

--- a/phalanx-abilities/src/events/index.ts
+++ b/phalanx-abilities/src/events/index.ts
@@ -1,0 +1,2 @@
+export { ABILITY_ACTIVATED_EVENT } from './AbilityEvents';
+export type { AbilityActivatedEvent } from './AbilityEvents';

--- a/phalanx-abilities/src/index.ts
+++ b/phalanx-abilities/src/index.ts
@@ -1,5 +1,6 @@
 export * from './api';
 export * from './components';
+export * from './events';
 export * from './registry';
 export * from './runtime';
 export * from './systems';

--- a/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
+++ b/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
@@ -26,9 +26,10 @@ export interface ResolvedAbilityActivationRecord {
  * {@link AbilityActivationSystem} on the next tick.
  *
  * Held on the per-world runtime (not on a component) for two reasons:
- *  1. The facade is `not` a `GameSystem` and has no entity manager privileges
- *     — writing directly to a runtime field keeps the facade trivially
- *     stateless beyond the registries it already holds.
+ *  1. The facade is `not` a `GameSystem`; even though it may use the entity
+ *     manager for lookups/component creation, the runtime remains the owner
+ *     of mutable per-world execution state, which keeps this queue out of the
+ *     registries the facade already holds.
  *  2. A single FIFO queue across all casters gives us a deterministic global
  *     order without an extra singleton entity. The drain pass iterates in
  *     enqueue order; the system itself decides whether to spread requests

--- a/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
+++ b/phalanx-abilities/src/runtime/AbilitySystemRuntime.ts
@@ -1,21 +1,96 @@
+import type { ProvidedTarget } from '../types';
 import { InstanceIdCounter } from './InstanceIdCounter';
+
+/**
+ * In-tick handoff between {@link AbilityActivationSystem} and
+ * {@link AbilityHookExecutorSystem}. Populated by activation, drained by
+ * the executor later in the same tick.
+ *
+ * Held on the runtime so two systems running on different `processTick`
+ * passes share one buffer without an extra constructor wiring step. The
+ * shape is intentionally minimal — it should not accumulate fields that
+ * make sense as event payloads instead (use {@link AbilityActivatedEvent}
+ * for those).
+ */
+export interface ResolvedAbilityActivationRecord {
+  abilityId: string;
+  casterEntityId: number;
+  resolvedTargets: number[];
+  providedTarget?: ProvidedTarget;
+  hookId?: string;
+  tick: number;
+}
+
+/**
+ * Enqueued by {@link AbilitySystemFacade.activateAbility}, drained by
+ * {@link AbilityActivationSystem} on the next tick.
+ *
+ * Held on the per-world runtime (not on a component) for two reasons:
+ *  1. The facade is `not` a `GameSystem` and has no entity manager privileges
+ *     — writing directly to a runtime field keeps the facade trivially
+ *     stateless beyond the registries it already holds.
+ *  2. A single FIFO queue across all casters gives us a deterministic global
+ *     order without an extra singleton entity. The drain pass iterates in
+ *     enqueue order; the system itself decides whether to spread requests
+ *     across casters in the same tick.
+ *
+ * `enqueueTick` records the tick on which the request was created, which is
+ * `-1` if the facade is called before the first tick. The system only acts on
+ * requests whose `enqueueTick !== currentTick` — i.e. the next tick. This
+ * matches the existing `pendingAdd` discipline in
+ * {@link ActiveEffectsComponent}: writes from "this tick's user code" land on
+ * "the next tick's drain pass", which is the contract `applyEffect` already
+ * promises.
+ */
+export interface AbilityActivationRequest {
+  casterEntityId: number;
+  abilityId: string;
+  providedTarget?: ProvidedTarget;
+  enqueueTick: number;
+}
 
 /**
  * Per-world runtime state for the ability system.
  *
  * The {@link AbilitySystemRegistries} bundle holds *definitions* (attributes,
  * effects, abilities, hooks) which are immutable across the lifetime of a
- * world. Mutable per-world state — currently just the monotonic instance-id
- * counter for {@link ActiveEffectInstance} — lives here so two parallel
- * `GameWorld` instances cannot accidentally share counters and break
- * determinism.
+ * world. Mutable per-world state — the monotonic instance-id counter for
+ * {@link ActiveEffectInstance} and the FIFO activation request queue — lives
+ * here so two parallel `GameWorld` instances cannot accidentally share state
+ * and break determinism.
  */
 export interface AbilitySystemRuntime {
   instanceIdCounter: InstanceIdCounter;
+  /**
+   * Pending activation requests in strict enqueue order. Drained by
+   * {@link AbilityActivationSystem} on the tick after they were enqueued.
+   * Mutated only by:
+   *  - {@link AbilitySystemFacade.activateAbility} (push), and
+   *  - {@link AbilityActivationSystem.processTick} (drain).
+   */
+  activationRequests: AbilityActivationRequest[];
+  /**
+   * Latest tick number observed by any ability system. Updated at the start
+   * of {@link AbilityActivationSystem.processTick} and read by the facade so
+   * `activateAbility` can record `enqueueTick` correctly. `-1` until the
+   * first tick runs.
+   */
+  currentTick: number;
+  /**
+   * Activations that cleared `CanActivate` on the current tick and are
+   * waiting for {@link AbilityHookExecutorSystem} to fire their hooks.
+   * Populated by {@link AbilityActivationSystem}, drained (with `splice`)
+   * by the executor. Must be empty at the start of every tick — the
+   * activation system asserts this invariant.
+   */
+  resolvedActivationsThisTick: ResolvedAbilityActivationRecord[];
 }
 
 export function createAbilitySystemRuntime(): AbilitySystemRuntime {
   return {
     instanceIdCounter: new InstanceIdCounter(),
+    activationRequests: [],
+    currentTick: -1,
+    resolvedActivationsThisTick: [],
   };
 }

--- a/phalanx-abilities/src/runtime/index.ts
+++ b/phalanx-abilities/src/runtime/index.ts
@@ -1,3 +1,7 @@
 export { InstanceIdCounter } from './InstanceIdCounter';
 export { createAbilitySystemRuntime } from './AbilitySystemRuntime';
-export type { AbilitySystemRuntime } from './AbilitySystemRuntime';
+export type {
+  AbilityActivationRequest,
+  AbilitySystemRuntime,
+  ResolvedAbilityActivationRecord,
+} from './AbilitySystemRuntime';

--- a/phalanx-abilities/src/systems/AbilityActivationSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityActivationSystem.ts
@@ -1,0 +1,523 @@
+import { GameSystem } from 'phalanx-ecs';
+import type { Entity } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  ActiveEffectsComponent,
+  AttributesComponent,
+  GameplayTagsComponent,
+} from '../components';
+import { ABILITY_ACTIVATED_EVENT } from '../events';
+import type { AbilityActivatedEvent } from '../events';
+import type { AbilitySystemRegistries } from '../registry';
+import type {
+  AbilityActivationRequest,
+  AbilitySystemRuntime,
+  ResolvedAbilityActivationRecord,
+} from '../runtime';
+import type { AbilityDef, ProvidedTarget, TargetOrigin, TargetSpec } from '../types';
+
+/**
+ * Drains pending {@link AbilityActivationRequest}s from the runtime, runs
+ * `CanActivate` against the caster, and — for every approved request —
+ * queues the caster-side and target-side effects on the relevant entities'
+ * `ActiveEffectsComponent.pendingAdd`.
+ *
+ * `CanActivate` evaluates in fixed order:
+ *  1. `activationBlockedTags` — none of the listed tags may be present on
+ *     the caster (`GameplayTagsComponent.tags`).
+ *  2. `tagsRequired` — every listed tag must be present on the caster.
+ *  3. Cost — if `costEffectId` is set, the referenced effect must be
+ *     affordable. Stage 5 supports cost effects of type `Instant` whose
+ *     modifiers use the `Add` op with negative magnitude; in that case the
+ *     caster's `current` attribute must remain `>= 0` after the subtraction.
+ *     Multi-modifier costs (e.g. mana + stamina) are checked together. Non-
+ *     `Instant` cost effects or non-`Add` modifiers throw at activation time
+ *     — they are not supported in MVP.
+ *  4. Cooldown — if `cooldownEffectId` is set, the effect's `tagsGranted`
+ *     are inspected; if the caster already carries any of them, activation
+ *     is rejected. This matches the convention in the design doc where a
+ *     cooldown is "a Duration effect granting `Cooldown.Ability.<id>`".
+ *
+ * **Same-tick chained activations.** A naive implementation would allow two
+ * activations of the same ability in the same tick because the cooldown
+ * effect's `tagsGranted` only land when `EffectApplicationSystem` runs later
+ * in the tick. To preserve "one cast per cooldown" semantics inside a single
+ * tick, the system tracks two transient bookkeeping maps for the duration of
+ * one drain pass:
+ *  - `inFlightTagsByCaster`: tags that earlier-this-tick approved requests
+ *    will grant. Each subsequent CanActivate check treats them as if they
+ *    were already on the caster.
+ *  - `inFlightCostsByCaster`: per-attribute cumulative would-be cost
+ *    debits. Each subsequent affordability check subtracts them from the
+ *    caster's `current` value.
+ *
+ * After successful CanActivate the system:
+ *  - Enqueues `costEffectId` (if any), `cooldownEffectId` (if any), and
+ *    every `selfEffectIds` entry on the caster's `pendingAdd`.
+ *  - Resolves `target` for the trivial shapes supported in Stage 5
+ *    (`Self`, `Entity { Caster | Caller | TargetEntity }`). `Radius` and
+ *    `Point` are deferred to Stage 6's `TargetResolutionSystem` and throw
+ *    here.
+ *  - Enqueues every `targetEffectIds` entry on each resolved target's
+ *    `pendingAdd`.
+ *  - Emits an {@link AbilityActivatedEvent} on the world event bus.
+ *  - Appends a {@link ResolvedAbilityActivation} to
+ *    `runtime.resolvedActivationsThisTick` so
+ *    `AbilityHookExecutorSystem` can fire `hookId` later in the tick.
+ *
+ * Failed activations are silently dropped — they do not throw. A `boolean`
+ * is returned by the facade-level `activateAbility` for the synchronous
+ * "did we enqueue a request at all" check, but the actual approval verdict
+ * is observable only via the side effects above (and the event). This
+ * mirrors UE5's GAS where `TryActivateAbility` accepts the input but the
+ * server-authoritative side decides whether the ability actually fires.
+ */
+export class AbilityActivationSystem extends GameSystem {
+  /** Per-tick scratch buffer: tag string → caster id → tag granted in flight. */
+  private readonly inFlightTagsByCaster = new Map<number, Set<string>>();
+  /**
+   * Per-tick scratch buffer: caster id → attribute id → cumulative debit.
+   * `debit` is stored as raw `FixedPoint` for cheap accumulation.
+   */
+  private readonly inFlightCostsByCaster = new Map<number, Map<string, bigint>>();
+
+  public constructor(
+    private readonly registries: AbilitySystemRegistries,
+    private readonly runtime: AbilitySystemRuntime
+  ) {
+    super();
+  }
+
+  public override processTick(tick: number): void {
+    this.runtime.currentTick = tick;
+
+    // Reset transient bookkeeping at the start of every drain pass. We
+    // deliberately do not retain in-flight state across ticks — by the next
+    // tick, the actual tags / costs will have landed via
+    // EffectApplicationSystem.
+    this.inFlightTagsByCaster.clear();
+    this.inFlightCostsByCaster.clear();
+
+    // The hook executor will drain this buffer later in the tick, after
+    // EffectApplicationSystem has run. We assert here that the buffer is
+    // empty: a non-empty buffer means the executor did not run last tick,
+    // which is a registration bug.
+    if (this.runtime.resolvedActivationsThisTick.length !== 0) {
+      throw new Error(
+        'AbilityActivationSystem: resolvedActivationsThisTick is not empty at start of tick. ' +
+          'Ensure AbilityHookExecutorSystem is registered after AbilityActivationSystem ' +
+          'and EffectApplicationSystem in the system pipeline.'
+      );
+    }
+
+    // Drain only requests that were enqueued BEFORE this tick. Requests made
+    // from inside the tick (e.g. by a hook scheduling another activation)
+    // wait for the next tick — mirrors the pendingAdd discipline used by
+    // ActiveEffectsComponent.
+    const pending = this.runtime.activationRequests;
+    if (pending.length === 0) {
+      return;
+    }
+
+    let writeIndex = 0;
+    for (let readIndex = 0; readIndex < pending.length; readIndex++) {
+      const request = pending[readIndex];
+      if (request.enqueueTick === tick) {
+        // Defer to next tick.
+        if (writeIndex !== readIndex) {
+          pending[writeIndex] = request;
+        }
+        writeIndex += 1;
+        continue;
+      }
+      this.processOne(request, tick);
+    }
+    pending.length = writeIndex;
+  }
+
+  private processOne(request: AbilityActivationRequest, tick: number): void {
+    const abilityDef = this.registries.abilities.tryGet(request.abilityId);
+    if (!abilityDef) {
+      // Unknown ability id is a programming error, not a runtime miss.
+      throw new Error(`AbilityRegistry does not contain '${request.abilityId}'`);
+    }
+
+    const caster = this.entityManager.getEntity(request.casterEntityId);
+    if (!caster) {
+      // Caster despawned between enqueue and drain; silently drop.
+      return;
+    }
+
+    if (!this.canActivate(caster, abilityDef)) {
+      return;
+    }
+
+    // 1) Resolve targets BEFORE enqueueing target effects so failures here
+    //    abort the activation cleanly (no half-application of cost/cooldown).
+    const resolvedTargets = this.resolveTargets(caster, abilityDef, request.providedTarget);
+
+    // 2) Apply caster-side effects (cost, cooldown, selfEffectIds).
+    this.enqueueCasterEffects(caster, abilityDef);
+
+    // 3) Apply target-side effects (every targetEffectIds entry on each
+    //    resolved target).
+    if (abilityDef.targetEffectIds && abilityDef.targetEffectIds.length > 0) {
+      for (let i = 0; i < resolvedTargets.length; i++) {
+        const targetEntity = this.entityManager.getEntity(resolvedTargets[i]);
+        if (!targetEntity) {
+          // Target despawned between resolve and apply; skip without
+          // aborting the rest of the activation. Determinism-safe because
+          // every peer makes the same observation (snapshot at this point
+          // in the tick).
+          continue;
+        }
+        for (const effectId of abilityDef.targetEffectIds) {
+          this.enqueueEffect(targetEntity, effectId, request.casterEntityId);
+        }
+      }
+    }
+
+    // 4) Record an in-flight cooldown tag-grant so subsequent same-tick
+    //    requests on the same caster see it.
+    this.recordCooldownInFlight(request.casterEntityId, abilityDef);
+
+    // 5) Stash the resolved activation for the hook executor.
+    const record: ResolvedAbilityActivationRecord = {
+      abilityId: abilityDef.id,
+      casterEntityId: request.casterEntityId,
+      resolvedTargets,
+      providedTarget: request.providedTarget,
+      hookId: abilityDef.hookId,
+      tick,
+    };
+    this.runtime.resolvedActivationsThisTick.push(record);
+
+    // 6) Emit AbilityActivated for any subscribers (gameplay scripts that
+    //    want to react to a successful cast — e.g. analytics, scripted
+    //    encounters). Hook execution runs later in the tick via the executor
+    //    system; the event is fired now so consumers see consistent ordering
+    //    with the cost/cooldown enqueue.
+    const event: AbilityActivatedEvent = {
+      abilityId: abilityDef.id,
+      casterEntityId: request.casterEntityId,
+      resolvedTargets,
+      providedTarget: request.providedTarget,
+      tick,
+    };
+    this.eventBus.emit(ABILITY_ACTIVATED_EVENT, event);
+  }
+
+  // ---------------------------------------------------------------------------
+  // CanActivate
+  // ---------------------------------------------------------------------------
+
+  private canActivate(caster: Entity, def: AbilityDef): boolean {
+    const casterId = caster.id;
+    const tags = caster.getComponent<GameplayTagsComponent>(AbilitiesComponentType.GameplayTags);
+    const inFlightTags = this.inFlightTagsByCaster.get(casterId);
+
+    if (def.activationBlockedTags) {
+      for (const tag of def.activationBlockedTags) {
+        if (tags?.tags.has(tag) === true) {
+          return false;
+        }
+        if (inFlightTags?.has(tag) === true) {
+          return false;
+        }
+      }
+    }
+
+    if (def.tagsRequired) {
+      for (const tag of def.tagsRequired) {
+        if (tags?.tags.has(tag) !== true && inFlightTags?.has(tag) !== true) {
+          return false;
+        }
+      }
+    }
+
+    if (def.costEffectId !== undefined) {
+      if (!this.canAffordCost(caster, def.costEffectId)) {
+        return false;
+      }
+    }
+
+    if (def.cooldownEffectId !== undefined) {
+      if (!this.isOffCooldown(caster, def.cooldownEffectId)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Stage 5 cost model:
+   *  - Cost effect must be `Instant`.
+   *  - Every modifier must be `Add` with negative magnitude (a debit).
+   *  - The caster must have enough `current` (post-aggregation) to absorb
+   *    every debit without dropping below `0`. We use `current` (not `base`)
+   *    so transient buffs / debuffs are accounted for — e.g. a fortitude
+   *    buff that boosts max mana also boosts affordable spend.
+   *  - Multiple modifiers on different attributes are checked independently.
+   *  - In-flight costs from earlier same-tick requests on the same caster
+   *    are subtracted before the comparison.
+   *
+   * Non-Instant cost effects and non-Add modifiers throw — they're a
+   * misconfiguration in MVP, not a runtime miss.
+   */
+  private canAffordCost(caster: Entity, costEffectId: string): boolean {
+    const effectDef = this.registries.effects.tryGet(costEffectId);
+    if (!effectDef) {
+      throw new Error(`EffectRegistry does not contain '${costEffectId}'`);
+    }
+    if (effectDef.type !== 'Instant') {
+      throw new Error(
+        `Ability cost effect '${costEffectId}' must be type 'Instant'; got '${effectDef.type}'`
+      );
+    }
+
+    if (effectDef.modifiers.length === 0) {
+      // Free cost: trivially affordable.
+      return true;
+    }
+
+    const attributes = caster.getComponent<AttributesComponent>(AbilitiesComponentType.Attributes);
+    if (!attributes) {
+      // No attribute store at all — cost cannot be charged. Reject so the
+      // caller isn't silently let through.
+      return false;
+    }
+
+    const inFlightCosts = this.inFlightCostsByCaster.get(caster.id);
+
+    for (const modifier of effectDef.modifiers) {
+      if (modifier.op !== 'Add') {
+        throw new Error(
+          `Ability cost effect '${costEffectId}' uses unsupported op '${modifier.op}'. ` +
+            'MVP supports only Instant + Add modifiers for cost.'
+        );
+      }
+      const rawMagnitude = FP.ToRaw(modifier.magnitude);
+      if (rawMagnitude >= 0n) {
+        // Non-negative magnitudes aren't really a "cost"; they cannot fail
+        // the affordability check and we let them through unchanged.
+        continue;
+      }
+      const attributeIndex = this.registries.attributes.indexOfOrMinusOne(modifier.attributeId);
+      if (attributeIndex === -1) {
+        throw new Error(
+          `Ability cost effect '${costEffectId}' references unknown attribute '${modifier.attributeId}'`
+        );
+      }
+      const currentRaw = attributes.current[attributeIndex];
+      const inFlightDebit = inFlightCosts?.get(modifier.attributeId) ?? 0n;
+      // After the debit, attribute value would be: current - inFlight + magnitude
+      // (magnitude is negative). Reject if it would go below 0.
+      const after = currentRaw - inFlightDebit + rawMagnitude;
+      if (after < 0n) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Cooldown is encoded as a Duration effect whose `tagsGranted` contains
+   * the cooldown tag (e.g. `Cooldown.Ability.AutoAttack`). The ability is
+   * "off cooldown" iff none of those tags are present on the caster — both
+   * as real tags and as in-flight grants from same-tick earlier activations.
+   *
+   * A cooldown effect with no `tagsGranted` is a misconfiguration: there
+   * would be no way to gate the next activation. We throw rather than
+   * silently letting the second activation through.
+   */
+  private isOffCooldown(caster: Entity, cooldownEffectId: string): boolean {
+    const effectDef = this.registries.effects.tryGet(cooldownEffectId);
+    if (!effectDef) {
+      throw new Error(`EffectRegistry does not contain '${cooldownEffectId}'`);
+    }
+    if (!effectDef.tagsGranted || effectDef.tagsGranted.length === 0) {
+      throw new Error(
+        `Ability cooldown effect '${cooldownEffectId}' must have at least one tagsGranted entry.`
+      );
+    }
+
+    const tags = caster.getComponent<GameplayTagsComponent>(AbilitiesComponentType.GameplayTags);
+    const inFlightTags = this.inFlightTagsByCaster.get(caster.id);
+
+    for (const tag of effectDef.tagsGranted) {
+      if (tags?.tags.has(tag) === true) {
+        return false;
+      }
+      if (inFlightTags?.has(tag) === true) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Application
+  // ---------------------------------------------------------------------------
+
+  private enqueueCasterEffects(caster: Entity, def: AbilityDef): void {
+    if (def.costEffectId !== undefined) {
+      this.enqueueEffect(caster, def.costEffectId, caster.id);
+      this.recordCostInFlight(caster.id, def.costEffectId);
+    }
+    if (def.cooldownEffectId !== undefined) {
+      this.enqueueEffect(caster, def.cooldownEffectId, caster.id);
+    }
+    if (def.selfEffectIds) {
+      for (const effectId of def.selfEffectIds) {
+        this.enqueueEffect(caster, effectId, caster.id);
+      }
+    }
+  }
+
+  /**
+   * Mirror of `AbilitySystemFacade.applyEffect`'s enqueue path. We do not
+   * call the facade directly — the facade requires entity existence to
+   * `throw`, which is appropriate for user code but the system already
+   * knows the entity exists.
+   */
+  private enqueueEffect(target: Entity, effectId: string, sourceEntityId: number): void {
+    if (!this.registries.effects.has(effectId)) {
+      throw new Error(`EffectRegistry does not contain '${effectId}'`);
+    }
+    const activeEffects = this.getOrCreateActiveEffects(target);
+    activeEffects.pendingAdd.push({ defId: effectId, sourceEntityId });
+  }
+
+  private getOrCreateActiveEffects(target: Entity): ActiveEffectsComponent {
+    const existing = target.getComponent<ActiveEffectsComponent>(
+      AbilitiesComponentType.ActiveEffects
+    );
+    if (existing) {
+      return existing;
+    }
+    const component = new ActiveEffectsComponent();
+    target.addComponent(component);
+    this.entityManager.onComponentAdded(target, component.type);
+    return component;
+  }
+
+  private recordCooldownInFlight(casterId: number, def: AbilityDef): void {
+    if (def.cooldownEffectId === undefined) {
+      return;
+    }
+    const effectDef = this.registries.effects.tryGet(def.cooldownEffectId);
+    if (!effectDef || !effectDef.tagsGranted) {
+      return;
+    }
+    let set = this.inFlightTagsByCaster.get(casterId);
+    if (!set) {
+      set = new Set<string>();
+      this.inFlightTagsByCaster.set(casterId, set);
+    }
+    for (const tag of effectDef.tagsGranted) {
+      set.add(tag);
+    }
+  }
+
+  private recordCostInFlight(casterId: number, costEffectId: string): void {
+    const effectDef = this.registries.effects.tryGet(costEffectId);
+    if (!effectDef) {
+      return;
+    }
+    let map = this.inFlightCostsByCaster.get(casterId);
+    for (const modifier of effectDef.modifiers) {
+      if (modifier.op !== 'Add') {
+        // Already rejected by canAffordCost; defensive skip.
+        continue;
+      }
+      const rawMagnitude = FP.ToRaw(modifier.magnitude);
+      if (rawMagnitude >= 0n) {
+        continue;
+      }
+      if (!map) {
+        map = new Map<string, bigint>();
+        this.inFlightCostsByCaster.set(casterId, map);
+      }
+      const existing = map.get(modifier.attributeId) ?? 0n;
+      // Stored as positive debit so canAffordCost can subtract it cleanly.
+      map.set(modifier.attributeId, existing + -rawMagnitude);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Target resolution (Stage 5 subset; Radius lands in Stage 6)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Minimal in-system target resolver covering only the shapes that make
+   * sense without spatial queries:
+   *  - `Self`            → `[casterId]`.
+   *  - `Entity { Caster }`     → `[casterId]`.
+   *  - `Entity { Caller }`     → `[providedTarget.entityId]` (required).
+   *  - `Entity { TargetEntity }` → `[origin.entityId]`.
+   *  - `Point` and `Radius` → throw. They require Stage 6's
+   *    `TargetResolutionSystem` for deterministic spatial resolve.
+   *
+   * Targets are returned in a freshly-allocated array because the resolved
+   * activations buffer holds it for the hook executor; sharing would couple
+   * lifetimes.
+   */
+  private resolveTargets(
+    caster: Entity,
+    def: AbilityDef,
+    providedTarget: ProvidedTarget | undefined
+  ): number[] {
+    return resolveSimpleTargets(caster.id, def.target, providedTarget);
+  }
+}
+
+function resolveSimpleTargets(
+  casterId: number,
+  target: TargetSpec,
+  providedTarget: ProvidedTarget | undefined
+): number[] {
+  switch (target.kind) {
+    case 'Self':
+      return [casterId];
+    case 'Entity': {
+      const entityId = resolveEntityOrigin(casterId, target.origin, providedTarget);
+      if (entityId === undefined) {
+        return [];
+      }
+      return [entityId];
+    }
+    case 'Point':
+      throw new Error(
+        "TargetSpec.kind === 'Point' requires Stage 6's TargetResolutionSystem (not yet implemented)."
+      );
+    case 'Radius':
+      throw new Error(
+        "TargetSpec.kind === 'Radius' requires Stage 6's TargetResolutionSystem (not yet implemented)."
+      );
+  }
+}
+
+function resolveEntityOrigin(
+  casterId: number,
+  origin: TargetOrigin,
+  providedTarget: ProvidedTarget | undefined
+): number | undefined {
+  switch (origin.kind) {
+    case 'Caster':
+      return casterId;
+    case 'TargetEntity':
+      return origin.entityId;
+    case 'Caller':
+      // Caller-style: read from providedTarget. Missing entityId means the
+      // caller forgot to supply a target — silently drop the activation.
+      return providedTarget?.entityId;
+    case 'Point':
+      throw new Error(
+        "TargetOrigin.kind === 'Point' is only meaningful for TargetSpec.kind 'Radius'/'Point'."
+      );
+  }
+}
+

--- a/phalanx-abilities/src/systems/AbilityActivationSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityActivationSystem.ts
@@ -120,20 +120,38 @@ export class AbilityActivationSystem extends GameSystem {
       return;
     }
 
+    // Compact the queue inside a `try`/`finally` so that even if
+    // `processOne` throws (e.g. on a misconfigured effect or an unsupported
+    // target shape), every already-visited request is removed from the
+    // queue. Otherwise a loud activation error would leave processed
+    // requests behind to be replayed on a later tick — after their effects
+    // were already enqueued and their `AbilityActivated` event emitted.
+    let readIndex = 0;
     let writeIndex = 0;
-    for (let readIndex = 0; readIndex < pending.length; readIndex++) {
-      const request = pending[readIndex];
-      if (request.enqueueTick === tick) {
-        // Defer to next tick.
-        if (writeIndex !== readIndex) {
-          pending[writeIndex] = request;
+    try {
+      for (; readIndex < pending.length; readIndex++) {
+        const request = pending[readIndex];
+        if (request.enqueueTick === tick) {
+          // Defer to next tick.
+          if (writeIndex !== readIndex) {
+            pending[writeIndex] = request;
+          }
+          writeIndex += 1;
+          continue;
         }
-        writeIndex += 1;
-        continue;
+        this.processOne(request, tick);
       }
-      this.processOne(request, tick);
+    } finally {
+      // Preserve any unread tail (readIndex+1..end) after the compacted
+      // prefix so deferred requests from later in the queue are not lost
+      // when an exception interrupts the drain mid-loop.
+      if (readIndex + 1 < pending.length) {
+        for (let k = readIndex + 1; k < pending.length; k++) {
+          pending[writeIndex++] = pending[k];
+        }
+      }
+      pending.length = writeIndex;
     }
-    pending.length = writeIndex;
   }
 
   private processOne(request: AbilityActivationRequest, tick: number): void {

--- a/phalanx-abilities/src/systems/AbilityActivationSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityActivationSystem.ts
@@ -62,7 +62,7 @@ import type { AbilityDef, ProvidedTarget, TargetOrigin, TargetSpec } from '../ty
  *  - Enqueues every `targetEffectIds` entry on each resolved target's
  *    `pendingAdd`.
  *  - Emits an {@link AbilityActivatedEvent} on the world event bus.
- *  - Appends a {@link ResolvedAbilityActivation} to
+ *  - Appends a {@link ResolvedAbilityActivationRecord} to
  *    `runtime.resolvedActivationsThisTick` so
  *    `AbilityHookExecutorSystem` can fire `hookId` later in the tick.
  *

--- a/phalanx-abilities/src/systems/AbilityHookExecutorSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityHookExecutorSystem.ts
@@ -1,0 +1,78 @@
+import { GameSystem } from 'phalanx-ecs';
+import type { AbilitySystemRegistries } from '../registry';
+import type { AbilitySystemRuntime } from '../runtime';
+import type { AbilityActivationContext } from '../types';
+
+/**
+ * Runs activation hooks for abilities that resolved earlier in the current
+ * tick.
+ *
+ * Per the design doc, hook execution is sandwiched between
+ * `EffectApplicationSystem` (so the hook sees freshly-applied
+ * cost/cooldown/selfEffects on the caster) and `EffectTickSystem` (so the
+ * hook can observe Duration effect lifetimes that started this tick).
+ * `AbilityActivationSystem` populates the `resolvedActivationsThisTick`
+ * buffer; this system drains it.
+ *
+ * Hook implementation contract:
+ *  - Hooks MUST be deterministic. They may spawn entities (projectiles,
+ *    auras), enqueue commands into the physics package, or read attributes
+ *    via `AbilitySystemFacade` — but they must not call `Date.now`,
+ *    `Math.random`, or any floating-point math whose results are not
+ *    reproducible across peers.
+ *  - Hooks that need to apply additional effects should go through the
+ *    facade's `applyEffect` — those effects land on the NEXT tick because
+ *    the application system has already run for this tick. That latency is
+ *    intentional and matches the published `applyEffect` contract.
+ *  - Hooks throwing synchronously will propagate up through `processTick`.
+ *    The buffer is cleared first so a partial drain does not leave the
+ *    next-tick start in an invalid state.
+ *
+ * Unknown `hookId`s are surfaced loudly: they almost always mean the user
+ * forgot to call `registerHook` for a known ability, which is the kind of
+ * mistake that should fail at the first activation rather than ship as a
+ * silent no-op.
+ */
+export class AbilityHookExecutorSystem extends GameSystem {
+  public constructor(
+    private readonly registries: AbilitySystemRegistries,
+    private readonly runtime: AbilitySystemRuntime
+  ) {
+    super();
+  }
+
+  public override processTick(_tick: number): void {
+    const buffer = this.runtime.resolvedActivationsThisTick;
+    if (buffer.length === 0) {
+      return;
+    }
+
+    // Snapshot then clear before iterating so:
+    //  - a hook that throws cannot leave entries behind for next tick (and
+    //    therefore cannot trigger the start-of-tick assertion in
+    //    AbilityActivationSystem);
+    //  - a hook that re-enters the activation path via the facade enqueues
+    //    requests for the NEXT tick (the runtime queue is separate from our
+    //    snapshot here), preserving determinism.
+    const drained = buffer.splice(0, buffer.length);
+
+    for (let i = 0; i < drained.length; i++) {
+      const resolved = drained[i];
+      if (resolved.hookId === undefined) {
+        continue;
+      }
+      const hook = this.registries.hooks.tryGet(resolved.hookId);
+      if (!hook) {
+        throw new Error(`AbilityHooksRegistry does not contain '${resolved.hookId}'`);
+      }
+      const ctx: AbilityActivationContext = {
+        abilityId: resolved.abilityId,
+        casterEntityId: resolved.casterEntityId,
+        resolvedTargets: resolved.resolvedTargets,
+        providedTarget: resolved.providedTarget,
+        tick: resolved.tick,
+      };
+      hook(ctx);
+    }
+  }
+}

--- a/phalanx-abilities/src/systems/index.ts
+++ b/phalanx-abilities/src/systems/index.ts
@@ -1,3 +1,5 @@
+export { AbilityActivationSystem } from './AbilityActivationSystem';
+export { AbilityHookExecutorSystem } from './AbilityHookExecutorSystem';
 export { AttributeAggregationSystem } from './AttributeAggregationSystem';
 export { EffectApplicationSystem } from './EffectApplicationSystem';
 export { EffectTickSystem } from './EffectTickSystem';

--- a/phalanx-abilities/tests/abilities.test.ts
+++ b/phalanx-abilities/tests/abilities.test.ts
@@ -672,6 +672,105 @@ describe('ability activation — request lifecycle', () => {
 
     world.dispose();
   });
+
+  it('snapshots providedTarget so mutating the caller object after enqueue does not change the request', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Mark',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-7) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.MarkTarget',
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          targetEffectIds: ['Effect.Mark'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const intendedTarget = addEntity(world);
+    const bystander = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(intendedTarget.id);
+    facade.initAttributesForEntity(bystander.id);
+    world.processAllTicks(1);
+
+    const providedTarget = { entityId: intendedTarget.id };
+    facade.activateAbility(caster.id, 'Ability.MarkTarget', providedTarget);
+
+    // Caller mutates the original object before the activation drains. The
+    // snapshot in the queue must keep pointing at the intended target.
+    providedTarget.entityId = bystander.id;
+
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(intendedTarget.id, 'Health').current)).toBe(93);
+    expect(FP.ToFloat(facade.getAttribute(bystander.id, 'Health').current)).toBe(100);
+
+    world.dispose();
+  });
+
+  it('compacts the queue even when processOne throws, so processed requests are not replayed', () => {
+    // Two abilities share a tick. The first has a misconfigured cooldown
+    // effect (no `tagsGranted`) and will throw during processing. The
+    // second is well-formed and should NOT be replayed on a later tick
+    // after the throw is swallowed by the test — the drain must compact
+    // away the throwing request so reprocessing cannot happen.
+    const { world, facade, runtime } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.BadCooldown',
+          // Duration with no tagsGranted — isOffCooldown will throw.
+          type: 'Duration',
+          durationTicks: 10,
+        }),
+        defineEffect({
+          id: 'Effect.GoodCooldown',
+          type: 'Duration',
+          durationTicks: 10,
+          tagsGranted: ['Cooldown.Ability.Good'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Bad',
+          cooldownEffectId: 'Effect.BadCooldown',
+          target: { kind: 'Self' },
+        }),
+        defineAbility({
+          id: 'Ability.Good',
+          cooldownEffectId: 'Effect.GoodCooldown',
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    facade.activateAbility(caster.id, 'Ability.Bad');
+    facade.activateAbility(caster.id, 'Ability.Good');
+    expect(runtime.activationRequests.length).toBe(2);
+
+    // Tick 2 drains. The bad request throws — the good request that was
+    // queued AFTER it has not been processed yet and must be preserved
+    // for next tick. The bad request must be discarded.
+    expect(() => world.processAllTicks(2)).toThrow();
+    expect(runtime.activationRequests.length).toBe(1);
+    expect(runtime.activationRequests[0].abilityId).toBe('Ability.Good');
+    // Bad cooldown tag must not be present (effect was never applied).
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Good')).toBe(false);
+
+    // Tick 3: the surviving good request drains cleanly.
+    world.processAllTicks(3);
+    expect(runtime.activationRequests.length).toBe(0);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Good')).toBe(true);
+
+    world.dispose();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/phalanx-abilities/tests/abilities.test.ts
+++ b/phalanx-abilities/tests/abilities.test.ts
@@ -1,0 +1,771 @@
+import { describe, expect, it } from 'vitest';
+import { Entity, GameWorld } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import {
+  ABILITY_ACTIVATED_EVENT,
+  AbilitiesComponentType,
+  AbilityActivationSystem,
+  AbilityHookExecutorSystem,
+  AbilitySystemFacade,
+  AttributeAggregationSystem,
+  EffectApplicationSystem,
+  EffectTickSystem,
+  createAbilitySystemRegistries,
+  createAbilitySystemRuntime,
+  defineAbility,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+import type { AbilityActivatedEvent, AbilitySystemRegistries, AbilitySystemRuntime } from '../src';
+
+// ---------------------------------------------------------------------------
+// Stage 5 — Abilities: cost / cooldown / CanActivate / hooks
+//
+// These tests cover the activation pipeline end-to-end. Each test sets up a
+// minimal world via `createTestWorld`, drives one or more activations through
+// the facade, and asserts the observable outcome (attribute deltas, tag
+// state, hook invocation, event emission). Failure cases are deliberately
+// silent — see `activateAbility` contract — so we verify rejection by
+// asserting the side effects DID NOT happen.
+// ---------------------------------------------------------------------------
+
+describe('ability activation — happy paths', () => {
+  it('queues cost + cooldown + selfEffectIds on the caster on the activation tick', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.SpendMana10',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-10) }],
+        }),
+        defineEffect({
+          id: 'Effect.Fireball.Cooldown',
+          type: 'Duration',
+          durationTicks: 30,
+          tagsGranted: ['Cooldown.Ability.Fireball'],
+        }),
+        defineEffect({
+          id: 'Effect.Buff.Cast',
+          type: 'Duration',
+          durationTicks: 60,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(5) }],
+          tagsGranted: ['State.Buff.CastSpeed'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Fireball',
+          costEffectId: 'Effect.SpendMana10',
+          cooldownEffectId: 'Effect.Fireball.Cooldown',
+          selfEffectIds: ['Effect.Buff.Cast'],
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(50);
+
+    facade.activateAbility(caster.id, 'Ability.Fireball');
+
+    // Tick 2: activation drains, cost+cooldown+self enqueued, EffectApplication
+    // applies them on the same tick because of system order.
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(40);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Fireball')).toBe(true);
+    expect(facade.hasTag(caster.id, 'State.Buff.CastSpeed')).toBe(true);
+    // Self-effect's Armor buff folded through aggregation.
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Armor').current)).toBe(55);
+
+    world.dispose();
+  });
+
+  it('emits AbilityActivated on the world event bus when activation succeeds', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Mark',
+          type: 'Duration',
+          durationTicks: 60,
+          modifiers: [
+            { attributeId: 'IncomingDamageMultiplier', op: 'Multiply', magnitude: FP.FromFloat(1.25) },
+          ],
+          tagsGranted: ['State.Marked'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.MarkBeam',
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          targetEffectIds: ['Effect.Mark'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    const seen: AbilityActivatedEvent[] = [];
+    world.eventBus.on<AbilityActivatedEvent>(ABILITY_ACTIVATED_EVENT, e => {
+      seen.push(e);
+    });
+
+    facade.activateAbility(caster.id, 'Ability.MarkBeam', { entityId: enemy.id });
+    world.processAllTicks(2);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].abilityId).toBe('Ability.MarkBeam');
+    expect(seen[0].casterEntityId).toBe(caster.id);
+    expect(seen[0].resolvedTargets).toEqual([enemy.id]);
+    expect(seen[0].providedTarget?.entityId).toBe(enemy.id);
+    expect(seen[0].tick).toBe(2);
+
+    // targetEffects were enqueued onto the enemy in the same tick and applied
+    // by EffectApplicationSystem.
+    expect(facade.hasTag(enemy.id, 'State.Marked')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('applies targetEffectIds to the entity returned by TargetSpec resolution', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.ArmorShred',
+          type: 'Duration',
+          durationTicks: 10,
+          modifiers: [{ attributeId: 'Armor', op: 'Add', magnitude: FP.FromInt(-20) }],
+          tagsGranted: ['State.Debuff.ArmorShred'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.ShredBeam',
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          targetEffectIds: ['Effect.ArmorShred'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Armor').current)).toBe(50);
+
+    facade.activateAbility(caster.id, 'Ability.ShredBeam', { entityId: enemy.id });
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Armor').current)).toBe(30);
+    // Caster is unaffected by a pure-target-effect ability.
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Armor').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('resolves Self targeting to the caster and applies targetEffectIds to self', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.SelfHeal',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(20) }],
+        }),
+        defineEffect({
+          id: 'Effect.TestDamage40',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-40) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.SelfHeal',
+          target: { kind: 'Self' },
+          targetEffectIds: ['Effect.SelfHeal'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    // Drop the caster's health so a heal is observable (clamp would mask it
+    // otherwise — Health defaults to its max).
+    facade.applyEffect(caster.id, 'Effect.TestDamage40', caster.id);
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Health').current)).toBe(60);
+
+    facade.activateAbility(caster.id, 'Ability.SelfHeal');
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Health').current)).toBe(80);
+
+    world.dispose();
+  });
+});
+
+describe('ability activation — CanActivate gating', () => {
+  it('blocks activation when caster has any activationBlockedTags', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Fireball.Cooldown',
+          type: 'Duration',
+          durationTicks: 30,
+          tagsGranted: ['Cooldown.Ability.Fireball'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Fireball',
+          cooldownEffectId: 'Effect.Fireball.Cooldown',
+          activationBlockedTags: ['State.Stun'],
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    facade.addTag(caster.id, 'State.Stun');
+
+    facade.activateAbility(caster.id, 'Ability.Fireball');
+    world.processAllTicks(2);
+
+    // Cooldown tag must NOT be granted: activation was rejected, no cooldown
+    // effect was enqueued.
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Fireball')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('blocks activation when caster lacks any tagsRequired', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Stance.Cooldown',
+          type: 'Duration',
+          durationTicks: 5,
+          tagsGranted: ['Cooldown.Ability.Stance'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.WarriorStance',
+          cooldownEffectId: 'Effect.Stance.Cooldown',
+          tagsRequired: ['Class.Warrior'],
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    // Missing required tag: activation rejected.
+    facade.activateAbility(caster.id, 'Ability.WarriorStance');
+    world.processAllTicks(2);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Stance')).toBe(false);
+
+    // Grant the tag and try again: activation now succeeds.
+    facade.addTag(caster.id, 'Class.Warrior');
+    facade.activateAbility(caster.id, 'Ability.WarriorStance');
+    world.processAllTicks(3);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Stance')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('blocks activation while the cooldown tag is present, then allows after expiry', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Snipe.Cooldown',
+          type: 'Duration',
+          durationTicks: 3,
+          tagsGranted: ['Cooldown.Ability.Snipe'],
+        }),
+        defineEffect({
+          id: 'Effect.Snipe.Damage',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Snipe',
+          cooldownEffectId: 'Effect.Snipe.Cooldown',
+          activationBlockedTags: ['Cooldown.Ability.Snipe'],
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          targetEffectIds: ['Effect.Snipe.Damage'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    // First cast lands.
+    facade.activateAbility(caster.id, 'Ability.Snipe', { entityId: enemy.id });
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(90);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Snipe')).toBe(true);
+
+    // Second cast on the next tick is blocked by the cooldown tag.
+    facade.activateAbility(caster.id, 'Ability.Snipe', { entityId: enemy.id });
+    world.processAllTicks(3);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(90);
+
+    // Cooldown expires (durationTicks=3 from tick 2): tick 5 sees the tag
+    // gone. Cast again — lands.
+    world.processAllTicks(4);
+    world.processAllTicks(5);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Snipe')).toBe(false);
+
+    facade.activateAbility(caster.id, 'Ability.Snipe', { entityId: enemy.id });
+    world.processAllTicks(6);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(80);
+
+    world.dispose();
+  });
+
+  it('blocks a same-tick second activation via in-flight cooldown bookkeeping', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Burst.Cooldown',
+          type: 'Duration',
+          durationTicks: 5,
+          tagsGranted: ['Cooldown.Ability.Burst'],
+        }),
+        defineEffect({
+          id: 'Effect.Burst.Damage',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Burst',
+          cooldownEffectId: 'Effect.Burst.Cooldown',
+          activationBlockedTags: ['Cooldown.Ability.Burst'],
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          targetEffectIds: ['Effect.Burst.Damage'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    // Two activations queued on the same tick. Only the first should land
+    // because the second sees the in-flight cooldown tag from the first.
+    facade.activateAbility(caster.id, 'Ability.Burst', { entityId: enemy.id });
+    facade.activateAbility(caster.id, 'Ability.Burst', { entityId: enemy.id });
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(90);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Burst')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('rejects activation when cost cannot be afforded', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.SpendMana60',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-60) }],
+        }),
+        defineEffect({
+          id: 'Effect.Heavy.Cooldown',
+          type: 'Duration',
+          durationTicks: 30,
+          tagsGranted: ['Cooldown.Ability.Heavy'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Heavy',
+          costEffectId: 'Effect.SpendMana60',
+          cooldownEffectId: 'Effect.Heavy.Cooldown',
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    // Default Mana is 50 — cannot afford 60.
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(50);
+
+    facade.activateAbility(caster.id, 'Ability.Heavy');
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(50);
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.Heavy')).toBe(false);
+
+    world.dispose();
+  });
+
+  it('rejects a same-tick second activation when its cost would overdraw the caster', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.SpendMana30',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-30) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.SpendMana',
+          costEffectId: 'Effect.SpendMana30',
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    // Default Mana 50: one cast (30) is fine, two casts (60) is not.
+
+    facade.activateAbility(caster.id, 'Ability.SpendMana');
+    facade.activateAbility(caster.id, 'Ability.SpendMana');
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(20);
+
+    world.dispose();
+  });
+});
+
+describe('ability activation — hooks', () => {
+  it('invokes registered hooks after the application pass with the resolved targets', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.AutoAttack.Cooldown',
+          type: 'Duration',
+          durationTicks: 30,
+          tagsGranted: ['Cooldown.Ability.AutoAttack'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.AutoAttack',
+          cooldownEffectId: 'Effect.AutoAttack.Cooldown',
+          activationBlockedTags: ['Cooldown.Ability.AutoAttack'],
+          target: { kind: 'Entity', origin: { kind: 'Caller' } },
+          hookId: 'Hook.SpawnProjectile',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    const calls: Array<{
+      abilityId: string;
+      casterEntityId: number;
+      targets: readonly number[];
+      tick: number;
+      casterHasCooldown: boolean;
+    }> = [];
+    facade.registerHook('Hook.SpawnProjectile', ctx => {
+      calls.push({
+        abilityId: ctx.abilityId,
+        casterEntityId: ctx.casterEntityId,
+        targets: [...ctx.resolvedTargets],
+        tick: ctx.tick,
+        // Inside the hook, the cooldown effect must have already been
+        // applied — system order guarantees this.
+        casterHasCooldown: facade.hasTag(ctx.casterEntityId, 'Cooldown.Ability.AutoAttack'),
+      });
+    });
+
+    facade.activateAbility(caster.id, 'Ability.AutoAttack', { entityId: enemy.id });
+    world.processAllTicks(2);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].abilityId).toBe('Ability.AutoAttack');
+    expect(calls[0].casterEntityId).toBe(caster.id);
+    expect(calls[0].targets).toEqual([enemy.id]);
+    expect(calls[0].tick).toBe(2);
+    expect(calls[0].casterHasCooldown).toBe(true);
+
+    world.dispose();
+  });
+
+  it('does not invoke any hook when CanActivate rejects the request', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.AutoAttack.Cooldown',
+          type: 'Duration',
+          durationTicks: 30,
+          tagsGranted: ['Cooldown.Ability.AutoAttack'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.AutoAttack',
+          cooldownEffectId: 'Effect.AutoAttack.Cooldown',
+          activationBlockedTags: ['State.Stun'],
+          target: { kind: 'Self' },
+          hookId: 'Hook.SpawnProjectile',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+    facade.addTag(caster.id, 'State.Stun');
+
+    let invoked = 0;
+    facade.registerHook('Hook.SpawnProjectile', () => {
+      invoked += 1;
+    });
+
+    facade.activateAbility(caster.id, 'Ability.AutoAttack');
+    world.processAllTicks(2);
+
+    expect(invoked).toBe(0);
+
+    world.dispose();
+  });
+
+  it('throws when an ability references a hookId that was never registered', () => {
+    const { world, facade } = createTestWorld({
+      effects: [],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Ghost',
+          target: { kind: 'Self' },
+          hookId: 'Hook.DoesNotExist',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    facade.activateAbility(caster.id, 'Ability.Ghost');
+    expect(() => world.processAllTicks(2)).toThrow(
+      "AbilityHooksRegistry does not contain 'Hook.DoesNotExist'"
+    );
+
+    world.dispose();
+  });
+});
+
+describe('ability activation — request lifecycle', () => {
+  it('returns false from activateAbility when caster or ability is unknown', () => {
+    const { world, facade } = createTestWorld({
+      effects: [],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Ghost',
+          target: { kind: 'Self' },
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+
+    expect(facade.activateAbility(999, 'Ability.Ghost')).toBe(false);
+    expect(facade.activateAbility(caster.id, 'Ability.DoesNotExist')).toBe(false);
+    expect(facade.activateAbility(caster.id, 'Ability.Ghost')).toBe(true);
+
+    world.dispose();
+  });
+
+  it('defers activation requests enqueued INSIDE the tick to the next tick', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Reentrant.Cooldown',
+          type: 'Duration',
+          durationTicks: 5,
+          tagsGranted: ['Cooldown.Ability.Reentrant'],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Reentrant',
+          cooldownEffectId: 'Effect.Reentrant.Cooldown',
+          activationBlockedTags: ['Cooldown.Ability.Reentrant'],
+          target: { kind: 'Self' },
+          hookId: 'Hook.Reentrant',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    // The hook fires inside tick 2 and enqueues a new activation request
+    // with enqueueTick === 2. The activation system must defer it to tick 3
+    // — otherwise we'd risk an infinite loop where the hook drives the same
+    // tick repeatedly.
+    let hookInvocations = 0;
+    facade.registerHook('Hook.Reentrant', ctx => {
+      hookInvocations += 1;
+      if (hookInvocations === 1) {
+        facade.activateAbility(ctx.casterEntityId, 'Ability.Reentrant');
+      }
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Reentrant');
+
+    world.processAllTicks(2);
+    expect(hookInvocations).toBe(1);
+
+    // Tick 3 drains the reentrant request. But the cooldown tag from the
+    // FIRST activation is still on the caster (durationTicks=5), so this
+    // request is rejected: hook is not invoked again.
+    world.processAllTicks(3);
+    expect(hookInvocations).toBe(1);
+
+    world.dispose();
+  });
+
+  it('skips a request whose caster has despawned between enqueue and drain', () => {
+    const { world, facade } = createTestWorld({
+      effects: [
+        defineEffect({
+          id: 'Effect.Boom',
+          type: 'Instant',
+          modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-10) }],
+        }),
+      ],
+      abilities: [
+        defineAbility({
+          id: 'Ability.Boom',
+          target: { kind: 'Self' },
+          targetEffectIds: ['Effect.Boom'],
+          hookId: 'Hook.Boom',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    let invoked = 0;
+    facade.registerHook('Hook.Boom', () => {
+      invoked += 1;
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Boom');
+    world.entityManager.removeEntity(caster);
+
+    expect(() => world.processAllTicks(2)).not.toThrow();
+    expect(invoked).toBe(0);
+
+    world.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test world helper
+// ---------------------------------------------------------------------------
+
+interface TestWorldOpts {
+  effects: readonly ReturnType<typeof defineEffect>[];
+  abilities: readonly ReturnType<typeof defineAbility>[];
+}
+
+interface TestWorld {
+  world: GameWorld;
+  facade: AbilitySystemFacade;
+  registries: AbilitySystemRegistries;
+  runtime: AbilitySystemRuntime;
+}
+
+function createTestWorld(opts: TestWorldOpts): TestWorld {
+  const registries = createAbilitySystemRegistries();
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Health',
+      default: FP.FromInt(100),
+      min: FP.FromInt(0),
+      max: FP.FromInt(100),
+      clamp: 'both',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Mana',
+      default: FP.FromInt(50),
+      min: FP.FromInt(0),
+      max: FP.FromInt(50),
+      clamp: 'both',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Armor',
+      default: FP.FromInt(50),
+      min: FP.FromInt(0),
+      max: FP.FromInt(1000),
+      clamp: 'min',
+    })
+  );
+  registries.attributes.register(
+    defineAttribute({
+      id: 'IncomingDamageMultiplier',
+      default: FP.FromInt(1),
+      min: FP.FromInt(0),
+      max: FP.FromInt(10),
+      clamp: 'both',
+    })
+  );
+  for (const effect of opts.effects) {
+    registries.effects.register(effect);
+  }
+  for (const ability of opts.abilities) {
+    registries.abilities.register(ability);
+  }
+
+  const runtime = createAbilitySystemRuntime();
+  const world = new GameWorld({
+    componentTypes: [
+      AbilitiesComponentType.Attributes,
+      AbilitiesComponentType.ActiveEffects,
+      AbilitiesComponentType.GameplayTags,
+    ],
+  });
+  // System order matches the design doc Stage 5:
+  //  AbilityActivation -> EffectApplication -> AbilityHookExecutor ->
+  //  EffectTick -> AttributeAggregation.
+  // Activation enqueues effects on pendingAdd; EffectApplication drains
+  // them; the hook fires after application sees the new state; tick
+  // counts down lifetimes; aggregation resolves `current`.
+  world.registerSystems(
+    [
+      new AbilityActivationSystem(registries, runtime),
+      new EffectApplicationSystem(registries, runtime),
+      new AbilityHookExecutorSystem(registries, runtime),
+      new EffectTickSystem(registries),
+      new AttributeAggregationSystem(registries),
+    ],
+    []
+  );
+  const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
+  return { world, facade, registries, runtime };
+}
+
+function addEntity(world: GameWorld): Entity {
+  const entity = new Entity();
+  world.entityManager.addEntity(entity);
+  return entity;
+}
+


### PR DESCRIPTION
Implements Stage 5 of `phalanx-abilities-plan.md`: ability activation pipeline with CanActivate gating, cost/cooldown application, and hook execution.

## What's included

### New systems
- **`AbilityActivationSystem`** — drains `runtime.activationRequests`, runs CanActivate checks (blocked tags → required tags → cost → cooldown), and on approval enqueues cost + cooldown + self-effects via `pendingAdd`, resolves targets and enqueues target effects, emits `AbilityActivatedEvent`.
- **`AbilityHookExecutorSystem`** — invokes registered `AbilityHook`s from `AbilityHooksRegistry` between self-effect application and target-effect enqueue. Throws loudly on unregistered `hookId`.

### Runtime extensions
- `activationRequests` queue, `currentTick` cursor, `resolvedActivationsThisTick` buffer.

### New event
- `AbilityActivatedEvent` with `abilityId`, `casterEntityId`, `resolvedTargets`, `providedTarget?`, `tick`.

### Facade additions
- `activateAbility(casterEntityId, abilityId, providedTarget?)`
- `registerHook(hookId, hook)`

## Determinism rules
- All mutations go through `pendingAdd` (no direct component writes).
- Same-tick chained activations tracked via in-flight tag/cost maps cleared per tick.
- Reentrant hook activations are deferred to next tick (`enqueueTick === currentTick` check).
- Hook executor snapshots its buffer via `splice` before iterating to avoid stale state on throw.
- Throws on Radius/Point targets (deferred to Stage 6) and on non-Instant/non-Add cost modifiers.

## Tests
16 new tests in `phalanx-abilities/tests/abilities.test.ts` across 4 describe blocks:
- **happy paths** — cost+cooldown+self application, `AbilityActivated` event, target effects on Entity targets, Self targeting.
- **CanActivate gating** — `activationBlockedTags`, `tagsRequired`, cooldown blocking + post-expiry success, same-tick chained activation block, cost overdraw.
- **hooks** — invocation with cooldown-tag-already-set assertion, no-invocation-on-rejected, throws on unregistered `hookId`.
- **request lifecycle** — false return on unknown caster/ability, reentrant hook deferred to next tick, despawned-caster skip.

All **53 tests pass** (16 new + 37 baseline).

## Scope notes
- Target resolution covers `Self` and `Entity` origins (`Caster`, `Caller`, `TargetEntity`). `Radius` and `Point` origins throw — those land in Stage 6.
- No changes to existing systems; pure additive.