### PR TITLE
docs: update FPQuaternion and quaternion-based Transform docs

### DIFF
--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -3,7 +3,7 @@ name: phalanx-physics
 description: Add deterministic fixed-point physics to a game using the phalanx-physics library from the phalanx-engine repository. Use when the user wants to set up collision detection, velocity integration, spatial hashing, or physics bodies. Covers PhysicsWorld facade, TransformComponent, InterpolationSystem, PhysicsBodyComponent, SpatialHashGrid, NarrowPhase, PhysicsSystem, and collision filtering patterns.
 metadata:
   author: phaeton2040-AI
-  version: '1.1'
+  version: '1.2'
 ---
 
 # Phalanx Physics Skill
@@ -26,7 +26,7 @@ Use this skill when the user asks to:
 
 - TypeScript project with strict mode
 - `phalanx-ecs` package (peer dependency — GameSystem, SoAComponent, EntityManager, EventBus, lifecycle hooks)
-- `phalanx-math` package (peer dependency — FP.*, FixedPoint, FPVector3)
+- `phalanx-math` package (peer dependency — FP.*, FixedPoint, FPVector3, FPQuaternion)
 
 ## Architecture Overview
 
@@ -123,7 +123,8 @@ class RenderSystem extends GameSystem {
     const sample = this.physics?.getInterpolatedTransform(entityId);
     if (sample) {
       mesh.position.set(sample.position.x, sample.position.y, sample.position.z);
-      mesh.rotation.set(sample.rotation.x, sample.rotation.y, sample.rotation.z);
+      // sample.rotation is a float quaternion { x, y, z, w } — apply it directly.
+      mesh.quaternion.set(sample.rotation.x, sample.rotation.y, sample.rotation.z, sample.rotation.w);
     }
   }
 }
@@ -188,10 +189,10 @@ import {
   InterpolationComponent,
   PhysicsBodyComponent,
 } from '@phalanx-engine/physics';
-import { FP, FPVector3 } from '@phalanx-engine/math';
+import { FP, FPVector3, FPQuaternion } from '@phalanx-engine/math';
 
 const fpPosition = FPVector3.FromFloat(10, 0, 20);
-const fpRotation = FPVector3.FromFloat(0, 0, 0);
+const fpRotation = FPQuaternion.Identity();
 
 entity.addComponent(new TransformComponent(entity.id, fpPosition, fpRotation));
 entity.addComponent(new InterpolationComponent(fpPosition, fpRotation));
@@ -288,6 +289,8 @@ if (pos) { /* pos.x, pos.z are FixedPoint */ }
 const sample = physicsWorld.getInterpolatedTransform(entityId);
 if (sample) {
   mesh.position.set(sample.position.x, sample.position.y, sample.position.z);
+  // sample.rotation is a float quaternion { x, y, z, w }
+  mesh.quaternion.set(sample.rotation.x, sample.rotation.y, sample.rotation.z, sample.rotation.w);
 }
 ```
 
@@ -295,17 +298,21 @@ if (sample) {
 
 Built-in SoA component for authoritative fixed-point spatial state:
 
-| Field           | Type  | Description                    |
-| --------------- | ----- | ------------------------------ |
-| `fpPositionX/Y/Z` | `i64` | Fixed-point position (raw FP) |
-| `fpRotationX/Y/Z` | `i64` | Fixed-point rotation (radians, raw FP) |
+| Field              | Type  | Description                                         |
+| ------------------ | ----- | --------------------------------------------------- |
+| `fpPositionX/Y/Z`  | `i64` | Fixed-point position (raw FP)                       |
+| `fpRotationX/Y/Z/W`| `i64` | Fixed-point rotation **quaternion** (raw FP); identity default has `w = 1` |
+
+Rotation is stored as a quaternion, not Euler radians. The authoritative value is `fpRotation` (`FPQuaternion`); `fpRotationEuler` (XYZ Euler radians) and `fpRotationY` (yaw) are computed views over it.
 
 ```typescript
 import { TransformComponent, TransformSoASchema, TRANSFORM_COMPONENT_TYPE } from '@phalanx-engine/physics';
+import { FPQuaternion } from '@phalanx-engine/math';
 
-const transform = new TransformComponent(entity.id, fpPosition, fpRotation);
-transform.fpPosition = newPosition;  // get/set FPVector3
-transform.fpRotationY = FP.FromFloat(Math.PI); // convenience for Y-axis
+const transform = new TransformComponent(entity.id, fpPosition, FPQuaternion.Identity());
+transform.fpPosition = newPosition;            // get/set FPVector3
+transform.fpRotation = FPQuaternion.Identity(); // get/set FPQuaternion (authoritative)
+transform.fpRotationY = FP.FromFloat(Math.PI);  // convenience yaw around FPVector3.Up
 ```
 
 Hot-path access:

--- a/phalanx-math/README.md
+++ b/phalanx-math/README.md
@@ -15,7 +15,7 @@ pnpm add @phalanx-engine/math
 ## Usage
 
 ```typescript
-import { FP, FPVector2, FPVector3 } from '@phalanx-engine/math';
+import { FP, FPVector2, FPVector3, FPQuaternion } from '@phalanx-engine/math';
 
 // Create fixed-point numbers
 const speed = FP.FromFloat(5.5);
@@ -33,8 +33,14 @@ const position = FPVector3.FromFloat(10, 0, 20);
 const target = FPVector3.FromFloat(15, 0, 25);
 const dist = FPVector3.Distance(position, target);
 
+// Quaternion rotations (deterministic, XYZ Euler order)
+const yaw = FPQuaternion.FromAxisAngle(FPVector3.Up, FP.PiOver2); // 90° around +Y
+const facing = FPQuaternion.RotateVector(yaw, FPVector3.Forward); // rotate a direction
+const blended = FPQuaternion.Slerp(FPQuaternion.Identity(), yaw, FP.FromFloat(0.5));
+
 // Convert back to numbers for rendering
 console.log(FP.ToFloat(dist));
+console.log(FPQuaternion.ToFloat(blended)); // { x, y, z, w }
 ```
 
 ## API
@@ -67,6 +73,7 @@ Unified namespace for fixed-point operations (Unity/Quantum style):
 
 #### Trigonometry
 - `FP.Sin`, `FP.Cos`, `FP.Atan2` - Deterministic approximations
+- `FP.Acos` - Arccosine via the `atan2` identity; input clamped to `[-1, 1]`, returns radians in `[0, PI]`
 
 ### FPVector2
 
@@ -107,6 +114,36 @@ Unified namespace for fixed-point operations (Unity/Quantum style):
 - `FPVector3.Distance`, `FPVector3.SqrDistance` - Distance calculations
 - `FPVector3.Lerp` - Interpolation
 - `FPVector3.ToFloat` - Convert for rendering
+
+### FPQuaternion
+
+Deterministic fixed-point quaternion for entity rotations. Stored in `(x, y, z, w)` order where `w` is the scalar component. All conversions use the XYZ Euler order (matching Unity's `Transform`), with intermediate math kept in `FixedPoint` for lockstep determinism. The `FPQuaternion` type/interface is also exported as `FPQuaternionInterface`.
+
+#### Creation
+- `FPQuaternion.Identity()` - Identity rotation `{ 0, 0, 0, 1 }`
+- `FPQuaternion.Create(x, y, z, w)` - Create from FixedPoint components
+- `FPQuaternion.FromFloat(x, y, z, w)` - Create from numbers
+
+#### Rotation constructors
+- `FPQuaternion.FromAxisAngle(axis: FPVector3, angle: FixedPoint)` - Rotation of `angle` radians around `axis`. The `axis` is assumed to be unit length (the caller's responsibility).
+- `FPQuaternion.LookRotation(forwardDir: FPVector3, upDir?: FPVector3)` - Rotation aligning +Z with `forwardDir`, using `upDir` (default `FPVector3.Up`) as the reference up. Falls back to `Identity()` for degenerate inputs (zero-length forward, or up parallel to forward).
+- `FPQuaternion.FromEulerXYZ(euler: FPVector3)` - Build from Euler angles (radians) applied in XYZ order
+- `FPQuaternion.ToEulerXYZ(q: FPQuaternion)` - Extract Euler angles (radians, XYZ order); pitch sine is clamped to `[-1, 1]` to avoid NaN at the gimbal poles
+
+#### Base operations
+- `FPQuaternion.Mul(a, b)` - Hamilton product `a * b` (applies rotation `b` first, then `a`)
+- `FPQuaternion.Dot(a, b)` - Dot product
+- `FPQuaternion.Magnitude`, `FPQuaternion.SqrMagnitude` - Length (Unity naming)
+- `FPQuaternion.Normalize(q)` - Normalize; returns `Identity()` if magnitude is zero
+- `FPQuaternion.Conjugate(q)` - Conjugate `{ -x, -y, -z, w }`
+- `FPQuaternion.Inverse(q)` - Inverse `Conjugate(q) / sqrMagnitude`; returns `Identity()` if magnitude is zero
+
+#### Interpolation
+- `FPQuaternion.Slerp(a, b, t: FixedPoint)` - Spherical linear interpolation along the shortest arc; falls back to normalized LERP for near-parallel inputs
+- `FPQuaternion.RotateVector(q, v: FPVector3)` - Rotate a vector by a quaternion (`q * [v, 0] * Conjugate(q)`)
+
+#### Conversion
+- `FPQuaternion.ToFloat(q)` - Convert to `{ x, y, z, w }` floats for display/serialization
 
 ## Why Fixed-Point?
 

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -125,7 +125,7 @@ import {
   TRANSFORM_COMPONENT_TYPE,
   INTERPOLATION_COMPONENT_TYPE,
 } from '@phalanx-engine/physics';
-import { FP, FPVector3 } from '@phalanx-engine/math';
+import { FP, FPVector3, FPQuaternion } from '@phalanx-engine/math';
 
 // Register canonical component type symbols from phalanx-physics
 export const ComponentType = createComponentTypeRegistry({
@@ -144,7 +144,11 @@ class MovementSystem extends GameSystem {
 class RenderSystem extends GameSystem {
   public override update(_dt: number): void {
     const sample = this.physics?.getInterpolatedTransform(entityId);
-    if (sample) mesh.position.set(sample.position.x, sample.position.y, sample.position.z);
+    if (sample) {
+      mesh.position.set(sample.position.x, sample.position.y, sample.position.z);
+      // sample.rotation is a float quaternion { x, y, z, w } — apply it as-is.
+      mesh.quaternion.set(sample.rotation.x, sample.rotation.y, sample.rotation.z, sample.rotation.w);
+    }
   }
 }
 const movementSystem = new MovementSystem();
@@ -176,8 +180,9 @@ world.start();
 // 4. Add transform, interpolation, and physics body to entities
 declare const entity: { id: number; addComponent(c: unknown): void };
 const fpPosition = FPVector3.FromFloat(0, 0, 0);
-entity.addComponent(new TransformComponent(entity.id, fpPosition));
-entity.addComponent(new InterpolationComponent(fpPosition));
+const fpRotation = FPQuaternion.Identity();
+entity.addComponent(new TransformComponent(entity.id, fpPosition, fpRotation));
+entity.addComponent(new InterpolationComponent(fpPosition, fpRotation));
 entity.addComponent(new PhysicsBodyComponent(entity.id, { radius: FP.FromFloat(1.0) }));
 world.entityManager.addEntity(entity as any);
 
@@ -282,7 +287,7 @@ class PhysicsWorld {
 
 - **`getSystems()`** — Returns both `physicsSystem` (register as tick system) and `interpolationSystem` (register as frame system).
 - **`getEntityPosition(entityId)`** — Fixed-point position for gameplay queries (e.g. ability targeting).
-- **`getInterpolatedTransform(entityId)`** — Interpolated float position/rotation for rendering, populated after `InterpolationSystem` runs.
+- **`getInterpolatedTransform(entityId)`** — Interpolated float transform for rendering, populated after `InterpolationSystem` runs. Returns an `InterpolatedTransformSample` with `position: { x, y, z }` and `rotation: { x, y, z, w }` — rotation is a float quaternion (slerped between tick samples), apply it directly to a mesh quaternion.
 
 - **`applyImpulse(entityId, vx, vz)`** — Set body velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
 - **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`).
@@ -314,15 +319,18 @@ class TransformComponent extends SoAComponent<typeof TransformSoASchema.definiti
   static readonly soaSchema: typeof TransformSoASchema;
   readonly type: symbol; // TRANSFORM_COMPONENT_TYPE
 
-  constructor(entityId: number, initialPosition?: FPVector3, initialRotation?: FPVector3);
+  constructor(entityId: number, initialPosition?: FPVector3, initialRotation?: FPQuaternion);
 
-  fpPosition: FPVector3;   // get/set — authoritative fixed-point position
-  fpRotation: FPVector3;   // get/set — authoritative fixed-point rotation (radians)
-  fpRotationY: FixedPoint; // get/set — convenience for Y-axis rotation
+  fpPosition: FPVector3;        // get/set — authoritative fixed-point position
+  fpRotation: FPQuaternion;     // get/set — authoritative rotation quaternion
+  fpRotationEuler: FPVector3;   // get/set — computed Euler view (radians, XYZ order)
+  fpRotationY: FixedPoint;      // get/set — convenience Y-yaw (radians)
 }
 ```
 
-`TransformSoASchema` fields: `fpPositionX/Y/Z`, `fpRotationX/Y/Z` (all `i64`).
+Rotation is authoritatively a quaternion (`fpRotation`). `fpRotationEuler` (XYZ Euler radians) and `fpRotationY` (yaw) are computed views over it — recomputed on each access, mirroring Unity's `Transform.rotation` / `Transform.eulerAngles`. Setting `fpRotationEuler` calls `FPQuaternion.FromEulerXYZ`; setting `fpRotationY` builds a yaw rotation around `FPVector3.Up`.
+
+`TransformSoASchema` fields: `fpPositionX/Y/Z`, `fpRotationX/Y/Z/W` (all `i64`). Rotation defaults to the identity quaternion (`w = 1`).
 
 ### `InterpolationComponent`
 
@@ -330,10 +338,10 @@ class TransformComponent extends SoAComponent<typeof TransformSoASchema.definiti
 class InterpolationComponent implements IComponent {
   readonly type: symbol; // INTERPOLATION_COMPONENT_TYPE
 
-  constructor(initialPosition?: FPVector3, initialRotation?: FPVector3);
+  constructor(initialPosition?: FPVector3, initialRotation?: FPQuaternion);
 
   snapshot(): void;  // copy current → previous (called by InterpolationSystem before tick)
-  capture(fpPosition: FPVector3, fpRotation: FPVector3): void; // capture authoritative state after tick
+  capture(fpPosition: FPVector3, fpRotation: FPQuaternion): void; // capture authoritative state after tick
 }
 ```
 


### PR DESCRIPTION
## Summary

PR #42 (already merged) added the deterministic fixed-point `FPQuaternion` (plus `FP.Acos`) to `@phalanx-engine/math` and migrated phalanx-physics `Transform` rotation from Euler (`FPVector3`) to an authoritative quaternion (`FPQuaternion`). This PR is **docs-only** — it brings the documentation in line with the merged API. No TypeScript source or tests are touched.

### `phalanx-math/README.md`
- Added `FP.Acos` under **Trigonometry** (clamped input `[-1, 1]`, returns radians in `[0, PI]`).
- Added a new **`### FPQuaternion`** subsection mirroring the FPVector3 style: Creation (`Identity`, `Create`, `FromFloat`), Rotation constructors (`FromAxisAngle`, `LookRotation`, `FromEulerXYZ`, `ToEulerXYZ`), Base ops (`Mul`, `Dot`, `Magnitude`/`SqrMagnitude`, `Normalize`, `Conjugate`, `Inverse`), Interpolation (`Slerp`, `RotateVector`), Conversion (`ToFloat`). Notes determinism, unit-axis assumption for `FromAxisAngle`, and `Identity()` fallback for degenerate `LookRotation`.
- Updated the Usage example and import to include `FPQuaternion`.

### `phalanx-physics/README.md`
- `TransformComponent`: constructor now `(entityId, initialPosition?, initialRotation?: FPQuaternion)`; `fpRotation: FPQuaternion` (authoritative), `fpRotationEuler: FPVector3` (computed Euler radians), `fpRotationY: FixedPoint` (computed yaw). Removed the old `fpRotation: FPVector3`.
- `TransformSoASchema`: rotation fields are now `fpRotationX/Y/Z/W` (i64), identity default `w = 1`.
- `InterpolationComponent`: constructor and `capture()` rotation param now `FPQuaternion`.
- `getInterpolatedTransform()` / `InterpolatedTransformSample.rotation` documented as a float quaternion `{ x, y, z, w }`; RenderSystem example updated to `mesh.quaternion.set(...)` (framework-agnostic, no real engine imports).

### `.cursor/skills/phalanx-physics/SKILL.md`
- Schema table updated to `fpRotationX/Y/Z/W` quaternion (identity `w = 1`).
- Entity-creation and RenderSystem examples updated to `FPQuaternion.Identity()` / quaternion `sample.rotation`.
- Prerequisites mention `FPQuaternion`; skill `version` bumped `1.1 → 1.2`.

## Testing

- [x] Verified every documented signature against the merged source (`phalanx-math/src/FixedMath.ts`, `phalanx-math/src/index.ts`, `phalanx-physics/src/components/TransformComponent.ts`, `InterpolationComponent.ts`, `systems/InterpolationSystem.ts`, `phalanx-ecs/src/IPhysicsWorld.ts`).
- [x] Docs-only change — no source/test files modified; examples kept framework-agnostic (no Three.js/Babylon imports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)