### PR TITLE
phalanx-physics: opt-in impulse (momentum-conserving) collision response; enable in Chapayev

### DIFF
--- a/chapaev/src/core/WorldBootstrapper.ts
+++ b/chapaev/src/core/WorldBootstrapper.ts
@@ -27,6 +27,7 @@ import {
   FRICTION,
   BOARD_ELIM_HALF_EXTENT,
   CELL_SIZE,
+  RESTITUTION,
 } from '../config/constants.ts';
 import { TeamTag } from '../enums/TeamTag.ts';
 import { LockstepManager } from '../network';
@@ -51,6 +52,10 @@ function buildPhysicsConfig(): PhysicsConfig {
     maxVelocity: FP.FromFloat(MAX_FLICK_FORCE),
     defaultFriction: FP.FromFloat(1 - FRICTION * PHYSICS_DT),
     pushStrength: FP.FromFloat(15),
+    // Chapayev needs momentum transfer ("click / knock-away"), not the default
+    // push separation — a flicked checker must knock the struck one away.
+    collisionResponse: 'impulse',
+    restitution: FP.FromFloat(RESTITUTION),
     gridCellSize: FP.FromFloat(CELL_SIZE),
     worldBounds: {
       minX: FP.Neg(half),

--- a/phalanx-abilities/package.json
+++ b/phalanx-abilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/abilities",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Deterministic gameplay ability system for Phalanx Engine",
   "type": "module",
   "main": "./dist/index.js",

--- a/phalanx-client/package.json
+++ b/phalanx-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/client",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Client library for Phalanx Engine - a game-agnostic deterministic lockstep multiplayer engine",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/phalanx-ecs/package.json
+++ b/phalanx-ecs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/ecs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Lightweight, renderer-agnostic Entity-Component-System library with optional multiplayer support via Phalanx Engine",
   "type": "module",
   "main": "./dist/index.js",

--- a/phalanx-math/package.json
+++ b/phalanx-math/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/math",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Deterministic fixed-point math library for Phalanx Engine - ensures identical calculations across all platforms",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -306,10 +306,37 @@ interface PhysicsWorldConfig {
   defaultFriction?: FixedPoint;  // default FP.FromFloat(0.92)
   maxVelocity?: FixedPoint;      // default FP.FromFloat(15)
   pushStrength?: FixedPoint;     // default FP.FromFloat(15)
+  collisionResponse?: 'push' | 'impulse'; // default 'push'
+  restitution?: FixedPoint;      // impulse mode only; falls back to per-body restitution
   tickProvider?: IPhysicsTickProvider;
   ejectOnBoundsExit?: boolean;   // default false
   settleThreshold?: FixedPoint;  // default FP.FromFloat(0.01)
 }
+```
+
+### Collision Response (`'push'` vs `'impulse'`)
+
+`collisionResponse` selects how overlapping bodies are resolved. It defaults to
+`'push'`, so existing consumers are unchanged.
+
+| Mode | Behavior | Use when |
+|---|---|---|
+| `'push'` *(default)* | Positional separation plus a mass-weighted push velocity scaled by `pushStrength`. Does **not** conserve momentum — a fast body slides past a slower one. Cheap and very stable. | Crowd/soft separation, characters, projectiles that shouldn't ricochet — most real-time games. |
+| `'impulse'` | Momentum-conserving elastic collision along the contact normal. Applies the impulse scalar `j = (1 + e) · vₙ / (1/mₐ + 1/m_b)` (`vₙ` = relative velocity along the normal), with a "skip if separating" guard. Restores the "click / knock-away" feel. | Billiards / Chapayev checkers / air-hockey — anything where a strike must transfer momentum. |
+
+In `'impulse'` mode the restitution coefficient `e` comes from
+`config.restitution` when set, otherwise from the average of the two bodies'
+per-body `restitution`. `e = 0` is perfectly inelastic; `e = 1` is perfectly
+elastic (equal-mass head-on bodies swap velocities). Only the XZ velocity
+components are affected — `velocityY` is left untouched. Static bodies are
+treated as infinite mass (they don't move and reflect the dynamic body).
+
+```typescript
+// Chapayev-style knock-away collisions
+const physicsWorld = new PhysicsWorld({
+  collisionResponse: 'impulse',
+  restitution: FP.FromFloat(0.85),
+});
 ```
 
 ### `TransformComponent`

--- a/phalanx-physics/package.json
+++ b/phalanx-physics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/physics",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Deterministic fixed-point physics engine for Phalanx Engine - spatial hashing, collision detection, and resolution",
   "type": "module",
   "main": "./dist/index.js",

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -41,6 +41,8 @@ export class PhysicsWorld {
       gridCellSize,
       worldBounds: config?.worldBounds,
       ejectOnBoundsExit: config?.ejectOnBoundsExit,
+      collisionResponse: config?.collisionResponse,
+      restitution: config?.restitution,
     };
 
     this.physicsSystem = new PhysicsSystem(physicsConfig);

--- a/phalanx-physics/src/PhysicsWorldConfig.ts
+++ b/phalanx-physics/src/PhysicsWorldConfig.ts
@@ -24,8 +24,21 @@ export interface PhysicsWorldConfig {
   defaultFriction?: FixedPoint;
   /** Maximum velocity magnitude */
   maxVelocity?: FixedPoint;
-  /** Push strength for collision resolution */
+  /** Push strength for collision resolution (used by the 'push' response) */
   pushStrength?: FixedPoint;
+
+  /**
+   * Collision response model: `'push'` (default, positional separation only)
+   * or `'impulse'` (momentum-conserving elastic collision along the normal).
+   * See PhysicsConfig.collisionResponse for details.
+   */
+  collisionResponse?: 'push' | 'impulse';
+
+  /**
+   * Coefficient of restitution `e` for the `'impulse'` response.
+   * Falls back to per-body restitution when omitted. Ignored by `'push'`.
+   */
+  restitution?: FixedPoint;
 
   /**
    * Optional custom tick provider.

--- a/phalanx-physics/src/systems/PhysicsSystem.ts
+++ b/phalanx-physics/src/systems/PhysicsSystem.ts
@@ -308,16 +308,29 @@ export class PhysicsSystem extends GameSystem {
         ? FP._1
         : FP.Div(FP.Add(restitutionA, restitutionB), FP.FromFloat(2));
 
-      // Resolve collision
-      this.resolveCollision(
-        manifold,
-        restitution,
-        physIndexA, physIndexB,
-        transformIndexA, transformIndexB,
-        physVelocityX, physVelocityZ,
-        physMass, physIsStatic,
-        fpPosXArr, fpPosZArr,
-      );
+      // Resolve collision using the configured response model.
+      if (this.config.collisionResponse === 'impulse') {
+        const e = this.config.restitution ?? restitution;
+        this.resolveImpulse(
+          manifold,
+          e,
+          physIndexA, physIndexB,
+          transformIndexA, transformIndexB,
+          physVelocityX, physVelocityZ,
+          physMass, physIsStatic,
+          fpPosXArr, fpPosZArr,
+        );
+      } else {
+        this.resolveCollision(
+          manifold,
+          restitution,
+          physIndexA, physIndexB,
+          transformIndexA, transformIndexB,
+          physVelocityX, physVelocityZ,
+          physMass, physIsStatic,
+          fpPosXArr, fpPosZArr,
+        );
+      }
 
       // Emit collision event
       const event: CollisionEvent = {
@@ -396,6 +409,106 @@ export class PhysicsSystem extends GameSystem {
       const newBZ = FP.Add(posBZ, FP.Mul(nz, sepB));
       fpPosXArr[transformIndexB] = FP.ToRaw(newBX);
       fpPosZArr[transformIndexB] = FP.ToRaw(newBZ);
+    }
+  }
+
+  /**
+   * Resolve a single collision with a momentum-conserving elastic impulse
+   * along the contact normal (XZ plane), plus positional separation.
+   *
+   * Implements the legacy Chapayev formula:
+   *   j = (1 + e) * velAlongNormal / (1/mA + 1/mB)
+   * applied as vA -= j/mA * n, vB += j/mB * n, guarded by the "skip if
+   * separating" test (velAlongNormal <= 0). Static bodies are treated as
+   * having infinite mass (inverse mass 0). Only X/Z are touched; velocityY is
+   * left untouched for other consumers.
+   *
+   * The manifold normal points from A to B (n = (posB - posA)/dist), matching
+   * the legacy convention.
+   */
+  private resolveImpulse(
+    manifold: CollisionManifold,
+    restitution: FixedPoint,
+    physIndexA: number, physIndexB: number,
+    transformIndexA: number, transformIndexB: number,
+    physVelocityX: BigInt64Array, physVelocityZ: BigInt64Array,
+    physMass: BigInt64Array, physIsStatic: Uint8Array,
+    fpPosXArr: BigInt64Array, fpPosZArr: BigInt64Array,
+  ): void {
+    const isStaticA = physIsStatic[physIndexA] === 1;
+    const isStaticB = physIsStatic[physIndexB] === 1;
+
+    // Both static — nothing to do
+    if (isStaticA && isStaticB) return;
+
+    const nx = manifold.normalX;
+    const nz = manifold.normalZ;
+
+    // Inverse masses (static bodies have infinite mass -> inverse mass 0).
+    const invMassA = isStaticA ? FP._0 : FP.Div(FP._1, FP.FromRaw(physMass[physIndexA]));
+    const invMassB = isStaticB ? FP._0 : FP.Div(FP._1, FP.FromRaw(physMass[physIndexB]));
+    const invMassSum = FP.Add(invMassA, invMassB);
+    if (FP.Lte(invMassSum, FP._0)) return;
+
+    // Relative velocity of A with respect to B, projected on the normal.
+    const velAx = FP.FromRaw(physVelocityX[physIndexA]);
+    const velAz = FP.FromRaw(physVelocityZ[physIndexA]);
+    const velBx = FP.FromRaw(physVelocityX[physIndexB]);
+    const velBz = FP.FromRaw(physVelocityZ[physIndexB]);
+
+    const dvx = FP.Sub(velAx, velBx);
+    const dvz = FP.Sub(velAz, velBz);
+    const velAlongNormal = FP.Add(FP.Mul(dvx, nx), FP.Mul(dvz, nz));
+
+    // Positional separation (split the overlap evenly among dynamic bodies).
+    const overlap = manifold.penetration;
+    if (isStaticA) {
+      this.separateBody(transformIndexB, nx, nz, overlap, fpPosXArr, fpPosZArr, true);
+    } else if (isStaticB) {
+      this.separateBody(transformIndexA, nx, nz, overlap, fpPosXArr, fpPosZArr, false);
+    } else {
+      const half = FP.Mul(overlap, SEPARATION_HALF);
+      this.separateBody(transformIndexA, nx, nz, half, fpPosXArr, fpPosZArr, false);
+      this.separateBody(transformIndexB, nx, nz, half, fpPosXArr, fpPosZArr, true);
+    }
+
+    // Bodies separating already — skip the impulse (do not "suck" them together).
+    if (FP.Lte(velAlongNormal, FP._0)) return;
+
+    // Impulse scalar: j = (1 + e) * velAlongNormal / (invMassA + invMassB)
+    const onePlusE = FP.Add(FP._1, restitution);
+    const j = FP.Div(FP.Mul(onePlusE, velAlongNormal), invMassSum);
+
+    if (!isStaticA) {
+      const scale = FP.Mul(j, invMassA); // j / mA
+      physVelocityX[physIndexA] = FP.ToRaw(FP.Sub(velAx, FP.Mul(nx, scale)));
+      physVelocityZ[physIndexA] = FP.ToRaw(FP.Sub(velAz, FP.Mul(nz, scale)));
+    }
+    if (!isStaticB) {
+      const scale = FP.Mul(j, invMassB); // j / mB
+      physVelocityX[physIndexB] = FP.ToRaw(FP.Add(velBx, FP.Mul(nx, scale)));
+      physVelocityZ[physIndexB] = FP.ToRaw(FP.Add(velBz, FP.Mul(nz, scale)));
+    }
+  }
+
+  /** Move one body along the contact normal by `amount` (dir=+1 for B side, -1 for A side). */
+  private separateBody(
+    transformIndex: number,
+    nx: FixedPoint, nz: FixedPoint,
+    amount: FixedPoint,
+    fpPosXArr: BigInt64Array, fpPosZArr: BigInt64Array,
+    positive: boolean,
+  ): void {
+    const posX = FP.FromRaw(fpPosXArr[transformIndex]);
+    const posZ = FP.FromRaw(fpPosZArr[transformIndex]);
+    const dx = FP.Mul(nx, amount);
+    const dz = FP.Mul(nz, amount);
+    if (positive) {
+      fpPosXArr[transformIndex] = FP.ToRaw(FP.Add(posX, dx));
+      fpPosZArr[transformIndex] = FP.ToRaw(FP.Add(posZ, dz));
+    } else {
+      fpPosXArr[transformIndex] = FP.ToRaw(FP.Sub(posX, dx));
+      fpPosZArr[transformIndex] = FP.ToRaw(FP.Sub(posZ, dz));
     }
   }
 

--- a/phalanx-physics/src/systems/PhysicsSystem.ts
+++ b/phalanx-physics/src/systems/PhysicsSystem.ts
@@ -304,7 +304,7 @@ export class PhysicsSystem extends GameSystem {
       // Compute restitution: average of both bodies, default to 1.0 if both unset
       const restitutionA = FP.FromRaw(physRestitution[physIndexA]);
       const restitutionB = FP.FromRaw(physRestitution[physIndexB]);
-      const restitution = (restitutionA === FP._0 && restitutionB === FP._0)
+      const restitution = (FP.Eq(restitutionA, FP._0) && FP.Eq(restitutionB, FP._0))
         ? FP._1
         : FP.Div(FP.Add(restitutionA, restitutionB), FP.FromFloat(2));
 
@@ -444,9 +444,13 @@ export class PhysicsSystem extends GameSystem {
     const nx = manifold.normalX;
     const nz = manifold.normalZ;
 
-    // Inverse masses (static bodies have infinite mass -> inverse mass 0).
-    const invMassA = isStaticA ? FP._0 : FP.Div(FP._1, FP.FromRaw(physMass[physIndexA]));
-    const invMassB = isStaticB ? FP._0 : FP.Div(FP._1, FP.FromRaw(physMass[physIndexB]));
+    // Inverse masses. Static bodies — and non-static bodies with mass <= 0 —
+    // are treated as infinite mass (inverse mass 0), which also avoids a
+    // divide-by-zero on FP.Div(1, 0).
+    const massA = FP.FromRaw(physMass[physIndexA]);
+    const massB = FP.FromRaw(physMass[physIndexB]);
+    const invMassA = (isStaticA || FP.Lte(massA, FP._0)) ? FP._0 : FP.Div(FP._1, massA);
+    const invMassB = (isStaticB || FP.Lte(massB, FP._0)) ? FP._0 : FP.Div(FP._1, massB);
     const invMassSum = FP.Add(invMassA, invMassB);
     if (FP.Lte(invMassSum, FP._0)) return;
 

--- a/phalanx-physics/src/types.ts
+++ b/phalanx-physics/src/types.ts
@@ -42,8 +42,27 @@ export interface PhysicsConfig {
   maxVelocity: FixedPoint;
   /** Default friction applied per sub-step when entity friction field is 0 */
   defaultFriction: FixedPoint;
-  /** Push strength for collision resolution */
+  /** Push strength for collision resolution (used by the 'push' response) */
   pushStrength: FixedPoint;
+  /**
+   * Collision response model.
+   * - `'push'` (default): positional separation with a mass-weighted push
+   *   velocity. Fast, stable, but does NOT conserve momentum — a fast body
+   *   slides past a slower one instead of knocking it away.
+   * - `'impulse'`: momentum-conserving elastic collision along the contact
+   *   normal (restitution coefficient `e`). Restores the "click / knock-away"
+   *   feel needed for games like Chapayev checkers.
+   *
+   * Default: `'push'`.
+   */
+  collisionResponse?: 'push' | 'impulse';
+  /**
+   * Coefficient of restitution `e` for the `'impulse'` response
+   * (0 = perfectly inelastic, 1 = perfectly elastic). When omitted, the
+   * impulse path falls back to the average of the two bodies' per-body
+   * restitution. Ignored by the `'push'` response.
+   */
+  restitution?: FixedPoint;
   /** Spatial hash grid cell size */
   gridCellSize: FixedPoint;
   /** World bounds for position clamping (optional) */

--- a/phalanx-physics/tests/impulseCollision.test.ts
+++ b/phalanx-physics/tests/impulseCollision.test.ts
@@ -58,6 +58,7 @@ describe('impulse collision response', () => {
     posX: number,
     velX: number,
     mass = 1,
+    restitution = 0.5,
   ): void {
     physicsStore.add(entityId, {
       velocityX: FP.ToRaw(FP.FromFloat(velX)),
@@ -65,7 +66,7 @@ describe('impulse collision response', () => {
       velocityZ: FP.ToRaw(FP._0),
       radius: FP.ToRaw(FP._1), // radius 1 -> sumR 2
       mass: FP.ToRaw(FP.FromFloat(mass)),
-      restitution: FP.ToRaw(FP.FromFloat(0.5)),
+      restitution: FP.ToRaw(FP.FromFloat(restitution)),
       friction: FP.ToRaw(FP._1),
       isStatic: 0,
       ignorePhysics: 0,
@@ -106,6 +107,53 @@ describe('impulse collision response', () => {
     // Striker stops, struck body carries the momentum.
     expect(velX(physicsStore, 1)).toBeCloseTo(0, 3);
     expect(velX(physicsStore, 2)).toBeCloseTo(10, 3);
+  });
+
+  it('non-static body with mass=0 is treated as infinite mass (no divide-by-zero, immovable)', () => {
+    const { system, physicsStore, transformStore } = setup({
+      collisionResponse: 'impulse',
+      restitution: FP.FromFloat(1.0),
+    });
+    // Body 1: non-static but mass = 0 -> must be treated as infinite mass.
+    addBody(physicsStore, transformStore, 1, -0.9, 10, 0);
+    // Body 2: normal dynamic body, stationary.
+    addBody(physicsStore, transformStore, 2, 0.9, 0, 1);
+
+    // Must not throw (guards FP.Div(1, 0)).
+    expect(() => system.step()).not.toThrow();
+
+    // Zero-mass body behaves as immovable: its velocity is unchanged.
+    expect(velX(physicsStore, 1)).toBeCloseTo(10, 3);
+    // The struck finite-mass body still receives the impulse and moves off.
+    expect(velX(physicsStore, 2)).toBeGreaterThan(0);
+  });
+
+  it('two zero-mass non-static bodies collide without throwing and neither is impulsed', () => {
+    const { system, physicsStore, transformStore } = setup({
+      collisionResponse: 'impulse',
+      restitution: FP.FromFloat(1.0),
+    });
+    addBody(physicsStore, transformStore, 1, -0.9, 10, 0);
+    addBody(physicsStore, transformStore, 2, 0.9, -10, 0);
+
+    // invMassSum == 0 -> early return, no divide-by-zero, velocities untouched.
+    expect(() => system.step()).not.toThrow();
+    expect(velX(physicsStore, 1)).toBeCloseTo(10, 3);
+    expect(velX(physicsStore, 2)).toBeCloseTo(-10, 3);
+  });
+
+  it('unset (zero) restitution on both bodies defaults to e=1.0 in push mode (FIX 1)', () => {
+    const { system, physicsStore, transformStore } = setup(); // push mode (default)
+    // Both bodies have raw-zero restitution: the "both unset -> default 1.0"
+    // branch must fire (value-equality via FP.Eq, not reference ===).
+    addBody(physicsStore, transformStore, 1, -0.9, 10, 1, 0);
+    addBody(physicsStore, transformStore, 2, 0.9, 0, 1, 0);
+
+    system.step();
+
+    // With the bug (restitution stuck at 0) pushForce would be 0 and the
+    // struck body would gain no push velocity. Defaulting to 1.0 pushes it.
+    expect(velX(physicsStore, 2)).toBeGreaterThan(0);
   });
 
   it('default push response does NOT conserve momentum (striker keeps moving)', () => {

--- a/phalanx-physics/tests/impulseCollision.test.ts
+++ b/phalanx-physics/tests/impulseCollision.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import {
+  EntityManager,
+  EventBus,
+  SystemContext,
+  SoAComponent,
+  type SoAComponentStore,
+} from '@phalanx-engine/ecs';
+import { PhysicsSystem } from '../src/systems/PhysicsSystem';
+import { PhysicsSoASchema } from '../src/components/PhysicsBodyComponent';
+import { TransformSoASchema } from '../src/components/TransformComponent';
+import type { PhysicsConfig } from '../src/types';
+import { addTransformRow } from './testTransformHelpers';
+
+function createConfig(overrides?: Partial<PhysicsConfig>): PhysicsConfig {
+  return {
+    // Tiny dt so integration barely moves the (already overlapping) bodies:
+    // this isolates the collision-response velocity change under test.
+    tickDt: FP.FromFloat(0.001),
+    subSteps: 1,
+    maxVelocity: FP.FromFloat(1000),
+    defaultFriction: FP.FromFloat(1.0), // no damping
+    pushStrength: FP.FromFloat(15.0),
+    gridCellSize: FP.FromFloat(4),
+    ...overrides,
+  };
+}
+
+describe('impulse collision response', () => {
+  let entityManager: EntityManager;
+  let eventBus: EventBus;
+  let context: SystemContext;
+
+  beforeEach(() => {
+    entityManager = new EntityManager();
+    eventBus = new EventBus();
+    context = new SystemContext(eventBus, entityManager);
+    SoAComponent.useEntityManager(entityManager);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function setup(overrides?: Partial<PhysicsConfig>) {
+    const system = new PhysicsSystem(createConfig(overrides));
+    system.init(context);
+    const physicsStore = entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+    const transformStore = entityManager.getOrCreateSoAStore(TransformSoASchema);
+    return { system, physicsStore, transformStore };
+  }
+
+  function addBody(
+    physicsStore: SoAComponentStore<typeof PhysicsSoASchema.definition>,
+    transformStore: SoAComponentStore<typeof TransformSoASchema.definition>,
+    entityId: number,
+    posX: number,
+    velX: number,
+    mass = 1,
+  ): void {
+    physicsStore.add(entityId, {
+      velocityX: FP.ToRaw(FP.FromFloat(velX)),
+      velocityY: FP.ToRaw(FP._0),
+      velocityZ: FP.ToRaw(FP._0),
+      radius: FP.ToRaw(FP._1), // radius 1 -> sumR 2
+      mass: FP.ToRaw(FP.FromFloat(mass)),
+      restitution: FP.ToRaw(FP.FromFloat(0.5)),
+      friction: FP.ToRaw(FP._1),
+      isStatic: 0,
+      ignorePhysics: 0,
+      lastX: 0,
+      lastZ: 0,
+    });
+    addTransformRow(transformStore, entityId, posX, 0);
+  }
+
+  const velX = (store: SoAComponentStore<typeof PhysicsSoASchema.definition>, id: number) =>
+    FP.ToFloat(FP.FromRaw(store.arrays.velocityX[store.indexOf(id)]));
+
+  it('equal-mass head-on at e=1 exchanges velocities', () => {
+    const { system, physicsStore, transformStore } = setup({
+      collisionResponse: 'impulse',
+      restitution: FP.FromFloat(1.0),
+    });
+    // Overlapping along X (dist 1.8 < sumR 2), moving toward each other.
+    addBody(physicsStore, transformStore, 1, -0.9, 10);
+    addBody(physicsStore, transformStore, 2, 0.9, -10);
+
+    system.step();
+
+    expect(velX(physicsStore, 1)).toBeCloseTo(-10, 3);
+    expect(velX(physicsStore, 2)).toBeCloseTo(10, 3);
+  });
+
+  it('moving body hitting stationary equal-mass body transfers momentum', () => {
+    const { system, physicsStore, transformStore } = setup({
+      collisionResponse: 'impulse',
+      restitution: FP.FromFloat(1.0),
+    });
+    addBody(physicsStore, transformStore, 1, -0.9, 10);
+    addBody(physicsStore, transformStore, 2, 0.9, 0);
+
+    system.step();
+
+    // Striker stops, struck body carries the momentum.
+    expect(velX(physicsStore, 1)).toBeCloseTo(0, 3);
+    expect(velX(physicsStore, 2)).toBeCloseTo(10, 3);
+  });
+
+  it('default push response does NOT conserve momentum (striker keeps moving)', () => {
+    const { system, physicsStore, transformStore } = setup(); // collisionResponse defaults to 'push'
+    addBody(physicsStore, transformStore, 1, -0.9, 10);
+    addBody(physicsStore, transformStore, 2, 0.9, 0);
+
+    system.step();
+
+    // Push only nudges apart; the striker retains most of its forward velocity.
+    expect(velX(physicsStore, 1)).toBeGreaterThan(1);
+    expect(velX(physicsStore, 2)).toBeGreaterThan(0);
+  });
+});

--- a/phalanx-server/package.json
+++ b/phalanx-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@phalanx-engine/server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Phalanx Engine Server - A game-agnostic deterministic lockstep multiplayer server with authentication, matchmaking, and command synchronization",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,89 @@ importers:
         specifier: ^8.20.0
         version: 8.56.1(eslint@9.39.3)(typescript@5.9.3)
 
+  abilities-playground:
+    dependencies:
+      '@phalanx-engine/abilities':
+        specifier: workspace:*
+        version: link:../phalanx-abilities
+      '@phalanx-engine/client':
+        specifier: workspace:*
+        version: link:../phalanx-client
+      '@phalanx-engine/ecs':
+        specifier: workspace:*
+        version: link:../phalanx-ecs
+      '@phalanx-engine/math':
+        specifier: workspace:*
+        version: link:../phalanx-math
+      '@phalanx-engine/physics':
+        specifier: workspace:*
+        version: link:../phalanx-physics
+      '@phalanx-engine/server':
+        specifier: workspace:*
+        version: link:../phalanx-server
+      three:
+        specifier: ^0.175.0
+        version: 0.175.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.30
+      '@types/three':
+        specifier: ^0.175.0
+        version: 0.175.0
+      concurrently:
+        specifier: ^9.1.2
+        version: 9.2.3
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.0.5
+        version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.30)(esbuild@0.27.2)(tsx@4.21.0)
+      vitest:
+        specifier: ^1.0.0
+        version: 1.6.1(@types/node@20.19.30)(happy-dom@20.8.9)(lightningcss@1.32.0)
+
+  arena-shooter:
+    dependencies:
+      '@babylonjs/core':
+        specifier: 8.53.0
+        version: 8.53.0
+      '@babylonjs/gui':
+        specifier: 8.53.0
+        version: 8.53.0(@babylonjs/core@8.53.0)
+      '@babylonjs/materials':
+        specifier: 8.53.0
+        version: 8.53.0(@babylonjs/core@8.53.0)
+      '@capacitor/android':
+        specifier: ^8.3.0
+        version: 8.3.0(@capacitor/core@8.3.0)
+      '@capacitor/cli':
+        specifier: ^8.3.0
+        version: 8.3.0
+      '@capacitor/core':
+        specifier: ^8.3.0
+        version: 8.3.0
+      '@phalanx-engine/ecs':
+        specifier: workspace:*
+        version: link:../phalanx-ecs
+      '@phalanx-engine/math':
+        specifier: workspace:*
+        version: link:../phalanx-math
+      '@phalanx-engine/physics':
+        specifier: workspace:*
+        version: link:../phalanx-physics
+    devDependencies:
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.2.4
+        version: 7.3.6(@types/node@24.12.4)(lightningcss@1.32.0)(tsx@4.21.0)
+
   chapaev:
     dependencies:
       '@capacitor/android':
@@ -139,6 +222,49 @@ importers:
       vitest:
         specifier: ^1.6.1
         version: 1.6.1(@types/node@20.19.30)(happy-dom@20.8.9)(lightningcss@1.32.0)
+
+  direct-strike-babylon-example:
+    dependencies:
+      '@babylonjs/core':
+        specifier: 8.53.0
+        version: 8.53.0
+      '@babylonjs/gui':
+        specifier: 8.53.0
+        version: 8.53.0(@babylonjs/core@8.53.0)
+      '@babylonjs/loaders':
+        specifier: 8.53.0
+        version: 8.53.0(@babylonjs/core@8.53.0)(babylonjs-gltf2interface@8.56.2)
+      '@phalanx-engine/client':
+        specifier: workspace:*
+        version: link:../phalanx-client
+      '@phalanx-engine/ecs':
+        specifier: workspace:*
+        version: link:../phalanx-ecs
+      '@phalanx-engine/math':
+        specifier: workspace:*
+        version: link:../phalanx-math
+      '@phalanx-engine/physics':
+        specifier: workspace:*
+        version: link:../phalanx-physics
+    devDependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.705.0
+        version: 3.1000.0
+      '@aws-sdk/lib-storage':
+        specifier: ^3.705.0
+        version: 3.1000.0(@aws-sdk/client-s3@3.1000.0)
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      mime-types:
+        specifier: ^3.0.2
+        version: 3.0.2
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: 8.0.5
+        version: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.4)(esbuild@0.27.2)(tsx@4.21.0)
 
   phalanx-abilities:
     devDependencies:
@@ -420,6 +546,25 @@ packages:
   '@aws/lambda-invoke-store@0.2.3':
     resolution: {integrity: sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==}
     engines: {node: '>=18.0.0'}
+
+  '@babylonjs/core@8.53.0':
+    resolution: {integrity: sha512-SQlXJkADI+JoZ4iH9qrKPvA9FyC8aYHKZSF7I7s2SQG716hcnd/z9zQz7e8oPkzXmBTPkC+apmhK4vZZmfuEBA==}
+
+  '@babylonjs/gui@8.53.0':
+    resolution: {integrity: sha512-PjJOeWWbhQTmL/QpFRtA6up53ZRK6hhvD0UdQJ5Dv8hqNh9omhDfIZCetoWrIfrtuWZauM+ayeb/UlW76H07aw==}
+    peerDependencies:
+      '@babylonjs/core': ^8.0.0
+
+  '@babylonjs/loaders@8.53.0':
+    resolution: {integrity: sha512-1TFE/Qo6VjEl8elpO2isB8npIG/jLPKaENZF76tmkQP0DBO9WchMwzxn+F+cwDfk/f+Ria4j+oaIythhLyxFYg==}
+    peerDependencies:
+      '@babylonjs/core': ^8.0.0
+      babylonjs-gltf2interface: ^8.0.0
+
+  '@babylonjs/materials@8.53.0':
+    resolution: {integrity: sha512-DoO80Ux7YZ0GPVEFVyrFeDqpisOjcN+qY5PGN3La3kAdSdxHzXkgHBb2maB4a8X/k3uzxzg+sCA6GED1LPk3Ew==}
+    peerDependencies:
+      '@babylonjs/core': ^8.6.0
 
   '@capacitor/android@8.3.0':
     resolution: {integrity: sha512-EQy6ByUuKayQBJmMm/e0byJiHavqsQHrvW23BuT2GNVQvenAvipqwaePiJHzrv2PZr7A0T0+se4kgDCeROj0mQ==}
@@ -1551,6 +1696,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  babylonjs-gltf2interface@8.56.2:
+    resolution: {integrity: sha512-c2k14C9mPR0pnfksjBdC4uXEos3t2IAYxcMgn5tI1OSC3aDfr6JAq4kADM4gfN9cUo2qIiDdSg6geUVeU8vi6w==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1628,6 +1776,10 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -1641,6 +1793,11 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  concurrently@9.2.3:
+    resolution: {integrity: sha512-ihjs0E2SxvDgq/MK418hX6YycQgKhsqxpbZuZbHo0yKfqDWdymWMjWYIpCIzqDDLLKClHlXev8whW/8WXmJ0BA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -1744,6 +1901,10 @@ packages:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -1902,6 +2063,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
@@ -2153,9 +2318,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -2314,10 +2487,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -2338,10 +2507,6 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
-
-  postcss@8.5.6:
-    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.9:
     resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
@@ -2405,6 +2570,10 @@ packages:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -2430,6 +2599,9 @@ packages:
     resolution: {integrity: sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2457,6 +2629,10 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2556,6 +2732,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   synckit@0.11.12:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
@@ -2704,6 +2884,46 @@ packages:
       terser:
         optional: true
 
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vite@8.0.5:
     resolution: {integrity: sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2835,9 +3055,21 @@ packages:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
     engines: {node: '>=0.4.0'}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
@@ -3307,6 +3539,21 @@ snapshots:
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.2.3': {}
+
+  '@babylonjs/core@8.53.0': {}
+
+  '@babylonjs/gui@8.53.0(@babylonjs/core@8.53.0)':
+    dependencies:
+      '@babylonjs/core': 8.53.0
+
+  '@babylonjs/loaders@8.53.0(@babylonjs/core@8.53.0)(babylonjs-gltf2interface@8.56.2)':
+    dependencies:
+      '@babylonjs/core': 8.53.0
+      babylonjs-gltf2interface: 8.56.2
+
+  '@babylonjs/materials@8.53.0(@babylonjs/core@8.53.0)':
+    dependencies:
+      '@babylonjs/core': 8.53.0
 
   '@capacitor/android@8.3.0(@capacitor/core@8.3.0)':
     dependencies:
@@ -4407,6 +4654,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  babylonjs-gltf2interface@8.56.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -4485,6 +4734,12 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4494,6 +4749,15 @@ snapshots:
   commander@12.1.0: {}
 
   concat-map@0.0.1: {}
+
+  concurrently@9.2.3:
+    dependencies:
+      chalk: 4.1.2
+      rxjs: 7.8.2
+      shell-quote: 1.8.4
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
 
   confbox@0.1.8: {}
 
@@ -4639,6 +4903,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   eslint-config-prettier@9.1.2(eslint@9.39.3):
@@ -4760,9 +5026,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -4806,6 +5072,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-caller-file@2.0.5: {}
 
   get-func-name@2.0.2: {}
 
@@ -5018,9 +5286,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mimic-fn@4.0.0: {}
 
@@ -5166,8 +5440,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pino-abstract-transport@3.0.0:
@@ -5201,12 +5473,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  postcss@8.5.6:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.9:
     dependencies:
@@ -5278,6 +5544,8 @@ snapshots:
 
   real-require@0.2.0: {}
 
+  require-directory@2.1.1: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -5346,6 +5614,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.55.1
       fsevents: 2.3.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
@@ -5361,6 +5633,8 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  shell-quote@1.8.4: {}
 
   siginfo@2.0.0: {}
 
@@ -5482,6 +5756,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   synckit@0.11.12:
     dependencies:
       '@pkgr/core': 0.2.9
@@ -5523,8 +5801,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinypool@0.8.4: {}
 
@@ -5628,7 +5906,7 @@ snapshots:
   vite@5.4.21(@types/node@20.19.30)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.6
+      postcss: 8.5.9
       rollup: 4.55.1
     optionalDependencies:
       '@types/node': 20.19.30
@@ -5638,12 +5916,26 @@ snapshots:
   vite@5.4.21(@types/node@24.12.4)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.21.5
-      postcss: 8.5.6
+      postcss: 8.5.9
       rollup: 4.55.1
     optionalDependencies:
       '@types/node': 24.12.4
       fsevents: 2.3.3
       lightningcss: 1.32.0
+
+  vite@7.3.6(@types/node@24.12.4)(lightningcss@1.32.0)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.2
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.4
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      tsx: 4.21.0
 
   vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@20.19.30)(esbuild@0.27.2)(tsx@4.21.0):
     dependencies:
@@ -5654,6 +5946,22 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 20.19.30
+      esbuild: 0.27.2
+      fsevents: 2.3.3
+      tsx: 4.21.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.4)(esbuild@0.27.2)(tsx@4.21.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.9
+      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 24.12.4
       esbuild: 0.27.2
       fsevents: 2.3.3
       tsx: 4.21.0
@@ -5778,7 +6086,21 @@ snapshots:
 
   xmlhttprequest-ssl@2.1.2: {}
 
+  y18n@5.0.8: {}
+
   yallist@5.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yauzl@2.10.0:
     dependencies:


### PR DESCRIPTION
## Problem

After Chapayev migrated to `@phalanx-engine/physics`, collisions lost their "click / knock-away" feel. The library's resolver is **push-based** — it separates overlapping bodies positionally and applies a mass-weighted push, but it does **not** conserve momentum. A flicked checker slides past the one it hits, and the struck checker barely moves.

## Fix (opt-in, default behavior unchanged)

Add a `collisionResponse` flag to `PhysicsConfig` selecting the resolution model:

- **`'push'` (default)** — existing behavior, byte-for-byte unchanged. arena-shooter, abilities-playground, and every other consumer keep exactly what they had.
- **`'impulse'`** — momentum-conserving elastic collision along the contact normal, restoring the legacy Chapayev physics.

The impulse path replicates the original chapaev formula (deterministic FixedPoint math on the XZ plane; `velocityY` untouched):

```
velAlongNormal = (vA - vB) · n            // n points A -> B
if velAlongNormal <= 0: skip              // bodies already separating
j = (1 + e) * velAlongNormal / (1/mA + 1/mB)
vA -= (j / mA) * n
vB += (j / mB) * n
```

plus even-split positional separation. Static bodies are treated as infinite mass (inverse mass 0), so walls reflect dynamic bodies without moving. The restitution `e` comes from `PhysicsConfig.restitution` when set, otherwise falls back to the per-body restitution average.

Chapayev opts in via `WorldBootstrapper` using its existing `RESTITUTION` constant (0.85).

## Files changed

- `phalanx-physics/src/types.ts` — `PhysicsConfig.collisionResponse?: 'push' | 'impulse'` (default `'push'`) + `restitution?`.
- `phalanx-physics/src/systems/PhysicsSystem.ts` — branch in `detectAndResolve`; new `resolveImpulse` + `separateBody` helpers. Push path untouched.
- `phalanx-physics/src/PhysicsWorldConfig.ts` / `PhysicsWorld.ts` — plumb the flags through the facade.
- `chapaev/src/core/WorldBootstrapper.ts` — `collisionResponse: 'impulse'`, `restitution: FP.FromFloat(RESTITUTION)`.
- `phalanx-physics/README.md` — document both modes, the restitution parameter, and when to use each.
- `phalanx-physics/tests/impulseCollision.test.ts` — new unit tests.

## Verification

- `pnpm --filter @phalanx-engine/physics build` — passes.
- `pnpm --filter @phalanx-engine/physics test` — **101 passed**, including 3 new impulse tests:
  - equal-mass head-on at `e=1` exchanges velocities;
  - moving body into stationary equal-mass body transfers momentum (striker stops, struck body carries it);
  - default `'push'` response does NOT conserve momentum (regression guard).
- `tsc -p chapaev/tsconfig.json --noEmit` — passes.
- `pnpm --filter chapaev build` — passes.

## Caveats

- Positional separation in impulse mode uses the legacy even (50/50) split among dynamic bodies rather than inverse-mass weighting, to match the original chapaev behavior 1:1.
- Only X/Z velocity/position are modified; `velocityY` is preserved for 3D consumers.