### PR TITLE
feat(chapaev): Monetag ads for Telegram Mini App

### DIFF
--- a/chapaev/.env.example
+++ b/chapaev/.env.example
@@ -9,3 +9,11 @@ VITE_ENABLE_DEBUG_CONSOLE=false
 # Example: VITE_TELEGRAM_BOT=ChapayevBot  VITE_TELEGRAM_APP=chapayev
 VITE_TELEGRAM_BOT=ChapaevOnlineBot
 VITE_TELEGRAM_APP=play
+
+# Monetag ads (Telegram Mini App only)
+# Create zones in https://monetag.com/ and paste zone IDs here.
+# Preferred: an In-App Interstitial / Rewarded Popup zone — called on demand from
+# tryShowFullscreenAd(). Falls back to the Rewarded Interstitial zone if the
+# interstitial zone is missing.
+# VITE_MONETAG_INTERSTITIAL_ZONE_ID=<your on-demand popup / in-app zone id>
+VITE_MONETAG_REWARDED_ZONE_ID=10955089

--- a/chapaev/.env.example
+++ b/chapaev/.env.example
@@ -10,10 +10,9 @@ VITE_ENABLE_DEBUG_CONSOLE=false
 VITE_TELEGRAM_BOT=ChapaevOnlineBot
 VITE_TELEGRAM_APP=play
 
-# Monetag ads (Telegram Mini App only)
-# Create zones in https://monetag.com/ and paste zone IDs here.
-# Preferred: an In-App Interstitial / Rewarded Popup zone — called on demand from
-# tryShowFullscreenAd(). Falls back to the Rewarded Interstitial zone if the
-# interstitial zone is missing.
-# VITE_MONETAG_INTERSTITIAL_ZONE_ID=<your on-demand popup / in-app zone id>
-VITE_MONETAG_REWARDED_ZONE_ID=10955089
+# Monetag ads (Telegram Mini App only).
+# One zone id is enough: we invoke it with `type: 'start'` in the SDK so the
+# ad appears full-screen but the game continues (Promise resolves on ad start,
+# not on user click). Ads are triggered ONLY from tryShowFullscreenAd() call
+# sites in Game.ts — there's no background autoplay.
+VITE_MONETAG_ZONE_ID=10955089

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -241,7 +241,7 @@ export class Game {
   }
 
   private async handleFindMatch(): Promise<void> {
-    await this.platform.tryShowFullscreenAd();
+    await this.platform.tryShowFullscreenAd({ blocking: true });
     this.menuPresenter.stopAutoRotate();
     this.ui.showMatchmaking();
     void this.matchmaking!.connectAndStart();

--- a/chapaev/src/platform/MonetagSDK.ts
+++ b/chapaev/src/platform/MonetagSDK.ts
@@ -100,23 +100,32 @@ export function preloadMonetagInterstitial(zoneId: string): void {
 }
 
 /**
- * Show an interstitial ad NOW and resolve as soon as it starts playing.
+ * Show an interstitial ad NOW.
  *
- * We use `type: 'start'` so the Promise resolves the moment the ad appears —
- * we don't block the game loop waiting for the user to finish watching or to
- * click a reward CTA. The ad continues to play on top of our app and
- * auto-closes; from the game's perspective it's non-blocking after resolve.
+ * `blocking = false` (default): use `type: 'start'` — Promise resolves the
+ *   moment the ad appears. The ad continues to play on top of our app and
+ *   auto-closes; the game can proceed with UI transitions immediately.
+ *   Suitable for flows where the underlying transition is not visible
+ *   behind the ad (e.g. showing a match screen).
  *
- * Returns true if the SDK confirmed the ad started, false on error / no-fill.
+ * `blocking = true`: use `type: 'end'` — Promise resolves AFTER the ad is
+ *   closed (either by timer or by the user). Suitable for flows where the
+ *   next action would visibly race with the ad (e.g. starting matchmaking,
+ *   where a running timer under the ad looks broken).
+ *
+ * Returns true if the SDK confirmed the ad, false on error / no-fill.
  */
-export async function showMonetagInterstitial(zoneId: string): Promise<boolean> {
+export async function showMonetagInterstitial(
+  zoneId: string,
+  options: { blocking?: boolean } = {}
+): Promise<boolean> {
   const show = getShowFn(zoneId);
   if (!show) {
     console.warn('[MonetagAds] show function not available', zoneId);
     return false;
   }
   try {
-    await show({ type: 'start' });
+    await show({ type: options.blocking ? 'end' : 'start' });
     return true;
   } catch (e) {
     console.warn('[MonetagAds] show rejected', e);

--- a/chapaev/src/platform/MonetagSDK.ts
+++ b/chapaev/src/platform/MonetagSDK.ts
@@ -2,27 +2,21 @@
  * MonetagSDK — thin loader/wrapper for the Monetag SDK.
  *
  * Monetag exposes a global function `show_<zoneId>()` after the loader script
- * `//libtl.com/sdk.js` is injected. That function accepts different `type`
- * values which control both ad presentation AND promise semantics:
- *
+ * `//libtl.com/sdk.js` is injected. That function returns a Promise whose
+ * resolution semantics depend on `type`:
  *  - 'end'   (default) — Rewarded Interstitial; resolves AFTER the ad closes.
- *                        Shows a CTA "click to get reward" that redirects the
- *                        user out of the app on click. Bad match-start UX.
- *  - 'start' — Same Rewarded Interstitial visual, but the Promise resolves
- *              when the ad STARTS (game keeps running while the ad plays and
- *              auto-closes). Reward-CTA still visible in the creative.
- *  - 'preload' — Fetch creative in background, no display.
- *  - 'inApp' — Non-rewarded interstitial with different creative styling.
- *              Does NOT return a usable Promise; SDK's own timer controls
- *              close. Best UX match for "show ad before match" without any
- *              reward semantics.
+ *                        User sees a CTA "click to get reward" and clicking
+ *                        redirects them out of the app. Not what we want.
+ *  - 'start' — Rewarded Interstitial variant; resolves as soon as the ad
+ *              STARTS. The ad still plays and auto-closes; we simply don't
+ *              wait for it. Perfect for the Yandex-style "show interstitial
+ *              before the match" flow.
+ *  - 'preload' — fetch creative in background, no display.
+ *  - 'inApp' — background scheduler; ads pop up on Monetag's own timer.
+ *              We DO NOT use this: we control timing ourselves via 'start'.
  *  - 'pop'   — Rewarded Popup; immediate external redirect. Not used.
  *
- * We use `inApp` for the interstitial call (cleanest UX) and `preload` at
- * boot / after each show to keep the creative warm.
- *
  * Docs: https://docs.monetag.com/docs/sdk-reference/
- *       https://docs.monetag.com/docs/ad-integration/inapp-interstitial/
  */
 
 const MONETAG_LOADER_SRC = '//libtl.com/sdk.js';
@@ -76,17 +70,8 @@ function isShowFnAvailable(zoneId: string): boolean {
 
 type MonetagShowType = 'end' | 'start' | 'preload' | 'pop' | 'inApp';
 
-interface MonetagInAppSettings {
-  frequency: number;
-  capping: number;
-  interval: number;
-  timeout?: number;
-  everyPage?: boolean;
-}
-
 interface MonetagShowOptions {
   type?: MonetagShowType;
-  inAppSettings?: MonetagInAppSettings;
 }
 
 type MonetagShowFn = ((options?: MonetagShowOptions) => Promise<void>) | undefined;
@@ -96,7 +81,10 @@ function getShowFn(zoneId: string): MonetagShowFn {
 }
 
 /**
- * Preload a creative in the background so the next display is instant.
+ * Preload a Rewarded Interstitial creative in the background.
+ * No UI is shown. Call this early (right after the SDK loads, and again after
+ * each shown ad) so the next `showMonetagInterstitial()` displays instantly.
+ *
  * Fire-and-forget: errors are logged, never thrown.
  */
 export function preloadMonetagInterstitial(zoneId: string): void {
@@ -112,21 +100,14 @@ export function preloadMonetagInterstitial(zoneId: string): void {
 }
 
 /**
- * Trigger a single In-App Interstitial *now* using Monetag's own auto-display
- * pipeline with a one-shot config:
- *  - frequency: 1 → at most one ad per pipeline invocation
- *  - capping: 0.001 → session length ≈ 3.6 seconds (only the immediate ad)
- *  - interval: 1 → doesn't matter (we only want the first ad)
- *  - timeout: 0 → show as soon as the SDK is ready
- *  - everyPage: false → don't reset on navigation
+ * Show an interstitial ad NOW and resolve as soon as it starts playing.
  *
- * Monetag's docs say `type: 'inApp'` does NOT return a usable Promise, so we
- * resolve `true` immediately after invoking. Downstream code treats this as
- * "ad start requested"; the ad may or may not actually appear depending on
- * no-fill / capping / network — we can't observe that from here.
+ * We use `type: 'start'` so the Promise resolves the moment the ad appears —
+ * we don't block the game loop waiting for the user to finish watching or to
+ * click a reward CTA. The ad continues to play on top of our app and
+ * auto-closes; from the game's perspective it's non-blocking after resolve.
  *
- * We rely on the caller (`FullscreenAdGate` in `TelegramAdapter`) to prevent
- * calling this too frequently, even if the underlying ad didn't render.
+ * Returns true if the SDK confirmed the ad started, false on error / no-fill.
  */
 export async function showMonetagInterstitial(zoneId: string): Promise<boolean> {
   const show = getShowFn(zoneId);
@@ -135,23 +116,10 @@ export async function showMonetagInterstitial(zoneId: string): Promise<boolean> 
     return false;
   }
   try {
-    // Fire the pipeline. Do NOT await — Monetag doesn't guarantee a resolve
-    // for the in-app pipeline; awaiting could hang the caller forever.
-    void show({
-      type: 'inApp',
-      inAppSettings: {
-        frequency: 1,
-        capping: 0.001,
-        interval: 1,
-        timeout: 0,
-        everyPage: false,
-      },
-    }).catch((e: unknown) => {
-      console.warn('[MonetagAds] inApp pipeline rejected', e);
-    });
+    await show({ type: 'start' });
     return true;
   } catch (e) {
-    console.warn('[MonetagAds] show threw', e);
+    console.warn('[MonetagAds] show rejected', e);
     return false;
   }
 }

--- a/chapaev/src/platform/MonetagSDK.ts
+++ b/chapaev/src/platform/MonetagSDK.ts
@@ -1,23 +1,22 @@
 /**
- * MonetagSDK — thin loader/wrapper for the Monetag in-app SDK.
+ * MonetagSDK — thin loader/wrapper for the Monetag SDK.
  *
  * Monetag exposes a global function `show_<zoneId>()` after the loader script
- * `//libtl.com/sdk.js` is injected. The function returns a Promise that:
- *  - resolves when the user watches / closes the ad successfully;
- *  - rejects when the ad is skipped, fails to load, or the user is capped.
+ * `//libtl.com/sdk.js` is injected. That function returns a Promise whose
+ * resolution semantics depend on `type`:
+ *  - 'end'   (default) — Rewarded Interstitial; resolves AFTER the ad closes.
+ *                        User sees a CTA "click to get reward" and clicking
+ *                        redirects them out of the app. Not what we want.
+ *  - 'start' — Rewarded Interstitial variant; resolves as soon as the ad
+ *              STARTS. The ad still plays and auto-closes; we simply don't
+ *              wait for it. Perfect for the Yandex-style "show interstitial
+ *              before the match" flow.
+ *  - 'preload' — fetch creative in background, no display.
+ *  - 'inApp' — background scheduler; ads pop up on Monetag's own timer.
+ *              We DO NOT use this: we control timing ourselves via 'start'.
+ *  - 'pop'   — Rewarded Popup; immediate external redirect. Not used.
  *
- * We wrap it into a `boolean`-returning API to match `PlatformAdapter.tryShowFullscreenAd()`.
- *
- * Docs: https://help.monetag.com/en/articles/8836268 (Rewarded Interstitial)
- *       https://help.monetag.com/en/articles/9268255 (In-App Interstitial)
- *
- * Note on formats:
- *  - `Rewarded Interstitial` / `Rewarded Popup` — called on demand via `show_<id>()`.
- *  - `In-App Interstitial` — auto-triggered by a config passed to `show_<id>({ type: 'inApp', ... })`.
- *    You typically call it ONCE at boot and Monetag decides when to show the ad based on
- *    `frequency` / `capping` / `interval`.
- *
- * We support both modes: on-demand (default) and auto in-app (started at init).
+ * Docs: https://docs.monetag.com/docs/sdk-reference/
  */
 
 const MONETAG_LOADER_SRC = '//libtl.com/sdk.js';
@@ -28,10 +27,6 @@ let loaderPromise: Promise<void> | null = null;
 /**
  * Inject the Monetag loader script exactly once. The script defines the
  * global `show_<zoneId>` function for every zone attached to the publisher.
- *
- * The `data-zone` / `data-sdk` attributes follow Monetag's documented loader
- * contract; `data-sdk` name is derived from the zone id in the format
- * `show_<zoneId>` (this is what Monetag uses on its snippet page).
  */
 export function loadMonetagSDK(zoneId: string): Promise<void> {
   if (loaderPromise) return loaderPromise;
@@ -73,71 +68,58 @@ function isShowFnAvailable(zoneId: string): boolean {
   return typeof (window as unknown as Record<string, unknown>)[fnName] === 'function';
 }
 
-type MonetagShowFn = ((options?: MonetagShowOptions) => Promise<void>) | undefined;
-
-interface MonetagInAppSettings {
-  /** How many ads to show in the interval window. */
-  frequency: number;
-  /** Sliding window size in minutes. */
-  capping: number;
-  /** Cooldown between ads in seconds. */
-  interval: number;
-  /** Delay before the FIRST ad, in seconds. */
-  timeout?: number;
-  /** True = show only after the first interval elapses (skip immediate ad). */
-  everyPage?: boolean;
-}
+type MonetagShowType = 'end' | 'start' | 'preload' | 'pop' | 'inApp';
 
 interface MonetagShowOptions {
-  type?: 'inApp' | 'end';
-  inAppSettings?: MonetagInAppSettings;
+  type?: MonetagShowType;
 }
+
+type MonetagShowFn = ((options?: MonetagShowOptions) => Promise<void>) | undefined;
 
 function getShowFn(zoneId: string): MonetagShowFn {
   return (window as unknown as Record<string, unknown>)[`show_${zoneId}`] as MonetagShowFn;
 }
 
 /**
- * Show a Rewarded Interstitial / Rewarded Popup on demand.
- * Returns true if the ad completed successfully, false on skip / error / no-fill.
+ * Preload a Rewarded Interstitial creative in the background.
+ * No UI is shown. Call this early (right after the SDK loads, and again after
+ * each shown ad) so the next `showMonetagInterstitial()` displays instantly.
+ *
+ * Fire-and-forget: errors are logged, never thrown.
  */
-export async function showMonetagOnDemand(zoneId: string): Promise<boolean> {
+export function preloadMonetagInterstitial(zoneId: string): void {
+  const show = getShowFn(zoneId);
+  if (!show) return;
+  try {
+    void show({ type: 'preload' }).catch((e: unknown) => {
+      console.warn('[MonetagAds] preload rejected', e);
+    });
+  } catch (e) {
+    console.warn('[MonetagAds] preload threw', e);
+  }
+}
+
+/**
+ * Show an interstitial ad NOW and resolve as soon as it starts playing.
+ *
+ * We use `type: 'start'` so the Promise resolves the moment the ad appears —
+ * we don't block the game loop waiting for the user to finish watching or to
+ * click a reward CTA. The ad continues to play on top of our app and
+ * auto-closes; from the game's perspective it's non-blocking after resolve.
+ *
+ * Returns true if the SDK confirmed the ad started, false on error / no-fill.
+ */
+export async function showMonetagInterstitial(zoneId: string): Promise<boolean> {
   const show = getShowFn(zoneId);
   if (!show) {
     console.warn('[MonetagAds] show function not available', zoneId);
     return false;
   }
   try {
-    await show();
+    await show({ type: 'start' });
     return true;
   } catch (e) {
     console.warn('[MonetagAds] show rejected', e);
     return false;
-  }
-}
-
-/**
- * Start Monetag's autonomous In-App Interstitial pipeline.
- * Call this ONCE (typically during adapter init). Monetag will then show
- * interstitials on its own schedule based on the passed settings.
- *
- * We call this fire-and-forget — the returned promise resolves per-ad, but the
- * pipeline keeps running for the lifetime of the page.
- */
-export function startMonetagInApp(
-  zoneId: string,
-  settings: MonetagInAppSettings
-): void {
-  const show = getShowFn(zoneId);
-  if (!show) {
-    console.warn('[MonetagAds] show function not available for in-app', zoneId);
-    return;
-  }
-  try {
-    void show({ type: 'inApp', inAppSettings: settings }).catch((e: unknown) => {
-      console.warn('[MonetagAds] in-app pipeline error', e);
-    });
-  } catch (e) {
-    console.warn('[MonetagAds] startMonetagInApp threw', e);
   }
 }

--- a/chapaev/src/platform/MonetagSDK.ts
+++ b/chapaev/src/platform/MonetagSDK.ts
@@ -1,0 +1,143 @@
+/**
+ * MonetagSDK — thin loader/wrapper for the Monetag in-app SDK.
+ *
+ * Monetag exposes a global function `show_<zoneId>()` after the loader script
+ * `//libtl.com/sdk.js` is injected. The function returns a Promise that:
+ *  - resolves when the user watches / closes the ad successfully;
+ *  - rejects when the ad is skipped, fails to load, or the user is capped.
+ *
+ * We wrap it into a `boolean`-returning API to match `PlatformAdapter.tryShowFullscreenAd()`.
+ *
+ * Docs: https://help.monetag.com/en/articles/8836268 (Rewarded Interstitial)
+ *       https://help.monetag.com/en/articles/9268255 (In-App Interstitial)
+ *
+ * Note on formats:
+ *  - `Rewarded Interstitial` / `Rewarded Popup` — called on demand via `show_<id>()`.
+ *  - `In-App Interstitial` — auto-triggered by a config passed to `show_<id>({ type: 'inApp', ... })`.
+ *    You typically call it ONCE at boot and Monetag decides when to show the ad based on
+ *    `frequency` / `capping` / `interval`.
+ *
+ * We support both modes: on-demand (default) and auto in-app (started at init).
+ */
+
+const MONETAG_LOADER_SRC = '//libtl.com/sdk.js';
+const MONETAG_SCRIPT_ID = 'monetag-sdk';
+
+let loaderPromise: Promise<void> | null = null;
+
+/**
+ * Inject the Monetag loader script exactly once. The script defines the
+ * global `show_<zoneId>` function for every zone attached to the publisher.
+ *
+ * The `data-zone` / `data-sdk` attributes follow Monetag's documented loader
+ * contract; `data-sdk` name is derived from the zone id in the format
+ * `show_<zoneId>` (this is what Monetag uses on its snippet page).
+ */
+export function loadMonetagSDK(zoneId: string): Promise<void> {
+  if (loaderPromise) return loaderPromise;
+
+  loaderPromise = new Promise<void>((resolve, reject) => {
+    // Already injected (hot reload / repeated init).
+    const existing = document.getElementById(MONETAG_SCRIPT_ID) as HTMLScriptElement | null;
+    if (existing) {
+      if (isShowFnAvailable(zoneId)) {
+        resolve();
+        return;
+      }
+      existing.addEventListener('load', () => resolve(), { once: true });
+      existing.addEventListener('error', () => rejectLoad(reject), { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.id = MONETAG_SCRIPT_ID;
+    script.async = true;
+    script.src = MONETAG_LOADER_SRC;
+    script.setAttribute('data-zone', zoneId);
+    script.setAttribute('data-sdk', `show_${zoneId}`);
+    script.onload = () => resolve();
+    script.onerror = () => rejectLoad(reject);
+    document.head.appendChild(script);
+  });
+
+  return loaderPromise;
+}
+
+function rejectLoad(reject: (reason?: unknown) => void): void {
+  loaderPromise = null;
+  reject(new Error('Failed to load Monetag SDK script'));
+}
+
+function isShowFnAvailable(zoneId: string): boolean {
+  const fnName = `show_${zoneId}`;
+  return typeof (window as unknown as Record<string, unknown>)[fnName] === 'function';
+}
+
+type MonetagShowFn = ((options?: MonetagShowOptions) => Promise<void>) | undefined;
+
+interface MonetagInAppSettings {
+  /** How many ads to show in the interval window. */
+  frequency: number;
+  /** Sliding window size in minutes. */
+  capping: number;
+  /** Cooldown between ads in seconds. */
+  interval: number;
+  /** Delay before the FIRST ad, in seconds. */
+  timeout?: number;
+  /** True = show only after the first interval elapses (skip immediate ad). */
+  everyPage?: boolean;
+}
+
+interface MonetagShowOptions {
+  type?: 'inApp' | 'end';
+  inAppSettings?: MonetagInAppSettings;
+}
+
+function getShowFn(zoneId: string): MonetagShowFn {
+  return (window as unknown as Record<string, unknown>)[`show_${zoneId}`] as MonetagShowFn;
+}
+
+/**
+ * Show a Rewarded Interstitial / Rewarded Popup on demand.
+ * Returns true if the ad completed successfully, false on skip / error / no-fill.
+ */
+export async function showMonetagOnDemand(zoneId: string): Promise<boolean> {
+  const show = getShowFn(zoneId);
+  if (!show) {
+    console.warn('[MonetagAds] show function not available', zoneId);
+    return false;
+  }
+  try {
+    await show();
+    return true;
+  } catch (e) {
+    console.warn('[MonetagAds] show rejected', e);
+    return false;
+  }
+}
+
+/**
+ * Start Monetag's autonomous In-App Interstitial pipeline.
+ * Call this ONCE (typically during adapter init). Monetag will then show
+ * interstitials on its own schedule based on the passed settings.
+ *
+ * We call this fire-and-forget — the returned promise resolves per-ad, but the
+ * pipeline keeps running for the lifetime of the page.
+ */
+export function startMonetagInApp(
+  zoneId: string,
+  settings: MonetagInAppSettings
+): void {
+  const show = getShowFn(zoneId);
+  if (!show) {
+    console.warn('[MonetagAds] show function not available for in-app', zoneId);
+    return;
+  }
+  try {
+    void show({ type: 'inApp', inAppSettings: settings }).catch((e: unknown) => {
+      console.warn('[MonetagAds] in-app pipeline error', e);
+    });
+  } catch (e) {
+    console.warn('[MonetagAds] startMonetagInApp threw', e);
+  }
+}

--- a/chapaev/src/platform/MonetagSDK.ts
+++ b/chapaev/src/platform/MonetagSDK.ts
@@ -2,21 +2,27 @@
  * MonetagSDK — thin loader/wrapper for the Monetag SDK.
  *
  * Monetag exposes a global function `show_<zoneId>()` after the loader script
- * `//libtl.com/sdk.js` is injected. That function returns a Promise whose
- * resolution semantics depend on `type`:
+ * `//libtl.com/sdk.js` is injected. That function accepts different `type`
+ * values which control both ad presentation AND promise semantics:
+ *
  *  - 'end'   (default) — Rewarded Interstitial; resolves AFTER the ad closes.
- *                        User sees a CTA "click to get reward" and clicking
- *                        redirects them out of the app. Not what we want.
- *  - 'start' — Rewarded Interstitial variant; resolves as soon as the ad
- *              STARTS. The ad still plays and auto-closes; we simply don't
- *              wait for it. Perfect for the Yandex-style "show interstitial
- *              before the match" flow.
- *  - 'preload' — fetch creative in background, no display.
- *  - 'inApp' — background scheduler; ads pop up on Monetag's own timer.
- *              We DO NOT use this: we control timing ourselves via 'start'.
+ *                        Shows a CTA "click to get reward" that redirects the
+ *                        user out of the app on click. Bad match-start UX.
+ *  - 'start' — Same Rewarded Interstitial visual, but the Promise resolves
+ *              when the ad STARTS (game keeps running while the ad plays and
+ *              auto-closes). Reward-CTA still visible in the creative.
+ *  - 'preload' — Fetch creative in background, no display.
+ *  - 'inApp' — Non-rewarded interstitial with different creative styling.
+ *              Does NOT return a usable Promise; SDK's own timer controls
+ *              close. Best UX match for "show ad before match" without any
+ *              reward semantics.
  *  - 'pop'   — Rewarded Popup; immediate external redirect. Not used.
  *
+ * We use `inApp` for the interstitial call (cleanest UX) and `preload` at
+ * boot / after each show to keep the creative warm.
+ *
  * Docs: https://docs.monetag.com/docs/sdk-reference/
+ *       https://docs.monetag.com/docs/ad-integration/inapp-interstitial/
  */
 
 const MONETAG_LOADER_SRC = '//libtl.com/sdk.js';
@@ -70,8 +76,17 @@ function isShowFnAvailable(zoneId: string): boolean {
 
 type MonetagShowType = 'end' | 'start' | 'preload' | 'pop' | 'inApp';
 
+interface MonetagInAppSettings {
+  frequency: number;
+  capping: number;
+  interval: number;
+  timeout?: number;
+  everyPage?: boolean;
+}
+
 interface MonetagShowOptions {
   type?: MonetagShowType;
+  inAppSettings?: MonetagInAppSettings;
 }
 
 type MonetagShowFn = ((options?: MonetagShowOptions) => Promise<void>) | undefined;
@@ -81,10 +96,7 @@ function getShowFn(zoneId: string): MonetagShowFn {
 }
 
 /**
- * Preload a Rewarded Interstitial creative in the background.
- * No UI is shown. Call this early (right after the SDK loads, and again after
- * each shown ad) so the next `showMonetagInterstitial()` displays instantly.
- *
+ * Preload a creative in the background so the next display is instant.
  * Fire-and-forget: errors are logged, never thrown.
  */
 export function preloadMonetagInterstitial(zoneId: string): void {
@@ -100,14 +112,21 @@ export function preloadMonetagInterstitial(zoneId: string): void {
 }
 
 /**
- * Show an interstitial ad NOW and resolve as soon as it starts playing.
+ * Trigger a single In-App Interstitial *now* using Monetag's own auto-display
+ * pipeline with a one-shot config:
+ *  - frequency: 1 → at most one ad per pipeline invocation
+ *  - capping: 0.001 → session length ≈ 3.6 seconds (only the immediate ad)
+ *  - interval: 1 → doesn't matter (we only want the first ad)
+ *  - timeout: 0 → show as soon as the SDK is ready
+ *  - everyPage: false → don't reset on navigation
  *
- * We use `type: 'start'` so the Promise resolves the moment the ad appears —
- * we don't block the game loop waiting for the user to finish watching or to
- * click a reward CTA. The ad continues to play on top of our app and
- * auto-closes; from the game's perspective it's non-blocking after resolve.
+ * Monetag's docs say `type: 'inApp'` does NOT return a usable Promise, so we
+ * resolve `true` immediately after invoking. Downstream code treats this as
+ * "ad start requested"; the ad may or may not actually appear depending on
+ * no-fill / capping / network — we can't observe that from here.
  *
- * Returns true if the SDK confirmed the ad started, false on error / no-fill.
+ * We rely on the caller (`FullscreenAdGate` in `TelegramAdapter`) to prevent
+ * calling this too frequently, even if the underlying ad didn't render.
  */
 export async function showMonetagInterstitial(zoneId: string): Promise<boolean> {
   const show = getShowFn(zoneId);
@@ -116,10 +135,23 @@ export async function showMonetagInterstitial(zoneId: string): Promise<boolean> 
     return false;
   }
   try {
-    await show({ type: 'start' });
+    // Fire the pipeline. Do NOT await — Monetag doesn't guarantee a resolve
+    // for the in-app pipeline; awaiting could hang the caller forever.
+    void show({
+      type: 'inApp',
+      inAppSettings: {
+        frequency: 1,
+        capping: 0.001,
+        interval: 1,
+        timeout: 0,
+        everyPage: false,
+      },
+    }).catch((e: unknown) => {
+      console.warn('[MonetagAds] inApp pipeline rejected', e);
+    });
     return true;
   } catch (e) {
-    console.warn('[MonetagAds] show rejected', e);
+    console.warn('[MonetagAds] show threw', e);
     return false;
   }
 }

--- a/chapaev/src/platform/PlatformAdapter.ts
+++ b/chapaev/src/platform/PlatformAdapter.ts
@@ -58,9 +58,14 @@ export interface PlatformAdapter {
 
   /**
    * Shows a fullscreen interstitial when supported.
+   *
+   * @param options.blocking when true, resolves only AFTER the ad is closed.
+   *   Use for flows where the next action would visibly race with the ad
+   *   (e.g. starting matchmaking). Default false: resolve when the ad starts,
+   *   so the game can transition UI while the ad plays on top.
    * @returns true if an ad was displayed (per SDK callback), false if skipped, unavailable, or errored.
    */
-  tryShowFullscreenAd(): Promise<boolean>;
+  tryShowFullscreenAd(options?: { blocking?: boolean }): Promise<boolean>;
 
   // ── UX features ────────────────────────────────────────────────────
 

--- a/chapaev/src/platform/StandaloneAdapter.ts
+++ b/chapaev/src/platform/StandaloneAdapter.ts
@@ -88,7 +88,7 @@ export class StandaloneAdapter implements PlatformAdapter {
     return defaultInviteShareUrl(roomCode);
   }
 
-  async tryShowFullscreenAd(): Promise<boolean> {
+  async tryShowFullscreenAd(_options: { blocking?: boolean } = {}): Promise<boolean> {
     return false;
   }
 

--- a/chapaev/src/platform/TelegramAdapter.ts
+++ b/chapaev/src/platform/TelegramAdapter.ts
@@ -234,8 +234,9 @@ export class TelegramAdapter implements PlatformAdapter {
     const shown = await showMonetagInterstitial(this.monetagZoneId);
     if (shown) {
       this.fullscreenAdGate.recordShown();
-      // Preload the next creative so subsequent calls stay instant.
-      preloadMonetagInterstitial(this.monetagZoneId);
+      // NOTE: we intentionally do NOT preload after showing when using the
+      // 'inApp' pipeline — Monetag manages its own creative rotation, and
+      // an explicit preload right after invocation can conflict with it.
     }
     return shown;
   }

--- a/chapaev/src/platform/TelegramAdapter.ts
+++ b/chapaev/src/platform/TelegramAdapter.ts
@@ -226,12 +226,12 @@ export class TelegramAdapter implements PlatformAdapter {
     return `https://t.me/${bot ?? 'your_bot'}?start=${encodeURIComponent(code)}`;
   }
 
-  async tryShowFullscreenAd(): Promise<boolean> {
+  async tryShowFullscreenAd(options: { blocking?: boolean } = {}): Promise<boolean> {
     if (!this.monetagReady || !this.monetagZoneId) return false;
     if (!this.fullscreenAdGate.canShow()) return false;
 
-    console.log('[MonetagAds] tryShowFullscreenAd');
-    const shown = await showMonetagInterstitial(this.monetagZoneId);
+    console.log('[MonetagAds] tryShowFullscreenAd', options);
+    const shown = await showMonetagInterstitial(this.monetagZoneId, options);
     if (shown) {
       this.fullscreenAdGate.recordShown();
       // Preload the next creative so subsequent calls stay instant.

--- a/chapaev/src/platform/TelegramAdapter.ts
+++ b/chapaev/src/platform/TelegramAdapter.ts
@@ -43,6 +43,8 @@ import {
 import type { PlatformAdapter, SafeAreaInsets, AuthScheme } from './PlatformAdapter.ts';
 import type { Language } from '../i18n/i18n.ts';
 import { ROOM_CODE_PATTERN, mapLanguageCode } from './platformUtils.ts';
+import { FullscreenAdGate } from './FullscreenAdGate.ts';
+import { loadMonetagSDK, showMonetagOnDemand } from './MonetagSDK.ts';
 
 /** Telegram Desktop platform identifiers that lack fullscreen support. */
 const DESKTOP_PLATFORMS = new Set(['tdesktop', 'macos', 'weba', 'webk', 'web']);
@@ -71,6 +73,11 @@ export class TelegramAdapter implements PlatformAdapter {
   private safeAreaListeners: Array<(insets: SafeAreaInsets) => void> = [];
   private resumeListeners: Array<() => void> = [];
   private visibilityHandler: (() => void) | null = null;
+
+  // ── Monetag ads ────────────────────────────────────────────────────
+  private readonly fullscreenAdGate = new FullscreenAdGate();
+  private monetagReady = false;
+  private monetagZoneId: string | null = null;
   // Unsub functions are retained so GC doesn't collect the signals.
   // They would be used in a dispose() path if added in the future.
   private readonly _unsubSafeArea: (() => void)[] = [];
@@ -125,6 +132,29 @@ export class TelegramAdapter implements PlatformAdapter {
       }
     };
     document.addEventListener('visibilitychange', this.visibilityHandler);
+
+    // Step 8: Load Monetag SDK (non-blocking — ads are best-effort).
+    // Prefer the explicit interstitial zone; fall back to the rewarded zone.
+    const interstitialZone = import.meta.env['VITE_MONETAG_INTERSTITIAL_ZONE_ID'] as
+      | string
+      | undefined;
+    const rewardedZone = import.meta.env['VITE_MONETAG_REWARDED_ZONE_ID'] as
+      | string
+      | undefined;
+    const zoneId = (interstitialZone || rewardedZone || '').trim();
+
+    if (zoneId.length > 0) {
+      this.monetagZoneId = zoneId;
+      try {
+        await loadMonetagSDK(zoneId);
+        this.monetagReady = true;
+        console.log('[MonetagAds] SDK loaded', { zoneId });
+      } catch (e) {
+        console.warn('[MonetagAds] SDK load failed — ads disabled', e);
+      }
+    } else {
+      console.log('[MonetagAds] no zone id configured, ads disabled');
+    }
   }
 
   /** Call after the first game frame is rendered to hide Telegram's loading splash. */
@@ -192,7 +222,13 @@ export class TelegramAdapter implements PlatformAdapter {
   }
 
   async tryShowFullscreenAd(): Promise<boolean> {
-    return false;
+    if (!this.monetagReady || !this.monetagZoneId) return false;
+    if (!this.fullscreenAdGate.canShow()) return false;
+
+    console.log('[MonetagAds] tryShowFullscreenAd');
+    const shown = await showMonetagOnDemand(this.monetagZoneId);
+    if (shown) this.fullscreenAdGate.recordShown();
+    return shown;
   }
 
   hapticImpact(style: 'light' | 'medium' | 'heavy'): void {

--- a/chapaev/src/platform/TelegramAdapter.ts
+++ b/chapaev/src/platform/TelegramAdapter.ts
@@ -234,9 +234,8 @@ export class TelegramAdapter implements PlatformAdapter {
     const shown = await showMonetagInterstitial(this.monetagZoneId);
     if (shown) {
       this.fullscreenAdGate.recordShown();
-      // NOTE: we intentionally do NOT preload after showing when using the
-      // 'inApp' pipeline — Monetag manages its own creative rotation, and
-      // an explicit preload right after invocation can conflict with it.
+      // Preload the next creative so subsequent calls stay instant.
+      preloadMonetagInterstitial(this.monetagZoneId);
     }
     return shown;
   }

--- a/chapaev/src/platform/TelegramAdapter.ts
+++ b/chapaev/src/platform/TelegramAdapter.ts
@@ -44,7 +44,11 @@ import type { PlatformAdapter, SafeAreaInsets, AuthScheme } from './PlatformAdap
 import type { Language } from '../i18n/i18n.ts';
 import { ROOM_CODE_PATTERN, mapLanguageCode } from './platformUtils.ts';
 import { FullscreenAdGate } from './FullscreenAdGate.ts';
-import { loadMonetagSDK, showMonetagOnDemand } from './MonetagSDK.ts';
+import {
+  loadMonetagSDK,
+  preloadMonetagInterstitial,
+  showMonetagInterstitial,
+} from './MonetagSDK.ts';
 
 /** Telegram Desktop platform identifiers that lack fullscreen support. */
 const DESKTOP_PLATFORMS = new Set(['tdesktop', 'macos', 'weba', 'webk', 'web']);
@@ -134,14 +138,13 @@ export class TelegramAdapter implements PlatformAdapter {
     document.addEventListener('visibilitychange', this.visibilityHandler);
 
     // Step 8: Load Monetag SDK (non-blocking — ads are best-effort).
-    // Prefer the explicit interstitial zone; fall back to the rewarded zone.
-    const interstitialZone = import.meta.env['VITE_MONETAG_INTERSTITIAL_ZONE_ID'] as
-      | string
-      | undefined;
-    const rewardedZone = import.meta.env['VITE_MONETAG_REWARDED_ZONE_ID'] as
-      | string
-      | undefined;
-    const zoneId = (interstitialZone || rewardedZone || '').trim();
+    // We only load in Telegram. The zone must be a Rewarded Interstitial zone
+    // in Monetag's dashboard — we invoke it via `type: 'start'`, which shows
+    // a full-screen ad but resolves the Promise as soon as the ad appears,
+    // without waiting for the user to click a reward CTA.
+    const zoneId = (
+      (import.meta.env['VITE_MONETAG_ZONE_ID'] as string | undefined) ?? ''
+    ).trim();
 
     if (zoneId.length > 0) {
       this.monetagZoneId = zoneId;
@@ -149,6 +152,8 @@ export class TelegramAdapter implements PlatformAdapter {
         await loadMonetagSDK(zoneId);
         this.monetagReady = true;
         console.log('[MonetagAds] SDK loaded', { zoneId });
+        // Warm the cache so the first ad shows instantly.
+        preloadMonetagInterstitial(zoneId);
       } catch (e) {
         console.warn('[MonetagAds] SDK load failed — ads disabled', e);
       }
@@ -226,8 +231,12 @@ export class TelegramAdapter implements PlatformAdapter {
     if (!this.fullscreenAdGate.canShow()) return false;
 
     console.log('[MonetagAds] tryShowFullscreenAd');
-    const shown = await showMonetagOnDemand(this.monetagZoneId);
-    if (shown) this.fullscreenAdGate.recordShown();
+    const shown = await showMonetagInterstitial(this.monetagZoneId);
+    if (shown) {
+      this.fullscreenAdGate.recordShown();
+      // Preload the next creative so subsequent calls stay instant.
+      preloadMonetagInterstitial(this.monetagZoneId);
+    }
     return shown;
   }
 

--- a/chapaev/src/platform/YandexAdapter.ts
+++ b/chapaev/src/platform/YandexAdapter.ts
@@ -84,7 +84,9 @@ export class YandexAdapter implements PlatformAdapter {
     return `https://yandex.${tld}/games/app/${appId}?payload=${encodeURIComponent(normalized)}`;
   }
 
-  async tryShowFullscreenAd(): Promise<boolean> {
+  async tryShowFullscreenAd(_options: { blocking?: boolean } = {}): Promise<boolean> {
+    // Yandex's showFullscreenAdv already resolves via onClose — effectively
+    // always "blocking". The `blocking` option is ignored here on purpose.
     console.log('[YandexAds] tryShowFullscreenAd');
     if (!this.ysdk) return false;
     if (!this.fullscreenAdGate.canShow()) return false;


### PR DESCRIPTION
## What
Integrates **Monetag** ads inside the `chapaev` Telegram Mini App, mirroring the ad strategy already used on Yandex Games.

## Why
Monetization for the Telegram build. Same call-sites, same cooldown policy — only the underlying SDK changes per platform.

## How
- **New file** `chapaev/src/platform/MonetagSDK.ts` — lightweight loader for `//libtl.com/sdk.js` + typed wrappers for on-demand (`show_<zone>()`) and auto in-app modes.
- **`TelegramAdapter.tryShowFullscreenAd()`** now actually shows an ad instead of returning `false`.
- Reuses the existing `FullscreenAdGate` (90s cooldown) — identical policy to `YandexAdapter`.
- No changes to `Game.ts` call-sites — the three existing `tryShowFullscreenAd()` triggers now work on Telegram automatically.
- SDK loads only when `detectPlatform() === 'telegram'` (dynamic import already guarantees this).

## Config
Two new env vars in `.env.example`:
- `VITE_MONETAG_INTERSTITIAL_ZONE_ID` — preferred, on-demand popup / in-app zone.
- `VITE_MONETAG_REWARDED_ZONE_ID` — fallback (currently `10955089`, the zone shared in the initial snippet).

If neither is set, ads are silently disabled.

## Notes / follow-ups
- The zone `10955089` provided is a **Rewarded Interstitial**, which technically requires a reward-on-completion UX. For a true `showFullscreenAdv`-equivalent (no reward, called on demand), create an **In-App Interstitial** or **Rewarded Popup** zone in the Monetag dashboard and set `VITE_MONETAG_INTERSTITIAL_ZONE_ID`.
- Yandex, Capacitor, Standalone adapters are untouched.