### PR TITLE
feat(abilities): stage 6 — Targeting: Radius + applyEffectAoE

### DIFF
--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -172,11 +172,14 @@ export class AbilitySystemFacade {
    * launcher should not damage themselves with their own splash, even
    * when the rocket has no "source" in the gameplay sense.
    *
-   * Returns the resolved target list (the same array {@link TargetResolver}
-   * produced) so user code can drive secondary effects — cues, damage
-   * numbers, screen shakes. The list is sorted by entity id ASC; user
-   * code that needs presentation order should re-sort by distance or
-   * other criteria.
+   * Returns the list of entity ids that actually received the effect
+   * (i.e. had `pendingAdd` enqueued). The list is sorted by entity id ASC.
+   * It is a subset of what {@link TargetResolver} produced: any id that
+   * the resolver returned but that no longer exists in the entity
+   * manager at enqueue time is omitted. User code can rely on this list
+   * to drive secondary effects — cues, damage numbers, screen shakes —
+   * without re-validating entities itself. Re-sort by distance if you
+   * need presentation order.
    *
    * Throws if no spatial query is registered. Self / Entity / Point
    * abilities do not need one, but this method always does — it is the
@@ -210,20 +213,23 @@ export class AbilitySystemFacade {
         includeSelf: opts.includeSelf,
       },
     });
+    // Only return ids that successfully enqueued the effect. The resolver
+    // already drops stale ids, but a removal can still happen between
+    // resolve and enqueue inside a single tick (e.g. an earlier hook in
+    // the same activation despawned the target). Returning the enqueued
+    // subset gives callers a precise "who actually got hit" list and
+    // matches what observers will see via component pendingAdd queues.
+    const applied: number[] = [];
     for (let i = 0; i < targets.length; i++) {
       const entity = this.entityManager.getEntity(targets[i]);
       if (!entity) {
-        // The resolver already filtered out unknown entities for tag
-        // checks, but a removal between resolve and enqueue is still
-        // possible inside a single tick (e.g. an earlier hook in the
-        // same activation despawned the target). Skip silently — every
-        // peer makes the same observation.
         continue;
       }
       const activeEffects = this.getOrCreateActiveEffects(entity);
       activeEffects.pendingAdd.push({ defId: effectId, sourceEntityId });
+      applied.push(targets[i]);
     }
-    return targets;
+    return applied;
   }
 
   /**

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -9,7 +9,9 @@ import {
 } from '../components';
 import type { AbilitySystemRegistries } from '../registry';
 import type { AbilitySystemRuntime } from '../runtime';
-import type { AbilityHook, ProvidedTarget } from '../types';
+import type { ISpatialQuery } from '../spatial';
+import { TargetResolver } from '../targeting';
+import type { AbilityHook, ProvidedTarget, TargetFilter } from '../types';
 
 export interface AttributeValue {
   base: FixedPoint;
@@ -149,6 +151,79 @@ export class AbilitySystemFacade {
 
     const activeEffects = this.getOrCreateActiveEffects(target);
     activeEffects.pendingAdd.push({ defId: effectId, sourceEntityId });
+  }
+
+  /**
+   * Short-circuit AoE: resolve every entity inside a disc and enqueue
+   * `effectId` onto each. Designed for the projectile-impact path used by
+   * rockets and grenades — the projectile entity lives in user code, and
+   * when it impacts the user calls `applyEffectAoE(point, ...)` directly,
+   * bypassing the ability layer.
+   *
+   * The resolve is deterministic: every peer using the same
+   * {@link ISpatialQuery} implementation and the same world state
+   * produces the same sorted, deduplicated, capped target list. See
+   * {@link TargetResolver} for the determinism rules.
+   *
+   * `selfId` is the entity that "owns" the AoE for `includeSelf`
+   * filtering. Defaults to `sourceEntityId`. Pass an explicit value
+   * when the source is `NO_SOURCE_ENTITY_ID` (world hazards) and you
+   * still want to exclude a specific entity — e.g. the rocket's
+   * launcher should not damage themselves with their own splash, even
+   * when the rocket has no "source" in the gameplay sense.
+   *
+   * Returns the resolved target list (the same array {@link TargetResolver}
+   * produced) so user code can drive secondary effects — cues, damage
+   * numbers, screen shakes. The list is sorted by entity id ASC; user
+   * code that needs presentation order should re-sort by distance or
+   * other criteria.
+   *
+   * Throws if no spatial query is registered. Self / Entity / Point
+   * abilities do not need one, but this method always does — it is the
+   * Radius shape by construction.
+   */
+  public applyEffectAoE(
+    origin: { x: FixedPoint; z: FixedPoint },
+    effectId: string,
+    sourceEntityId: number = NO_SOURCE_ENTITY_ID,
+    opts: {
+      radius: FixedPoint;
+      maxTargets?: number;
+      filter?: TargetFilter;
+      includeSelf?: boolean;
+      selfId?: number;
+    }
+  ): number[] {
+    if (!this.registries.effects.has(effectId)) {
+      throw new Error(`EffectRegistry does not contain '${effectId}'`);
+    }
+    const resolver = this.getTargetResolver();
+    const selfId = opts.selfId !== undefined ? opts.selfId : sourceEntityId;
+    const targets = resolver.resolve({
+      casterEntityId: selfId,
+      spec: {
+        kind: 'Radius',
+        origin: { kind: 'Point', x: origin.x, z: origin.z },
+        radius: opts.radius,
+        maxTargets: opts.maxTargets,
+        filter: opts.filter,
+        includeSelf: opts.includeSelf,
+      },
+    });
+    for (let i = 0; i < targets.length; i++) {
+      const entity = this.entityManager.getEntity(targets[i]);
+      if (!entity) {
+        // The resolver already filtered out unknown entities for tag
+        // checks, but a removal between resolve and enqueue is still
+        // possible inside a single tick (e.g. an earlier hook in the
+        // same activation despawned the target). Skip silently — every
+        // peer makes the same observation.
+        continue;
+      }
+      const activeEffects = this.getOrCreateActiveEffects(entity);
+      activeEffects.pendingAdd.push({ defId: effectId, sourceEntityId });
+    }
+    return targets;
   }
 
   /**
@@ -303,6 +378,22 @@ export class AbilitySystemFacade {
     this.registries.hooks.register(hookId, hook);
   }
 
+  /**
+   * Install the {@link ISpatialQuery} adapter that the resolver uses for
+   * `TargetSpec.kind === 'Radius'` and {@link applyEffectAoE}. The
+   * adapter is a thin wrapper over the user's spatial index (typically
+   * `SpatialHashGrid` in `phalanx-physics`); the package itself stays
+   * physics-free.
+   *
+   * Registration is a one-shot world-bootstrap step. Re-registering the
+   * same query replaces the previous one — useful for tests that swap
+   * the implementation. Callers wanting to detect a missing setup can
+   * read {@link AbilitySystemRegistries.spatialQuery} directly.
+   */
+  public registerSpatialQuery(query: ISpatialQuery): void {
+    this.registries.spatialQuery = query;
+  }
+
   // -----------------------------------------------------------------------
   // Tags
   // -----------------------------------------------------------------------
@@ -380,6 +471,20 @@ export class AbilitySystemFacade {
    */
   public get runtimeInternal(): AbilitySystemRuntime {
     return this.runtime;
+  }
+
+  /**
+   * Lazy singleton resolver. Stateless apart from its captured
+   * `entityManager` + `registries` pair; constructed on first use so
+   * tests that never touch AoE pay no allocation cost.
+   */
+  private targetResolver: TargetResolver | undefined;
+
+  private getTargetResolver(): TargetResolver {
+    if (!this.targetResolver) {
+      this.targetResolver = new TargetResolver(this.entityManager, this.registries);
+    }
+    return this.targetResolver;
   }
 
   private requireEntity(entityId: number): Entity {

--- a/phalanx-abilities/src/api/AbilitySystemFacade.ts
+++ b/phalanx-abilities/src/api/AbilitySystemFacade.ts
@@ -202,7 +202,7 @@ export class AbilitySystemFacade {
     }
     const resolver = this.getTargetResolver();
     const selfId = opts.selfId !== undefined ? opts.selfId : sourceEntityId;
-    const targets = resolver.resolve({
+    const resolution = resolver.resolve({
       casterEntityId: selfId,
       spec: {
         kind: 'Radius',
@@ -213,6 +213,14 @@ export class AbilitySystemFacade {
         includeSelf: opts.includeSelf,
       },
     });
+    // The synthetic spec above uses a literal Point origin (never
+    // Caller), so the resolver cannot return `dropped: true` here.
+    // Assert defensively in case the spec construction ever changes.
+    /* istanbul ignore if */
+    if (resolution.dropped) {
+      return [];
+    }
+    const targets = resolution.targets;
     // Only return ids that successfully enqueued the effect. The resolver
     // already drops stale ids, but a removal can still happen between
     // resolve and enqueue inside a single tick (e.g. an earlier hook in

--- a/phalanx-abilities/src/index.ts
+++ b/phalanx-abilities/src/index.ts
@@ -4,5 +4,6 @@ export * from './events';
 export * from './registry';
 export * from './runtime';
 export * from './systems';
+export * from './targeting';
 export type * from './spatial';
 export type * from './types';

--- a/phalanx-abilities/src/registry/AbilitySystemRegistries.ts
+++ b/phalanx-abilities/src/registry/AbilitySystemRegistries.ts
@@ -1,13 +1,38 @@
+import type { ISpatialQuery } from '../spatial';
 import { AbilityHooksRegistry } from './AbilityHooksRegistry';
 import { AbilityRegistry } from './AbilityRegistry';
 import { AttributeRegistry } from './AttributeRegistry';
 import { EffectRegistry } from './EffectRegistry';
 
+/**
+ * Bundle of per-world ability-system registries.
+ *
+ * `attributes`, `effects`, `abilities`, and `hooks` hold *definitions* —
+ * immutable across the lifetime of the world once the world has been built.
+ *
+ * `spatialQuery` is the one optional slot, populated via
+ * {@link AbilitySystemFacade.registerSpatialQuery}. It is required only for
+ * abilities and `applyEffectAoE` calls that resolve `TargetSpec.kind ===
+ * 'Radius'` targets — i.e. abilities that need to ask the world "which
+ * entities are inside this disc". Self / Entity / Point targets do not need
+ * a spatial query and work without one.
+ *
+ * Implementations are user-supplied (typically a thin adapter over
+ * `SpatialHashGrid` in `phalanx-physics`) so the package stays free of a
+ * physics peer dependency.
+ */
 export interface AbilitySystemRegistries {
   attributes: AttributeRegistry;
   effects: EffectRegistry;
   abilities: AbilityRegistry;
   hooks: AbilityHooksRegistry;
+  /**
+   * Optional adapter that translates a (center, radius) query into a list of
+   * entity ids. Stage 6's Radius targeting and `applyEffectAoE` require it;
+   * abilities that only use Self/Entity/Point targets do not. Left
+   * `undefined` until `AbilitySystemFacade.registerSpatialQuery` is called.
+   */
+  spatialQuery?: ISpatialQuery;
 }
 
 export function createAbilitySystemRegistries(): AbilitySystemRegistries {

--- a/phalanx-abilities/src/spatial/ISpatialQuery.ts
+++ b/phalanx-abilities/src/spatial/ISpatialQuery.ts
@@ -1,5 +1,40 @@
 import type { FixedPoint } from 'phalanx-math';
 
+/**
+ * Adapter that lets {@link TargetResolver} ask the surrounding world
+ * "which entities are inside this disc?".
+ *
+ * The interface is intentionally tiny so `phalanx-abilities` stays free of
+ * a hard `phalanx-physics` peer dependency. Implementations are expected
+ * to be a thin wrapper over the project's existing spatial index (a hash
+ * grid, a quadtree, or even an O(n) linear scan for prototype scenes).
+ *
+ * Contract for `queryRadius`:
+ *   - Returns every entity whose position satisfies
+ *     `dx*dx + dz*dz <= radius*radius`, with `dx = entity.x - center.x`
+ *     and `dz = entity.z - center.z`, evaluated in `FixedPoint`.
+ *   - Implementations MAY include the center entity if the center happens
+ *     to coincide with one. `TargetResolver` handles self-inclusion via
+ *     `TargetSpec.includeSelf` after the query, so implementations should
+ *     err on the side of being inclusive.
+ *   - Result order is NOT required to be stable. `TargetResolver` sorts
+ *     by entity id ASC before applying `maxTargets` / `filter`, so any
+ *     order is safe.
+ *   - The method MUST be deterministic for a given world state — every
+ *     lockstep peer at the same tick must produce the same multiset of
+ *     entity ids.
+ */
 export interface ISpatialQuery {
   queryRadius(x: FixedPoint, z: FixedPoint, radius: FixedPoint): number[];
+
+  /**
+   * OPTIONAL: return the position of an entity. Required only for
+   * `TargetSpec.kind === 'Radius'` with origin `Caster` or `TargetEntity`
+   * — the resolver needs to know where the disc is centered. Abilities
+   * that exclusively use `Point` or `Caller` (with `x`/`z` supplied)
+   * origins do not need this method.
+   *
+   * Returns `undefined` for unknown / removed entities.
+   */
+  getEntityPosition?(entityId: number): { x: FixedPoint; z: FixedPoint } | undefined;
 }

--- a/phalanx-abilities/src/systems/AbilityActivationSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityActivationSystem.ts
@@ -15,7 +15,8 @@ import type {
   AbilitySystemRuntime,
   ResolvedAbilityActivationRecord,
 } from '../runtime';
-import type { AbilityDef, ProvidedTarget, TargetOrigin, TargetSpec } from '../types';
+import { TargetResolver } from '../targeting';
+import type { AbilityDef, ProvidedTarget } from '../types';
 
 /**
  * Drains pending {@link AbilityActivationRequest}s from the runtime, runs
@@ -55,10 +56,11 @@ import type { AbilityDef, ProvidedTarget, TargetOrigin, TargetSpec } from '../ty
  * After successful CanActivate the system:
  *  - Enqueues `costEffectId` (if any), `cooldownEffectId` (if any), and
  *    every `selfEffectIds` entry on the caster's `pendingAdd`.
- *  - Resolves `target` for the trivial shapes supported in Stage 5
- *    (`Self`, `Entity { Caster | Caller | TargetEntity }`). `Radius` and
- *    `Point` are deferred to Stage 6's `TargetResolutionSystem` and throw
- *    here.
+ *  - Resolves `target` via {@link TargetResolver}. Every `TargetSpec.kind`
+ *    (`Self`, `Entity`, `Point`, `Radius`) and every `TargetOrigin.kind`
+ *    including `Caller` is supported. Radius shapes additionally require
+ *    a registered `ISpatialQuery` (see
+ *    `AbilitySystemFacade.registerSpatialQuery`).
  *  - Enqueues every `targetEffectIds` entry on each resolved target's
  *    `pendingAdd`.
  *  - Emits an {@link AbilityActivatedEvent} on the world event bus.
@@ -81,6 +83,14 @@ export class AbilityActivationSystem extends GameSystem {
    * `debit` is stored as raw `FixedPoint` for cheap accumulation.
    */
   private readonly inFlightCostsByCaster = new Map<number, Map<string, bigint>>();
+
+  /**
+   * Lazily constructed once the entity manager has been attached (the
+   * GameSystem base class sets `this.entityManager` after construction).
+   * The resolver is stateless apart from the registries + entityManager
+   * pair it captures.
+   */
+  private targetResolver: TargetResolver | undefined;
 
   public constructor(
     private readonly registries: AbilitySystemRegistries,
@@ -470,72 +480,30 @@ export class AbilityActivationSystem extends GameSystem {
   // ---------------------------------------------------------------------------
 
   /**
-   * Minimal in-system target resolver covering only the shapes that make
-   * sense without spatial queries:
-   *  - `Self`            → `[casterId]`.
-   *  - `Entity { Caster }`     → `[casterId]`.
-   *  - `Entity { Caller }`     → `[providedTarget.entityId]` (required).
-   *  - `Entity { TargetEntity }` → `[origin.entityId]`.
-   *  - `Point` and `Radius` → throw. They require Stage 6's
-   *    `TargetResolutionSystem` for deterministic spatial resolve.
+   * Stage 6 — delegate to {@link TargetResolver}. The resolver handles every
+   * `TargetSpec.kind` (`Self`, `Entity`, `Point`, `Radius`) and every
+   * `TargetOrigin.kind` including `Caller`. For shapes that require a
+   * spatial query (`Radius`), the resolver throws with an actionable
+   * message if `AbilitySystemFacade.registerSpatialQuery` was never
+   * called.
    *
-   * Targets are returned in a freshly-allocated array because the resolved
-   * activations buffer holds it for the hook executor; sharing would couple
-   * lifetimes.
+   * Targets are returned in a freshly-allocated array because the
+   * resolved-activations buffer holds it for the hook executor; sharing
+   * would couple lifetimes.
    */
   private resolveTargets(
     caster: Entity,
     def: AbilityDef,
     providedTarget: ProvidedTarget | undefined
   ): number[] {
-    return resolveSimpleTargets(caster.id, def.target, providedTarget);
-  }
-}
-
-function resolveSimpleTargets(
-  casterId: number,
-  target: TargetSpec,
-  providedTarget: ProvidedTarget | undefined
-): number[] {
-  switch (target.kind) {
-    case 'Self':
-      return [casterId];
-    case 'Entity': {
-      const entityId = resolveEntityOrigin(casterId, target.origin, providedTarget);
-      if (entityId === undefined) {
-        return [];
-      }
-      return [entityId];
+    if (this.targetResolver === undefined) {
+      this.targetResolver = new TargetResolver(this.entityManager, this.registries);
     }
-    case 'Point':
-      throw new Error(
-        "TargetSpec.kind === 'Point' requires Stage 6's TargetResolutionSystem (not yet implemented)."
-      );
-    case 'Radius':
-      throw new Error(
-        "TargetSpec.kind === 'Radius' requires Stage 6's TargetResolutionSystem (not yet implemented)."
-      );
-  }
-}
-
-function resolveEntityOrigin(
-  casterId: number,
-  origin: TargetOrigin,
-  providedTarget: ProvidedTarget | undefined
-): number | undefined {
-  switch (origin.kind) {
-    case 'Caster':
-      return casterId;
-    case 'TargetEntity':
-      return origin.entityId;
-    case 'Caller':
-      // Caller-style: read from providedTarget. Missing entityId means the
-      // caller forgot to supply a target — silently drop the activation.
-      return providedTarget?.entityId;
-    case 'Point':
-      throw new Error(
-        "TargetOrigin.kind === 'Point' is only meaningful for TargetSpec.kind 'Radius'/'Point'."
-      );
+    return this.targetResolver.resolve({
+      casterEntityId: caster.id,
+      spec: def.target,
+      providedTarget,
+    });
   }
 }
 

--- a/phalanx-abilities/src/systems/AbilityActivationSystem.ts
+++ b/phalanx-abilities/src/systems/AbilityActivationSystem.ts
@@ -16,6 +16,7 @@ import type {
   ResolvedAbilityActivationRecord,
 } from '../runtime';
 import { TargetResolver } from '../targeting';
+import type { TargetResolutionResult } from '../targeting';
 import type { AbilityDef, ProvidedTarget } from '../types';
 
 /**
@@ -181,9 +182,17 @@ export class AbilityActivationSystem extends GameSystem {
       return;
     }
 
-    // 1) Resolve targets BEFORE enqueueing target effects so failures here
-    //    abort the activation cleanly (no half-application of cost/cooldown).
-    const resolvedTargets = this.resolveTargets(caster, abilityDef, request.providedTarget);
+    // 1) Resolve targets BEFORE enqueueing any effects. If the caller
+    //    forgot to supply required input (Caller-origin point/entity)
+    //    the resolver returns `dropped: true` and we abort here — no
+    //    cost, no cooldown, no event, no hook. Other failure modes
+    //    (missing spatial query, missing entity position) throw inside
+    //    `resolve` and propagate up via the drain loop's try/finally.
+    const resolution = this.resolveTargets(caster, abilityDef, request.providedTarget);
+    if (resolution.dropped) {
+      return;
+    }
+    const resolvedTargets = resolution.targets;
 
     // 2) Apply caster-side effects (cost, cooldown, selfEffectIds).
     this.enqueueCasterEffects(caster, abilityDef);
@@ -476,7 +485,7 @@ export class AbilityActivationSystem extends GameSystem {
   }
 
   // ---------------------------------------------------------------------------
-  // Target resolution (Stage 5 subset; Radius lands in Stage 6)
+  // Target resolution
   // ---------------------------------------------------------------------------
 
   /**
@@ -487,15 +496,17 @@ export class AbilityActivationSystem extends GameSystem {
    * message if `AbilitySystemFacade.registerSpatialQuery` was never
    * called.
    *
-   * Targets are returned in a freshly-allocated array because the
-   * resolved-activations buffer holds it for the hook executor; sharing
-   * would couple lifetimes.
+   * Returns the resolver's discriminated result so `processOne` can
+   * distinguish a legitimate empty target list ("AoE with nobody in it")
+   * from a silent drop ("Caller forgot to supply the target point").
+   * Drops abort the activation before any side effects — see
+   * {@link TargetResolutionResult} for the contract.
    */
   private resolveTargets(
     caster: Entity,
     def: AbilityDef,
     providedTarget: ProvidedTarget | undefined
-  ): number[] {
+  ): TargetResolutionResult {
     if (this.targetResolver === undefined) {
       this.targetResolver = new TargetResolver(this.entityManager, this.registries);
     }

--- a/phalanx-abilities/src/targeting/TargetResolver.ts
+++ b/phalanx-abilities/src/targeting/TargetResolver.ts
@@ -20,11 +20,31 @@ export interface TargetResolutionInput {
    * Caller-supplied target for `TargetOrigin.kind === 'Caller'`. May supply
    * `entityId` (for `Entity` shapes) or `x`/`z` (for `Point`/`Radius`
    * origins). When the origin kind is `Caller` and the required field is
-   * missing the activation is silently dropped — see
-   * {@link resolveTargets} return value.
+   * missing, {@link TargetResolver.resolve} returns a `{ dropped: true }`
+   * result so the caller can abort the activation cleanly.
    */
   providedTarget?: ProvidedTarget;
 }
+
+/**
+ * Result of {@link TargetResolver.resolve}. The discriminated `dropped`
+ * flag distinguishes between:
+ *   - `{ dropped: false, targets: [...] }`: resolution succeeded. `targets`
+ *     is the deterministic, possibly-empty list of affected entity ids.
+ *     An empty list is a legitimate outcome (e.g. an AoE that contained
+ *     no entities, or a `Point` target shape) and the activation should
+ *     proceed: caster-side effects, event emission, hook scheduling.
+ *   - `{ dropped: true }`: the caller forgot to supply required input
+ *     (e.g. `TargetOrigin.kind === 'Caller'` on a Radius without a
+ *     point). The activation must NOT enqueue cost / cooldown / self
+ *     effects, must NOT emit `AbilityActivated`, and must NOT schedule
+ *     hooks. This matches the documented contract that "the verdict is
+ *     observed via side effects, not via `activateAbility`'s return
+ *     value".
+ */
+export type TargetResolutionResult =
+  | { dropped: false; targets: number[] }
+  | { dropped: true };
 
 /**
  * Pure resolver for {@link TargetSpec}. Owns the entire mapping from a
@@ -61,19 +81,36 @@ export class TargetResolver {
     private readonly registries: AbilitySystemRegistries
   ) {}
 
-  public resolve(input: TargetResolutionInput): number[] {
+  /**
+   * Sentinel value for the "drop activation" outcome. Reused across calls
+   * so the system path can compare by reference.
+   */
+  private static readonly DROPPED: TargetResolutionResult = { dropped: true };
+
+  public resolve(input: TargetResolutionInput): TargetResolutionResult {
     const { spec } = input;
     switch (spec.kind) {
       case 'Self':
-        return [input.casterEntityId];
+        return { dropped: false, targets: [input.casterEntityId] };
       case 'Entity': {
-        const entityId = this.resolveEntityOrigin(input.casterEntityId, spec.origin, input.providedTarget);
-        if (entityId === undefined) {
-          return [];
+        const resolved = this.resolveEntityOrigin(
+          input.casterEntityId,
+          spec.origin,
+          input.providedTarget
+        );
+        if (resolved.dropped) {
+          return TargetResolver.DROPPED;
         }
-        return [entityId];
+        if (resolved.entityId === undefined) {
+          // Legitimate "no target" — e.g. TargetEntity origin pointing
+          // at an id that's no longer present. We continue the
+          // activation: the caster pays the cost, the hook fires with
+          // an empty target list.
+          return { dropped: false, targets: [] };
+        }
+        return { dropped: false, targets: [resolved.entityId] };
       }
-      case 'Point':
+      case 'Point': {
         // A Point target intentionally resolves to zero entities. The point
         // itself is consumed by ability hooks via providedTarget (or by
         // user code reading AbilityActivationContext). `targetEffectIds`
@@ -81,7 +118,19 @@ export class TargetResolver {
         // expected: damage/heal is applied by the rocket/projectile hook
         // on impact via `applyEffectAoE`, not by the ability's
         // target-effects pipeline.
-        return [];
+        //
+        // However, when the origin is `Caller` the caller MUST supply a
+        // point — otherwise the hook has no impact location and the
+        // activation should drop. Other origins (Point, Caster,
+        // TargetEntity) carry the point inside the spec itself.
+        if (spec.origin.kind === 'Caller') {
+          const provided = input.providedTarget;
+          if (!provided || provided.x === undefined || provided.z === undefined) {
+            return TargetResolver.DROPPED;
+          }
+        }
+        return { dropped: false, targets: [] };
+      }
       case 'Radius':
         return this.resolveRadius(input);
     }
@@ -91,12 +140,13 @@ export class TargetResolver {
   // Radius (the heavy path)
   // ---------------------------------------------------------------------------
 
-  private resolveRadius(input: TargetResolutionInput): number[] {
+  private resolveRadius(input: TargetResolutionInput): TargetResolutionResult {
     const spec = input.spec as Extract<TargetSpec, { kind: 'Radius' }>;
-    const center = this.resolveRadiusOrigin(input, spec.origin);
-    if (!center) {
-      return [];
+    const originResult = this.resolveRadiusOrigin(input, spec.origin);
+    if (originResult.dropped) {
+      return TargetResolver.DROPPED;
     }
+    const center = originResult.center;
 
     const spatial = this.registries.spatialQuery;
     if (!spatial) {
@@ -142,7 +192,7 @@ export class TargetResolver {
     // push one entity before breaking on `1 >= 0`.
     const limit = spec.maxTargets;
     if (limit !== undefined && limit <= 0) {
-      return [];
+      return { dropped: false, targets: [] };
     }
 
     const out: number[] = [];
@@ -166,31 +216,38 @@ export class TargetResolver {
         break;
       }
     }
-    return out;
+    return { dropped: false, targets: out };
   }
 
   // ---------------------------------------------------------------------------
   // Origin resolution
   // ---------------------------------------------------------------------------
 
-  /** Resolve an `Entity`-shape origin to a single target entity id. */
+  /**
+   * Resolve an `Entity`-shape origin to a single target entity id, or a
+   * drop signal if the caller forgot to supply required input.
+   *
+   * `entityId: undefined` (with `dropped: false`) is a legitimate "target
+   * resolved but to nothing" outcome — currently unreachable here, but
+   * preserved so the call site can distinguish the empty case from the
+   * drop case in future origin kinds.
+   */
   private resolveEntityOrigin(
     casterId: number,
     origin: TargetOrigin,
     providedTarget: ProvidedTarget | undefined
-  ): number | undefined {
+  ): { dropped: false; entityId: number | undefined } | { dropped: true } {
     switch (origin.kind) {
       case 'Caster':
-        return casterId;
+        return { dropped: false, entityId: casterId };
       case 'TargetEntity':
-        return origin.entityId;
+        return { dropped: false, entityId: origin.entityId };
       case 'Caller':
-        // Missing entityId means the caller forgot to supply a target —
-        // silently drop the activation. The facade-level
-        // `activateAbility` already returned `true` for "request
-        // accepted"; this matches the documented "verdict observed via
-        // side effects, not return value" contract.
-        return providedTarget?.entityId;
+        if (providedTarget?.entityId === undefined) {
+          // Caller forgot to supply a target entity — drop the activation.
+          return { dropped: true };
+        }
+        return { dropped: false, entityId: providedTarget.entityId };
       case 'Point':
         // `Point` origin is meaningful only for `Radius`/`Point` target
         // shapes; using it as an `Entity` origin is a programming
@@ -202,15 +259,19 @@ export class TargetResolver {
   }
 
   /**
-   * Resolve a `Radius`-shape origin to a center point. Returns `undefined`
-   * for the silent-drop case (Caller origin with no point provided) —
-   * the resolver hands an empty target list back to the caller without
-   * reaching the spatial query at all.
+   * Resolve a `Radius`-shape origin to a center point, or signal a drop.
+   *
+   * The `dropped: true` outcome corresponds to a Caller origin without a
+   * point provided. All other failure modes (missing spatial query, no
+   * position for an entity) throw rather than drop — they are
+   * misconfigurations, not legitimate runtime states.
    */
   private resolveRadiusOrigin(
     input: TargetResolutionInput,
     origin: TargetOrigin
-  ): { x: FixedPoint; z: FixedPoint } | undefined {
+  ):
+    | { dropped: false; center: { x: FixedPoint; z: FixedPoint } }
+    | { dropped: true } {
     switch (origin.kind) {
       case 'Caster': {
         const pos = this.tryGetEntityPosition(input.casterEntityId);
@@ -222,7 +283,7 @@ export class TargetResolver {
               `position for this entity, or the ability must use TargetOrigin.kind === 'Point'.`
           );
         }
-        return pos;
+        return { dropped: false, center: pos };
       }
       case 'TargetEntity': {
         const pos = this.tryGetEntityPosition(origin.entityId);
@@ -234,17 +295,16 @@ export class TargetResolver {
               `position for this entity.`
           );
         }
-        return pos;
+        return { dropped: false, center: pos };
       }
       case 'Point':
-        return { x: origin.x, z: origin.z };
+        return { dropped: false, center: { x: origin.x, z: origin.z } };
       case 'Caller': {
         const providedTarget = input.providedTarget;
         if (!providedTarget || providedTarget.x === undefined || providedTarget.z === undefined) {
-          // Caller forgot to supply a point — silently drop.
-          return undefined;
+          return { dropped: true };
         }
-        return { x: providedTarget.x, z: providedTarget.z };
+        return { dropped: false, center: { x: providedTarget.x, z: providedTarget.z } };
       }
     }
   }

--- a/phalanx-abilities/src/targeting/TargetResolver.ts
+++ b/phalanx-abilities/src/targeting/TargetResolver.ts
@@ -1,0 +1,307 @@
+import type { EntityManager } from 'phalanx-ecs';
+import type { FixedPoint } from 'phalanx-math';
+import { AbilitiesComponentType, GameplayTagsComponent } from '../components';
+import type { AbilitySystemRegistries } from '../registry';
+import type { ProvidedTarget, TargetFilter, TargetOrigin, TargetSpec } from '../types';
+
+/**
+ * Input to {@link TargetResolver.resolve}. Keeps the resolver self-contained
+ * — every input it needs is on this record, not on a system field.
+ */
+export interface TargetResolutionInput {
+  /**
+   * The entity casting the ability. Used to resolve `TargetOrigin.kind ===
+   * 'Caster'`, to evaluate `includeSelf` on `Radius`, and as the `selfId`
+   * default for `applyEffectAoE` invocations that don't override it.
+   */
+  casterEntityId: number;
+  spec: TargetSpec;
+  /**
+   * Caller-supplied target for `TargetOrigin.kind === 'Caller'`. May supply
+   * `entityId` (for `Entity` shapes) or `x`/`z` (for `Point`/`Radius`
+   * origins). When the origin kind is `Caller` and the required field is
+   * missing the activation is silently dropped — see
+   * {@link resolveTargets} return value.
+   */
+  providedTarget?: ProvidedTarget;
+}
+
+/**
+ * Pure resolver for {@link TargetSpec}. Owns the entire mapping from a
+ * declarative spec + caller input to the deterministic ordered list of
+ * affected entity ids.
+ *
+ * Determinism rules enforced here:
+ *   1. The result is always sorted by `entityId` ASC. {@link ISpatialQuery}
+ *      implementations are free to return entities in any order — the
+ *      resolver normalises that.
+ *   2. {@link TargetSpec.maxTargets} (Radius only) trims the sorted list,
+ *      never the unsorted query result. Two peers running the same query
+ *      with different internal orderings still trim to the same first-N
+ *      entity ids.
+ *   3. Distance is never computed here. `dx*dx + dz*dz <= r*r` is the
+ *      contract of {@link ISpatialQuery.queryRadius}; the resolver trusts
+ *      it. Anything beyond that (cones, boxes, LOS) is v2.
+ *   4. The resolver is stateless — it never reads "the current tick" or
+ *      mutates registries — so two invocations with identical inputs are
+ *      byte-for-byte identical regardless of when they run.
+ *
+ * Used from two call sites:
+ *   - {@link AbilityActivationSystem} during ability activation, where the
+ *     spec comes from `AbilityDef.target` and the caller is the user that
+ *     invoked `activateAbility`.
+ *   - {@link AbilitySystemFacade.applyEffectAoE} for the short-circuit
+ *     "explode here, ignore the ability layer" path (rockets on impact,
+ *     environment hazards, etc.). That path always passes a synthetic
+ *     `Radius` spec — it never needs to resolve `Self`/`Entity`/`Point`.
+ */
+export class TargetResolver {
+  public constructor(
+    private readonly entityManager: EntityManager,
+    private readonly registries: AbilitySystemRegistries
+  ) {}
+
+  public resolve(input: TargetResolutionInput): number[] {
+    const { spec } = input;
+    switch (spec.kind) {
+      case 'Self':
+        return [input.casterEntityId];
+      case 'Entity': {
+        const entityId = this.resolveEntityOrigin(input.casterEntityId, spec.origin, input.providedTarget);
+        if (entityId === undefined) {
+          return [];
+        }
+        return [entityId];
+      }
+      case 'Point':
+        // A Point target intentionally resolves to zero entities. The point
+        // itself is consumed by ability hooks via providedTarget (or by
+        // user code reading AbilityActivationContext). `targetEffectIds`
+        // on a Point-targeted ability is therefore a no-op — that is
+        // expected: damage/heal is applied by the rocket/projectile hook
+        // on impact via `applyEffectAoE`, not by the ability's
+        // target-effects pipeline.
+        return [];
+      case 'Radius':
+        return this.resolveRadius(input);
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Radius (the heavy path)
+  // ---------------------------------------------------------------------------
+
+  private resolveRadius(input: TargetResolutionInput): number[] {
+    const spec = input.spec as Extract<TargetSpec, { kind: 'Radius' }>;
+    const center = this.resolveRadiusOrigin(input, spec.origin);
+    if (!center) {
+      return [];
+    }
+
+    const spatial = this.registries.spatialQuery;
+    if (!spatial) {
+      throw new Error(
+        "TargetSpec.kind === 'Radius' requires a spatial query. " +
+          'Call AbilitySystemFacade.registerSpatialQuery(...) at world bootstrap.'
+      );
+    }
+
+    const raw = spatial.queryRadius(center.x, center.z, spec.radius);
+
+    // Deduplicate, then sort by entityId ASC. We dedupe BEFORE sorting so
+    // misbehaving spatial implementations that return the same entity
+    // twice (e.g. multi-cell membership in a hash grid) cannot corrupt
+    // the deterministic ordering or burn a maxTargets slot per duplicate.
+    const seen = new Set<number>();
+    const buf: number[] = [];
+    for (const id of raw) {
+      if (seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      buf.push(id);
+    }
+    buf.sort((a, b) => a - b);
+
+    // Apply self filtering. `includeSelf` defaults to false so that an
+    // ability that says "deal damage to enemies in a radius" does not
+    // accidentally hit the caster when the caster sits inside its own
+    // query disc. Set to `true` for buffs / heals that the caster wants
+    // to benefit from.
+    const includeSelf = spec.includeSelf === true;
+    const casterId = input.casterEntityId;
+
+    // Apply tag filter. This is done AFTER the spatial query so the
+    // physics package never has to know about gameplay tags — its
+    // contract stays purely geometric.
+    const filter = spec.filter;
+
+    const out: number[] = [];
+    const limit = spec.maxTargets;
+    for (let i = 0; i < buf.length; i++) {
+      const id = buf[i];
+      if (!includeSelf && id === casterId) {
+        continue;
+      }
+      if (filter && !this.passesFilter(id, filter)) {
+        continue;
+      }
+      out.push(id);
+      if (limit !== undefined && out.length >= limit) {
+        break;
+      }
+    }
+    return out;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Origin resolution
+  // ---------------------------------------------------------------------------
+
+  /** Resolve an `Entity`-shape origin to a single target entity id. */
+  private resolveEntityOrigin(
+    casterId: number,
+    origin: TargetOrigin,
+    providedTarget: ProvidedTarget | undefined
+  ): number | undefined {
+    switch (origin.kind) {
+      case 'Caster':
+        return casterId;
+      case 'TargetEntity':
+        return origin.entityId;
+      case 'Caller':
+        // Missing entityId means the caller forgot to supply a target —
+        // silently drop the activation. The facade-level
+        // `activateAbility` already returned `true` for "request
+        // accepted"; this matches the documented "verdict observed via
+        // side effects, not return value" contract.
+        return providedTarget?.entityId;
+      case 'Point':
+        // `Point` origin is meaningful only for `Radius`/`Point` target
+        // shapes; using it as an `Entity` origin is a programming
+        // error, not a runtime miss.
+        throw new Error(
+          "TargetOrigin.kind === 'Point' is not valid for TargetSpec.kind === 'Entity'."
+        );
+    }
+  }
+
+  /**
+   * Resolve a `Radius`-shape origin to a center point. Returns `undefined`
+   * for the silent-drop case (Caller origin with no point provided) —
+   * the resolver hands an empty target list back to the caller without
+   * reaching the spatial query at all.
+   */
+  private resolveRadiusOrigin(
+    input: TargetResolutionInput,
+    origin: TargetOrigin
+  ): { x: FixedPoint; z: FixedPoint } | undefined {
+    switch (origin.kind) {
+      case 'Caster': {
+        const pos = this.tryGetCasterPosition(input.casterEntityId);
+        if (!pos) {
+          throw new Error(
+            `TargetSpec.kind === 'Radius' with origin 'Caster' requires the caster ` +
+              `(entity ${input.casterEntityId}) to have a position. Provide a position ` +
+              `via the spatial query implementation or use TargetOrigin.kind === 'Point'.`
+          );
+        }
+        return pos;
+      }
+      case 'TargetEntity': {
+        const pos = this.tryGetCasterPosition(origin.entityId);
+        if (!pos) {
+          throw new Error(
+            `TargetSpec.kind === 'Radius' with origin 'TargetEntity' requires the target ` +
+              `(entity ${origin.entityId}) to have a position resolvable by ISpatialQuery.`
+          );
+        }
+        return pos;
+      }
+      case 'Point':
+        return { x: origin.x, z: origin.z };
+      case 'Caller': {
+        const providedTarget = input.providedTarget;
+        if (!providedTarget || providedTarget.x === undefined || providedTarget.z === undefined) {
+          // Caller forgot to supply a point — silently drop.
+          return undefined;
+        }
+        return { x: providedTarget.x, z: providedTarget.z };
+      }
+    }
+  }
+
+  /**
+   * Best-effort lookup of an entity's position. `ISpatialQuery` does not
+   * expose a per-entity position read in MVP — the implementation may or
+   * may not have one. We therefore consult the optional
+   * `getEntityPosition` extension method (duck-typed) before giving up.
+   *
+   * Returning `undefined` here causes the resolver to throw an actionable
+   * error pointing the user at registerSpatialQuery, instead of silently
+   * dropping the activation.
+   */
+  private tryGetCasterPosition(
+    entityId: number
+  ): { x: FixedPoint; z: FixedPoint } | undefined {
+    const spatial = this.registries.spatialQuery;
+    if (!spatial) {
+      throw new Error(
+        "TargetSpec.kind === 'Radius' requires a spatial query. " +
+          'Call AbilitySystemFacade.registerSpatialQuery(...) at world bootstrap.'
+      );
+    }
+    if (typeof spatial.getEntityPosition === 'function') {
+      const pos = spatial.getEntityPosition(entityId);
+      return pos ?? undefined;
+    }
+    return undefined;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Filter
+  // ---------------------------------------------------------------------------
+
+  private passesFilter(entityId: number, filter: TargetFilter): boolean {
+    // No tag predicates → trivially passes. Avoid touching the entity.
+    if (
+      (!filter.tagsRequired || filter.tagsRequired.length === 0) &&
+      (!filter.tagsBlocked || filter.tagsBlocked.length === 0)
+    ) {
+      return true;
+    }
+    const entity = this.entityManager.getEntity(entityId);
+    if (!entity) {
+      // Spatial query returned a stale id (entity removed between the
+      // query and our consumption). Treat as not-passing — the entity
+      // can't satisfy any predicate that needs to read its tags.
+      return false;
+    }
+    const tagsComponent = entity.getComponent<GameplayTagsComponent>(
+      AbilitiesComponentType.GameplayTags
+    );
+    if (filter.tagsRequired && filter.tagsRequired.length > 0) {
+      if (!tagsComponent) {
+        // No tag component at all → cannot satisfy a `required` filter.
+        return false;
+      }
+      for (const tag of filter.tagsRequired) {
+        if (!tagsComponent.tags.has(tag)) {
+          return false;
+        }
+      }
+    }
+    if (filter.tagsBlocked && filter.tagsBlocked.length > 0) {
+      if (tagsComponent) {
+        for (const tag of filter.tagsBlocked) {
+          if (tagsComponent.tags.has(tag)) {
+            return false;
+          }
+        }
+      }
+      // No tag component → trivially passes the blocked check.
+    }
+    return true;
+  }
+}
+

--- a/phalanx-abilities/src/targeting/TargetResolver.ts
+++ b/phalanx-abilities/src/targeting/TargetResolver.ts
@@ -136,11 +136,26 @@ export class TargetResolver {
     // contract stays purely geometric.
     const filter = spec.filter;
 
-    const out: number[] = [];
+    // `maxTargets === 0` and negative values are treated as "resolve no
+    // targets at all". Guarding up front keeps the main loop simple and
+    // avoids the `>= limit` pre-decrement edge case where we'd otherwise
+    // push one entity before breaking on `1 >= 0`.
     const limit = spec.maxTargets;
+    if (limit !== undefined && limit <= 0) {
+      return [];
+    }
+
+    const out: number[] = [];
     for (let i = 0; i < buf.length; i++) {
       const id = buf[i];
       if (!includeSelf && id === casterId) {
+        continue;
+      }
+      // Drop stale ids unconditionally — even when no filter is set, the
+      // resolver's contract is to return real entities only. Without this
+      // check, callers like `applyEffectAoE` would see ghost ids in the
+      // returned list and enqueue logic would have to dedupe per-call.
+      if (!this.entityManager.getEntity(id)) {
         continue;
       }
       if (filter && !this.passesFilter(id, filter)) {
@@ -198,22 +213,25 @@ export class TargetResolver {
   ): { x: FixedPoint; z: FixedPoint } | undefined {
     switch (origin.kind) {
       case 'Caster': {
-        const pos = this.tryGetCasterPosition(input.casterEntityId);
+        const pos = this.tryGetEntityPosition(input.casterEntityId);
         if (!pos) {
           throw new Error(
             `TargetSpec.kind === 'Radius' with origin 'Caster' requires the caster ` +
-              `(entity ${input.casterEntityId}) to have a position. Provide a position ` +
-              `via the spatial query implementation or use TargetOrigin.kind === 'Point'.`
+              `(entity ${input.casterEntityId}) to have a position. The registered ` +
+              `ISpatialQuery must implement getEntityPosition(entityId) and return a ` +
+              `position for this entity, or the ability must use TargetOrigin.kind === 'Point'.`
           );
         }
         return pos;
       }
       case 'TargetEntity': {
-        const pos = this.tryGetCasterPosition(origin.entityId);
+        const pos = this.tryGetEntityPosition(origin.entityId);
         if (!pos) {
           throw new Error(
             `TargetSpec.kind === 'Radius' with origin 'TargetEntity' requires the target ` +
-              `(entity ${origin.entityId}) to have a position resolvable by ISpatialQuery.`
+              `(entity ${origin.entityId}) to have a position. The registered ` +
+              `ISpatialQuery must implement getEntityPosition(entityId) and return a ` +
+              `position for this entity.`
           );
         }
         return pos;
@@ -238,10 +256,10 @@ export class TargetResolver {
    * `getEntityPosition` extension method (duck-typed) before giving up.
    *
    * Returning `undefined` here causes the resolver to throw an actionable
-   * error pointing the user at registerSpatialQuery, instead of silently
-   * dropping the activation.
+   * error pointing the user at `ISpatialQuery.getEntityPosition`, instead
+   * of silently dropping the activation.
    */
-  private tryGetCasterPosition(
+  private tryGetEntityPosition(
     entityId: number
   ): { x: FixedPoint; z: FixedPoint } | undefined {
     const spatial = this.registries.spatialQuery;

--- a/phalanx-abilities/src/targeting/index.ts
+++ b/phalanx-abilities/src/targeting/index.ts
@@ -1,2 +1,2 @@
 export { TargetResolver } from './TargetResolver';
-export type { TargetResolutionInput } from './TargetResolver';
+export type { TargetResolutionInput, TargetResolutionResult } from './TargetResolver';

--- a/phalanx-abilities/src/targeting/index.ts
+++ b/phalanx-abilities/src/targeting/index.ts
@@ -1,0 +1,2 @@
+export { TargetResolver } from './TargetResolver';
+export type { TargetResolutionInput } from './TargetResolver';

--- a/phalanx-abilities/tests/target-resolution.test.ts
+++ b/phalanx-abilities/tests/target-resolution.test.ts
@@ -3,6 +3,7 @@ import { Entity, GameWorld } from 'phalanx-ecs';
 import { FP } from 'phalanx-math';
 import type { FixedPoint } from 'phalanx-math';
 import {
+  ABILITY_ACTIVATED_EVENT,
   AbilitiesComponentType,
   AbilityActivationSystem,
   AbilityHookExecutorSystem,
@@ -17,6 +18,7 @@ import {
   defineEffect,
 } from '../src';
 import type {
+  AbilityActivatedEvent,
   AbilitySystemRegistries,
   AbilitySystemRuntime,
   ISpatialQuery,
@@ -649,19 +651,54 @@ describe('TargetResolver via ability activation — Radius origin kinds', () => 
   });
 
   it('silently drops a Caller-origin Radius activation with no point provided', () => {
-    const { world, facade, spatial } = createTestWorld({
-      abilities: [
-        defineAbility({
-          id: 'Ability.FrostNova',
-          target: {
-            kind: 'Radius',
-            origin: { kind: 'Caller' },
-            radius: FP.FromInt(10),
-          },
-          targetEffectIds: ['Effect.Explosion'],
-        }),
-      ],
-    });
+    // The hard requirement: a Caller-origin Radius activation without a
+    // point must NOT charge cost, NOT enqueue cooldown, NOT emit the
+    // AbilityActivated event, NOT schedule the hook, AND not run the
+    // spatial query. Earlier implementations of the resolver returned an
+    // empty array indistinguishable from a legitimate "AoE hit nobody",
+    // which let processOne charge the caster anyway.
+    const { world, facade, spatial, registries } = createTestWorld();
+    // Define cost + cooldown effects so we can assert the caster was
+    // NOT charged. Mana is a custom attribute we add for this test.
+    registries.attributes.register(
+      defineAttribute({
+        id: 'Mana',
+        default: FP.FromInt(100),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.SpendMana20',
+        type: 'Instant',
+        modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-20) }],
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.FrostNova.Cooldown',
+        type: 'Duration',
+        durationTicks: 5,
+        tagsGranted: ['Cooldown.Ability.FrostNova'],
+      })
+    );
+    registries.abilities.register(
+      defineAbility({
+        id: 'Ability.FrostNova',
+        target: {
+          kind: 'Radius',
+          origin: { kind: 'Caller' },
+          radius: FP.FromInt(10),
+        },
+        targetEffectIds: ['Effect.Explosion'],
+        costEffectId: 'Effect.SpendMana20',
+        cooldownEffectId: 'Effect.FrostNova.Cooldown',
+        hookId: 'Hook.Nova',
+      })
+    );
+
     const caster = addEntity(world);
     const enemy = addEntity(world);
     facade.initAttributesForEntity(caster.id);
@@ -674,12 +711,122 @@ describe('TargetResolver via ability activation — Radius origin kinds', () => 
       return [enemy.id];
     });
 
+    let eventEmitted = false;
+    world.eventBus.on<AbilityActivatedEvent>(ABILITY_ACTIVATED_EVENT, () => {
+      eventEmitted = true;
+    });
+    let hookCalled = false;
+    facade.registerHook('Hook.Nova', () => {
+      hookCalled = true;
+    });
+
     // No providedTarget — Caller has nothing to read.
     facade.activateAbility(caster.id, 'Ability.FrostNova');
     world.processAllTicks(2);
 
+    // No side effects of any kind:
     expect(queryCalled).toBe(false);
+    expect(eventEmitted).toBe(false);
+    expect(hookCalled).toBe(false);
+    // Mana untouched (cost NOT charged).
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(100);
+    // Cooldown tag NOT applied — caster can still cast.
+    expect(facade.hasTag(caster.id, 'Cooldown.Ability.FrostNova')).toBe(false);
+    // Enemy untouched.
     expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(100);
+    world.dispose();
+  });
+
+  it('silently drops a Caller-origin Entity activation with no entityId provided', () => {
+    // Same contract for Entity-shape abilities: forgetting to pass
+    // `{ entityId }` must not charge cost or run the hook.
+    const { world, facade, registries } = createTestWorld();
+    registries.attributes.register(
+      defineAttribute({
+        id: 'Mana',
+        default: FP.FromInt(100),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.SpendMana15',
+        type: 'Instant',
+        modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-15) }],
+      })
+    );
+    registries.abilities.register(
+      defineAbility({
+        id: 'Ability.Smite',
+        target: { kind: 'Entity', origin: { kind: 'Caller' } },
+        targetEffectIds: ['Effect.Explosion'],
+        costEffectId: 'Effect.SpendMana15',
+        hookId: 'Hook.Smite',
+      })
+    );
+
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    let hookCalled = false;
+    facade.registerHook('Hook.Smite', () => {
+      hookCalled = true;
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Smite');
+    world.processAllTicks(2);
+
+    expect(hookCalled).toBe(false);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(100);
+    world.dispose();
+  });
+
+  it('silently drops a Caller-origin Point activation with no point provided', () => {
+    // Point-shape abilities also drop when origin Caller has no point.
+    // Otherwise the rocket hook would run with no impact location.
+    const { world, facade, registries } = createTestWorld();
+    registries.attributes.register(
+      defineAttribute({
+        id: 'Mana',
+        default: FP.FromInt(100),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.SpendMana25',
+        type: 'Instant',
+        modifiers: [{ attributeId: 'Mana', op: 'Add', magnitude: FP.FromInt(-25) }],
+      })
+    );
+    registries.abilities.register(
+      defineAbility({
+        id: 'Ability.Rocket',
+        target: { kind: 'Point', origin: { kind: 'Caller' } },
+        costEffectId: 'Effect.SpendMana25',
+        hookId: 'Hook.Rocket',
+      })
+    );
+
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    let hookCalled = false;
+    facade.registerHook('Hook.Rocket', () => {
+      hookCalled = true;
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Rocket');
+    world.processAllTicks(2);
+
+    expect(hookCalled).toBe(false);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Mana').current)).toBe(100);
     world.dispose();
   });
 });

--- a/phalanx-abilities/tests/target-resolution.test.ts
+++ b/phalanx-abilities/tests/target-resolution.test.ts
@@ -23,7 +23,7 @@ import type {
 } from '../src';
 
 // ---------------------------------------------------------------------------
-// Stage 6 — Targeting: Radius + TargetResolutionSystem + applyEffectAoE
+// Stage 6 — Targeting: Radius + TargetResolver + applyEffectAoE
 //
 // These tests cover the resolver behaviour end-to-end through the facade and
 // through ability activation. They exercise determinism guarantees that are
@@ -294,7 +294,7 @@ describe('TargetResolver via applyEffectAoE — Radius behaviour', () => {
     world.dispose();
   });
 
-  it('drops entity ids returned by the spatial query that have been removed already', () => {
+  it('drops entity ids returned by the spatial query that have been removed already (with filter)', () => {
     const { world, facade, spatial } = createTestWorld();
     const a = addEntity(world);
     const b = addEntity(world);
@@ -303,8 +303,6 @@ describe('TargetResolver via applyEffectAoE — Radius behaviour', () => {
     world.processAllTicks(1);
 
     const ghostId = 9999; // never added to the world
-    // Return one ghost id alongside legit ones. Filter forces the
-    // resolver to look the entity up — and the lookup fails cleanly.
     spatial.setQuery(() => [a.id, ghostId, b.id]);
 
     const targets = facade.applyEffectAoE(
@@ -316,10 +314,62 @@ describe('TargetResolver via applyEffectAoE — Radius behaviour', () => {
         filter: { tagsBlocked: ['Never.Granted'] },
       }
     );
-    // Without filter the resolver still passes the ghost id through;
-    // the facade's enqueue loop drops it because entityManager.getEntity
-    // returns undefined. With filter the resolver drops it earlier.
     expect(targets).toEqual([a.id, b.id]);
+
+    world.dispose();
+  });
+
+  it('drops entity ids returned by the spatial query that have been removed already (no filter)', () => {
+    // The resolver checks entity existence unconditionally — even when
+    // no filter is provided — so ghost ids never leak into the returned
+    // list. Without this guarantee the facade's enqueue loop would have
+    // been the only thing keeping them out, and callers reading the
+    // return value of `applyEffectAoE` could observe phantom hits.
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    world.processAllTicks(1);
+
+    const ghostId = 9999;
+    spatial.setQuery(() => [a.id, ghostId, b.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10) }
+    );
+    expect(targets).toEqual([a.id, b.id]);
+
+    world.dispose();
+  });
+
+  it('returns the enqueued subset — maxTargets === 0 yields an empty list', () => {
+    // Guard for the `maxTargets === 0` edge case: the loop guard must
+    // run BEFORE pushing the first id, so the call resolves to no
+    // targets at all (not one).
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [a.id, b.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10), maxTargets: 0 }
+    );
+    expect(targets).toEqual([]);
+
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(a.id, 'Health').current)).toBe(100);
+    expect(FP.ToFloat(facade.getAttribute(b.id, 'Health').current)).toBe(100);
 
     world.dispose();
   });
@@ -451,7 +501,11 @@ describe('TargetResolver via ability activation — Radius origin kinds', () => 
     world.dispose();
   });
 
-  it("throws when origin 'Caster' is used but no getEntityPosition is available", () => {
+  it("throws when origin 'Caster' is used but getEntityPosition returns undefined", () => {
+    // The adapter implements the optional method but has no position
+    // for the caster (e.g. entity hasn't been added to the spatial
+    // index yet). The error should still actionably point at
+    // ISpatialQuery.getEntityPosition.
     const { world, facade, spatial } = createTestWorld({
       abilities: [
         defineAbility({
@@ -469,11 +523,86 @@ describe('TargetResolver via ability activation — Radius origin kinds', () => 
     facade.initAttributesForEntity(caster.id);
     world.processAllTicks(1);
 
-    // Caster has no registered position.
+    // Caster has no registered position — getEntityPosition will return
+    // undefined for this id.
     spatial.clearPositions();
 
     facade.activateAbility(caster.id, 'Ability.Nova');
-    expect(() => world.processAllTicks(2)).toThrow(/requires the caster.*to have a position/);
+    expect(() => world.processAllTicks(2)).toThrow(
+      /getEntityPosition/
+    );
+
+    world.dispose();
+  });
+
+  it("throws when origin 'Caster' is used but the adapter does not implement getEntityPosition", () => {
+    // Validate the adapter-shape-mismatch path: a spatial query that
+    // satisfies the minimal ISpatialQuery contract (queryRadius) but
+    // omits the optional getEntityPosition entirely. Caster/TargetEntity
+    // Radius origins should fail loudly so users know which method to
+    // add to their adapter.
+    const registries = createAbilitySystemRegistries();
+    registries.attributes.register(
+      defineAttribute({
+        id: 'Health',
+        default: FP.FromInt(100),
+        min: FP.FromInt(0),
+        max: FP.FromInt(100),
+        clamp: 'both',
+      })
+    );
+    registries.effects.register(
+      defineEffect({
+        id: 'Effect.Explosion',
+        type: 'Instant',
+        modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-50) }],
+      })
+    );
+    registries.abilities.register(
+      defineAbility({
+        id: 'Ability.Nova',
+        target: {
+          kind: 'Radius',
+          origin: { kind: 'Caster' },
+          radius: FP.FromInt(10),
+        },
+        targetEffectIds: ['Effect.Explosion'],
+      })
+    );
+    const runtime = createAbilitySystemRuntime();
+    const world = new GameWorld({
+      componentTypes: [
+        AbilitiesComponentType.Attributes,
+        AbilitiesComponentType.ActiveEffects,
+        AbilitiesComponentType.GameplayTags,
+      ],
+    });
+    world.registerSystems(
+      [
+        new AbilityActivationSystem(registries, runtime),
+        new EffectApplicationSystem(registries, runtime),
+        new AbilityHookExecutorSystem(registries, runtime),
+        new EffectTickSystem(registries),
+        new AttributeAggregationSystem(registries),
+      ],
+      []
+    );
+    const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
+
+    // Bare-bones spatial query: just queryRadius, no getEntityPosition.
+    // This is the realistic shape of a v1 physics adapter that hasn't
+    // been upgraded for Stage 6 yet.
+    const bareAdapter: ISpatialQuery = {
+      queryRadius: () => [],
+    };
+    facade.registerSpatialQuery(bareAdapter);
+
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    facade.activateAbility(caster.id, 'Ability.Nova');
+    expect(() => world.processAllTicks(2)).toThrow(/getEntityPosition/);
 
     world.dispose();
   });

--- a/phalanx-abilities/tests/target-resolution.test.ts
+++ b/phalanx-abilities/tests/target-resolution.test.ts
@@ -1,0 +1,705 @@
+import { describe, expect, it } from 'vitest';
+import { Entity, GameWorld } from 'phalanx-ecs';
+import { FP } from 'phalanx-math';
+import type { FixedPoint } from 'phalanx-math';
+import {
+  AbilitiesComponentType,
+  AbilityActivationSystem,
+  AbilityHookExecutorSystem,
+  AbilitySystemFacade,
+  AttributeAggregationSystem,
+  EffectApplicationSystem,
+  EffectTickSystem,
+  createAbilitySystemRegistries,
+  createAbilitySystemRuntime,
+  defineAbility,
+  defineAttribute,
+  defineEffect,
+} from '../src';
+import type {
+  AbilitySystemRegistries,
+  AbilitySystemRuntime,
+  ISpatialQuery,
+} from '../src';
+
+// ---------------------------------------------------------------------------
+// Stage 6 — Targeting: Radius + TargetResolutionSystem + applyEffectAoE
+//
+// These tests cover the resolver behaviour end-to-end through the facade and
+// through ability activation. They exercise determinism guarantees that are
+// load-bearing for lockstep replay:
+//   - stable ASC entityId sort
+//   - maxTargets trim AFTER sort
+//   - filter (tagsRequired / tagsBlocked)
+//   - includeSelf (default false)
+//   - origin kinds (Caster / TargetEntity / Point / Caller)
+//   - dedup of duplicate ids from the spatial query
+//   - stale ids from the spatial query (entity removed) drop cleanly
+// ---------------------------------------------------------------------------
+
+describe('TargetResolver via applyEffectAoE — Radius behaviour', () => {
+  it('applies the effect to every entity returned by the spatial query, sorted by entityId ASC', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    const c = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    facade.initAttributesForEntity(c.id);
+    world.processAllTicks(1);
+
+    // Return ids in scrambled order; resolver must sort them.
+    spatial.setQuery(() => [c.id, a.id, b.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      /* sourceEntityId */ -1,
+      { radius: FP.FromInt(10) }
+    );
+    expect(targets).toEqual([a.id, b.id, c.id]);
+
+    world.processAllTicks(2);
+    // -50 health each: 100 -> 50.
+    expect(FP.ToFloat(facade.getAttribute(a.id, 'Health').current)).toBe(50);
+    expect(FP.ToFloat(facade.getAttribute(b.id, 'Health').current)).toBe(50);
+    expect(FP.ToFloat(facade.getAttribute(c.id, 'Health').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('deduplicates entities returned more than once by the spatial query', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    world.processAllTicks(1);
+
+    // Misbehaving hash grid: same entity returned multiple times.
+    spatial.setQuery(() => [a.id, b.id, a.id, b.id, a.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10) }
+    );
+    expect(targets).toEqual([a.id, b.id]);
+
+    world.processAllTicks(2);
+    // Each target got hit exactly once — dedup must happen before enqueue.
+    expect(FP.ToFloat(facade.getAttribute(a.id, 'Health').current)).toBe(50);
+    expect(FP.ToFloat(facade.getAttribute(b.id, 'Health').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('caps the resolved list at maxTargets AFTER sorting (lowest entity ids win)', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    const c = addEntity(world);
+    const d = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    facade.initAttributesForEntity(c.id);
+    facade.initAttributesForEntity(d.id);
+    world.processAllTicks(1);
+
+    // Spatial returns them out of order to prove trim is post-sort.
+    spatial.setQuery(() => [d.id, b.id, c.id, a.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10), maxTargets: 2 }
+    );
+    expect(targets).toEqual([a.id, b.id]);
+
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(a.id, 'Health').current)).toBe(50);
+    expect(FP.ToFloat(facade.getAttribute(b.id, 'Health').current)).toBe(50);
+    // c and d are untouched.
+    expect(FP.ToFloat(facade.getAttribute(c.id, 'Health').current)).toBe(100);
+    expect(FP.ToFloat(facade.getAttribute(d.id, 'Health').current)).toBe(100);
+
+    world.dispose();
+  });
+
+  it('filters by tagsRequired before the maxTargets trim', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const ally1 = addEntity(world);
+    const enemy = addEntity(world);
+    const ally2 = addEntity(world);
+    facade.initAttributesForEntity(ally1.id);
+    facade.initAttributesForEntity(enemy.id);
+    facade.initAttributesForEntity(ally2.id);
+    facade.addTag(ally1.id, 'Team.Ally');
+    facade.addTag(ally2.id, 'Team.Ally');
+    facade.addTag(enemy.id, 'Team.Enemy');
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [ally1.id, enemy.id, ally2.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Heal',
+      -1,
+      {
+        radius: FP.FromInt(10),
+        filter: { tagsRequired: ['Team.Ally'] },
+      }
+    );
+    expect(targets).toEqual([ally1.id, ally2.id]);
+
+    world.processAllTicks(2);
+    // Hurt them first so the heal is observable (clamp would mask the
+    // attempted +20 against the 100 max otherwise).
+    // For brevity we just verify the targets list — the heal effect's
+    // application is covered by the existing effects tests.
+
+    world.dispose();
+  });
+
+  it('filters by tagsBlocked', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    const c = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    facade.initAttributesForEntity(c.id);
+    facade.addTag(b.id, 'State.Invulnerable');
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [a.id, b.id, c.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      {
+        radius: FP.FromInt(10),
+        filter: { tagsBlocked: ['State.Invulnerable'] },
+      }
+    );
+    expect(targets).toEqual([a.id, c.id]);
+
+    world.dispose();
+  });
+
+  it('excludes the caster by default (includeSelf omitted)', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [caster.id, enemy.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      /* sourceEntityId */ caster.id,
+      { radius: FP.FromInt(10) }
+    );
+    expect(targets).toEqual([enemy.id]);
+
+    world.processAllTicks(2);
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Health').current)).toBe(100);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(50);
+
+    world.dispose();
+  });
+
+  it('includes the caster when includeSelf is true (e.g. self-heal aura)', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const caster = addEntity(world);
+    const ally = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(ally.id);
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [caster.id, ally.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Heal',
+      caster.id,
+      { radius: FP.FromInt(10), includeSelf: true }
+    );
+    expect(targets).toEqual([caster.id, ally.id]);
+
+    world.dispose();
+  });
+
+  it('honours selfId override (excludes a specific entity even when sourceEntityId differs)', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const launcher = addEntity(world);
+    const rocket = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(launcher.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [launcher.id, rocket.id, enemy.id]);
+
+    // Rocket source, but we want the launcher excluded (it shouldn't
+    // splash itself). selfId override does exactly that.
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      rocket.id,
+      { radius: FP.FromInt(10), selfId: launcher.id }
+    );
+    expect(targets).toEqual([rocket.id, enemy.id]);
+
+    world.dispose();
+  });
+
+  it('throws when no spatial query is registered', () => {
+    const { world, facade } = createTestWorld({ skipSpatial: true });
+    addEntity(world);
+    world.processAllTicks(1);
+
+    expect(() =>
+      facade.applyEffectAoE(
+        { x: FP.FromInt(0), z: FP.FromInt(0) },
+        'Effect.Explosion',
+        -1,
+        { radius: FP.FromInt(10) }
+      )
+    ).toThrow(/spatial query/);
+
+    world.dispose();
+  });
+
+  it('throws when the effectId is unknown', () => {
+    const { world, facade } = createTestWorld();
+    addEntity(world);
+    world.processAllTicks(1);
+
+    expect(() =>
+      facade.applyEffectAoE(
+        { x: FP.FromInt(0), z: FP.FromInt(0) },
+        'Effect.DoesNotExist',
+        -1,
+        { radius: FP.FromInt(10) }
+      )
+    ).toThrow(/EffectRegistry does not contain/);
+
+    world.dispose();
+  });
+
+  it('drops entity ids returned by the spatial query that have been removed already', () => {
+    const { world, facade, spatial } = createTestWorld();
+    const a = addEntity(world);
+    const b = addEntity(world);
+    facade.initAttributesForEntity(a.id);
+    facade.initAttributesForEntity(b.id);
+    world.processAllTicks(1);
+
+    const ghostId = 9999; // never added to the world
+    // Return one ghost id alongside legit ones. Filter forces the
+    // resolver to look the entity up — and the lookup fails cleanly.
+    spatial.setQuery(() => [a.id, ghostId, b.id]);
+
+    const targets = facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      {
+        radius: FP.FromInt(10),
+        filter: { tagsBlocked: ['Never.Granted'] },
+      }
+    );
+    // Without filter the resolver still passes the ghost id through;
+    // the facade's enqueue loop drops it because entityManager.getEntity
+    // returns undefined. With filter the resolver drops it earlier.
+    expect(targets).toEqual([a.id, b.id]);
+
+    world.dispose();
+  });
+
+  it('produces the same ordering across two independent worlds (determinism check)', () => {
+    // Build two worlds and populate them independently so each gets
+    // its own fresh entity-id sequence. Both should end up with the
+    // same ids (0..9, modulo whatever the ECS allocator does), but the
+    // determinism guarantee we are testing is that the resolver sorts
+    // by entity id ASC — so if the spatial query returns the *same*
+    // ids in different orders, the resolver output is identical.
+    const worldA = createTestWorld();
+    const aIds: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      const e = addEntity(worldA.world);
+      aIds.push(e.id);
+      worldA.facade.initAttributesForEntity(e.id);
+    }
+    worldA.world.processAllTicks(1);
+
+    const worldB = createTestWorld();
+    const bIds: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      const e = addEntity(worldB.world);
+      bIds.push(e.id);
+      worldB.facade.initAttributesForEntity(e.id);
+    }
+    worldB.world.processAllTicks(1);
+
+    // Sanity: both worlds must allocate ids the same way for this test
+    // to make sense. If this ever breaks, the test needs revisiting.
+    expect(aIds).toEqual(bIds);
+
+    // Indices into aIds/bIds — same logical "who is in the AoE" set,
+    // but returned in two different orders.
+    const indices = [3, 1, 4, 1, 5, 9, 2, 6, 5];
+    worldA.spatial.setQuery(() => indices.map(i => aIds[i]));
+    worldB.spatial.setQuery(() => [...indices].reverse().map(i => bIds[i]));
+
+    const targetsA = worldA.facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10) }
+    );
+    const targetsB = worldB.facade.applyEffectAoE(
+      { x: FP.FromInt(0), z: FP.FromInt(0) },
+      'Effect.Explosion',
+      -1,
+      { radius: FP.FromInt(10) }
+    );
+
+    expect(targetsA).toEqual(targetsB);
+
+    worldA.world.dispose();
+    worldB.world.dispose();
+  });
+});
+
+describe('TargetResolver via ability activation — Radius origin kinds', () => {
+  it("resolves origin 'Point' from providedTarget for a Radius-target ability", () => {
+    const { world, facade, spatial } = createTestWorld({
+      abilities: [
+        defineAbility({
+          id: 'Ability.FrostNova',
+          target: {
+            kind: 'Radius',
+            origin: { kind: 'Caller' },
+            radius: FP.FromInt(10),
+          },
+          targetEffectIds: ['Effect.Explosion'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    spatial.setQuery(() => [enemy.id]);
+
+    facade.activateAbility(caster.id, 'Ability.FrostNova', {
+      x: FP.FromInt(5),
+      z: FP.FromInt(5),
+    });
+    world.processAllTicks(2);
+
+    // -50 health: 100 -> 50.
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(50);
+    world.dispose();
+  });
+
+  it("resolves origin 'Caster' from the caster's position via ISpatialQuery.getEntityPosition", () => {
+    const { world, facade, spatial } = createTestWorld({
+      abilities: [
+        defineAbility({
+          id: 'Ability.Nova',
+          target: {
+            kind: 'Radius',
+            origin: { kind: 'Caster' },
+            radius: FP.FromInt(10),
+            includeSelf: false,
+          },
+          targetEffectIds: ['Effect.Explosion'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    spatial.setPosition(caster.id, { x: FP.FromInt(7), z: FP.FromInt(7) });
+    spatial.setQuery((cx, cz) => {
+      // Verify the resolver passed the caster's position through.
+      expect(FP.ToFloat(cx)).toBe(7);
+      expect(FP.ToFloat(cz)).toBe(7);
+      return [caster.id, enemy.id];
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Nova');
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(50);
+    // Caster is excluded by default.
+    expect(FP.ToFloat(facade.getAttribute(caster.id, 'Health').current)).toBe(100);
+    world.dispose();
+  });
+
+  it("throws when origin 'Caster' is used but no getEntityPosition is available", () => {
+    const { world, facade, spatial } = createTestWorld({
+      abilities: [
+        defineAbility({
+          id: 'Ability.Nova',
+          target: {
+            kind: 'Radius',
+            origin: { kind: 'Caster' },
+            radius: FP.FromInt(10),
+          },
+          targetEffectIds: ['Effect.Explosion'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    // Caster has no registered position.
+    spatial.clearPositions();
+
+    facade.activateAbility(caster.id, 'Ability.Nova');
+    expect(() => world.processAllTicks(2)).toThrow(/requires the caster.*to have a position/);
+
+    world.dispose();
+  });
+
+  it("resolves origin 'TargetEntity' from the targeted entity's position", () => {
+    // TargetEntity origin lets the ability specify a fixed target entity
+    // at definition time. Useful for "centered on the boss spawn point"
+    // mechanics. The boss id must be known when the ability is
+    // registered — so we build the world without abilities first,
+    // allocate entities, then register the ability with the real id.
+    const { world, facade, spatial, registries } = createTestWorld();
+    const caster = addEntity(world);
+    const boss = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(boss.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    registries.abilities.register(
+      defineAbility({
+        id: 'Ability.NovaAt',
+        target: {
+          kind: 'Radius',
+          origin: { kind: 'TargetEntity', entityId: boss.id },
+          radius: FP.FromInt(10),
+        },
+        targetEffectIds: ['Effect.Explosion'],
+      })
+    );
+
+    spatial.setPosition(boss.id, { x: FP.FromInt(50), z: FP.FromInt(50) });
+    spatial.setQuery((cx, cz) => {
+      expect(FP.ToFloat(cx)).toBe(50);
+      expect(FP.ToFloat(cz)).toBe(50);
+      return [enemy.id];
+    });
+
+    facade.activateAbility(caster.id, 'Ability.NovaAt');
+    world.processAllTicks(2);
+
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(50);
+    world.dispose();
+  });
+
+  it('silently drops a Caller-origin Radius activation with no point provided', () => {
+    const { world, facade, spatial } = createTestWorld({
+      abilities: [
+        defineAbility({
+          id: 'Ability.FrostNova',
+          target: {
+            kind: 'Radius',
+            origin: { kind: 'Caller' },
+            radius: FP.FromInt(10),
+          },
+          targetEffectIds: ['Effect.Explosion'],
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    const enemy = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    facade.initAttributesForEntity(enemy.id);
+    world.processAllTicks(1);
+
+    let queryCalled = false;
+    spatial.setQuery(() => {
+      queryCalled = true;
+      return [enemy.id];
+    });
+
+    // No providedTarget — Caller has nothing to read.
+    facade.activateAbility(caster.id, 'Ability.FrostNova');
+    world.processAllTicks(2);
+
+    expect(queryCalled).toBe(false);
+    expect(FP.ToFloat(facade.getAttribute(enemy.id, 'Health').current)).toBe(100);
+    world.dispose();
+  });
+});
+
+describe('TargetResolver — Point target shape', () => {
+  it("Point target resolves to an empty target list; the providedTarget is passed to the hook", () => {
+    const { world, facade } = createTestWorld({
+      abilities: [
+        defineAbility({
+          id: 'Ability.Rocket',
+          target: { kind: 'Point', origin: { kind: 'Caller' } },
+          hookId: 'Hook.Rocket',
+        }),
+      ],
+    });
+    const caster = addEntity(world);
+    facade.initAttributesForEntity(caster.id);
+    world.processAllTicks(1);
+
+    let observed: { resolvedTargets: number[]; x?: FixedPoint; z?: FixedPoint } | undefined;
+    facade.registerHook('Hook.Rocket', ctx => {
+      observed = {
+        resolvedTargets: [...ctx.resolvedTargets],
+        x: ctx.providedTarget?.x,
+        z: ctx.providedTarget?.z,
+      };
+    });
+
+    facade.activateAbility(caster.id, 'Ability.Rocket', {
+      x: FP.FromInt(42),
+      z: FP.FromInt(7),
+    });
+    world.processAllTicks(2);
+
+    expect(observed?.resolvedTargets).toEqual([]);
+    expect(observed?.x !== undefined && FP.ToFloat(observed.x)).toBe(42);
+    expect(observed?.z !== undefined && FP.ToFloat(observed.z)).toBe(7);
+    world.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test world helper
+// ---------------------------------------------------------------------------
+
+interface TestWorldOpts {
+  effects?: readonly ReturnType<typeof defineEffect>[];
+  abilities?: readonly ReturnType<typeof defineAbility>[];
+  skipSpatial?: boolean;
+}
+
+interface TestWorld {
+  world: GameWorld;
+  facade: AbilitySystemFacade;
+  registries: AbilitySystemRegistries;
+  runtime: AbilitySystemRuntime;
+  spatial: FakeSpatialQuery;
+}
+
+class FakeSpatialQuery implements ISpatialQuery {
+  private queryFn: (x: FixedPoint, z: FixedPoint, r: FixedPoint) => number[] = () => [];
+  private positions = new Map<number, { x: FixedPoint; z: FixedPoint }>();
+
+  public queryRadius(x: FixedPoint, z: FixedPoint, radius: FixedPoint): number[] {
+    return this.queryFn(x, z, radius);
+  }
+
+  public getEntityPosition(
+    entityId: number
+  ): { x: FixedPoint; z: FixedPoint } | undefined {
+    return this.positions.get(entityId);
+  }
+
+  public setQuery(fn: (x: FixedPoint, z: FixedPoint, r: FixedPoint) => number[]): void {
+    this.queryFn = fn;
+  }
+
+  public setPosition(entityId: number, pos: { x: FixedPoint; z: FixedPoint }): void {
+    this.positions.set(entityId, pos);
+  }
+
+  public clearPositions(): void {
+    this.positions.clear();
+  }
+}
+
+function createTestWorld(opts: TestWorldOpts = {}): TestWorld {
+  const registries = createAbilitySystemRegistries();
+  registries.attributes.register(
+    defineAttribute({
+      id: 'Health',
+      default: FP.FromInt(100),
+      min: FP.FromInt(0),
+      max: FP.FromInt(100),
+      clamp: 'both',
+    })
+  );
+
+  // Two effects every test uses.
+  registries.effects.register(
+    defineEffect({
+      id: 'Effect.Explosion',
+      type: 'Instant',
+      modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(-50) }],
+    })
+  );
+  registries.effects.register(
+    defineEffect({
+      id: 'Effect.Heal',
+      type: 'Instant',
+      modifiers: [{ attributeId: 'Health', op: 'Add', magnitude: FP.FromInt(20) }],
+    })
+  );
+
+  for (const effect of opts.effects ?? []) {
+    registries.effects.register(effect);
+  }
+  for (const ability of opts.abilities ?? []) {
+    registries.abilities.register(ability);
+  }
+
+  const runtime = createAbilitySystemRuntime();
+  const world = new GameWorld({
+    componentTypes: [
+      AbilitiesComponentType.Attributes,
+      AbilitiesComponentType.ActiveEffects,
+      AbilitiesComponentType.GameplayTags,
+    ],
+  });
+  world.registerSystems(
+    [
+      new AbilityActivationSystem(registries, runtime),
+      new EffectApplicationSystem(registries, runtime),
+      new AbilityHookExecutorSystem(registries, runtime),
+      new EffectTickSystem(registries),
+      new AttributeAggregationSystem(registries),
+    ],
+    []
+  );
+  const facade = new AbilitySystemFacade(world.entityManager, registries, runtime);
+  const spatial = new FakeSpatialQuery();
+  if (!opts.skipSpatial) {
+    facade.registerSpatialQuery(spatial);
+  }
+  return { world, facade, registries, runtime, spatial };
+}
+
+function addEntity(world: GameWorld): Entity {
+  const entity = new Entity();
+  world.entityManager.addEntity(entity);
+  return entity;
+}


### PR DESCRIPTION
## Stage 6 — Targeting: Radius + `applyEffectAoE`

Implements Stage 6 of [`phalanx-abilities-plan.md`](../blob/main/phalanx-abilities-plan.md) (lines 627-633). Builds on the Stage 5 baseline (#34).

### What's new

**`TargetResolver`** (`src/targeting/TargetResolver.ts`) — pure stateless class that handles every combination of:
- `TargetSpec.kind`: `Self` | `Entity` | `Point` | `Radius`
- `TargetOrigin.kind`: `Caster` | `TargetEntity` | `Point` | `Caller`

It owns the determinism contract:
1. dedup output (defends against misbehaving hash grids)
2. **stable ASC sort by `entityId`**
3. apply filter (`tagsRequired` / `tagsBlocked`) after sort
4. trim to `maxTargets` last (lowest ids win)
5. `includeSelf` (default `false`) — caster is excluded from AoE unless opted in

Distances are never computed inside `phalanx-abilities` — that stays the `ISpatialQuery` contract.

**`ISpatialQuery.getEntityPosition?(entityId)`** — new optional method. Required only for Radius origins of kind `Caster` / `TargetEntity`. Adapters that don't supply it still work for `Point` / `Caller` origins; they get a clear actionable error if a Caster/TargetEntity origin is invoked without it.

**`AbilitySystemFacade.applyEffectAoE(origin, effectId, sourceEntityId?, opts)`** → `number[]` — apply an effect to everyone in a radius around a point or a known entity, returning the resolved id list.

**`AbilitySystemFacade.registerSpatialQuery(query)`** — wire a spatial backend.

**`AbilitySystemRegistries.spatialQuery?`** — new optional slot, mirrors how `hooks` are wired.

**`AbilityActivationSystem`** — replaces the Stage 5 throw-stubs with delegation to `TargetResolver`. Lazy-inits the resolver on first use.

### Tests

18 new tests in `tests/target-resolution.test.ts`:
- AoE by point (resolver from `applyEffectAoE`)
- AoE from caster (Radius + `Caster` origin via `getEntityPosition`)
- AoE from a fixed entity (`TargetEntity` origin)
- AoE from provided point (`Caller` origin via `activateAbility(_, _, point)`)
- alliance filter (`tagsRequired`)
- `tagsBlocked` exclusion
- `includeSelf` default `false` + explicit override
- dedup of duplicate ids from the spatial query
- stale-id drop (id no longer in entity manager)
- ASC sort regardless of spatial query order
- `maxTargets` trim applied **after** sort
- `Point` target shape resolves to `[]` and passes the point through `providedTarget` to hooks
- silent drop when `Caller`-origin Radius is activated without a provided point
- error when `Caster`-origin Radius is invoked without `getEntityPosition`
- cross-world determinism check

```
Test Files  6 passed (6)
     Tests  73 passed (73)
```
Previous baseline was 55 tests; +18 new, no regressions.

### Design notes

- `TargetResolver` is a stateless class rather than a `GameSystem`. The plan envisioned a `TargetResolutionSystem`, but inserting another ECS stage between activation and effect application would force a tick boundary; resolving inline keeps the pipeline single-tick and observable from the facade.
- `TargetSpec.kind === 'Point'` resolves to `[]` entities by design — the point flows through `providedTarget` in `AbilityActivationContext`, hooks consume it. `targetEffectIds` on a Point-targeted ability is intentionally a no-op.
- Filter (tagsRequired/tagsBlocked) is applied **after** the spatial query so the physics package stays gameplay-tag-free.

### Not in scope
Stage 5 follow-ups (multi-modifier cost overdraw, silent-drop of cost-effect `tagsRequired`, instant-cooldown effects locking permanently) are still deferred per the original Stage 5 notes.
