### PR TITLE
feat(chapaev): CrazyGames SDK v3 + muteAudio + isInstantMultiplayer (PR #1)

### DIFF
--- a/chapaev/src/config/AudioSettings.ts
+++ b/chapaev/src/config/AudioSettings.ts
@@ -21,6 +21,17 @@ class AudioSettingsStore {
   private data: AudioSettingsData;
   private readonly listeners: ChangeListener[] = [];
 
+  /**
+   * Transient master mute, layered ON TOP of the user's volume preferences
+   * without overwriting them. Used for platform-driven muting (CrazyGames
+   * `settings.muteAudio`, in-ad muting, etc.). Never persisted: it reflects a
+   * runtime host/ad state, not a user choice, so a page reload starts unmuted
+   * and re-syncs from the SDK. When `true`, `effective*Volume` returns 0 while
+   * `musicVolume`/`sfxVolume` keep the real values — so opening the in-game
+   * audio settings during a mute never clobbers what the player had set.
+   */
+  private masterMuted = false;
+
   constructor() {
     this.data = this.load();
   }
@@ -42,6 +53,30 @@ class AudioSettingsStore {
   public set sfxVolume(value: number) {
     this.data.sfxVolume = Math.max(0, Math.min(1, value));
     this.save();
+    this.notify();
+  }
+
+  /** Music volume after applying master mute. Consumers should read this. */
+  public get effectiveMusicVolume(): number {
+    return this.masterMuted ? 0 : this.data.musicVolume;
+  }
+
+  /** SFX volume after applying master mute. Consumers should read this. */
+  public get effectiveSfxVolume(): number {
+    return this.masterMuted ? 0 : this.data.sfxVolume;
+  }
+
+  public get isMasterMuted(): boolean {
+    return this.masterMuted;
+  }
+
+  /**
+   * Toggle transient master mute. Idempotent: a no-op change doesn't notify.
+   * Not persisted (see `masterMuted` docs).
+   */
+  public setMasterMuted(muted: boolean): void {
+    if (this.masterMuted === muted) return;
+    this.masterMuted = muted;
     this.notify();
   }
 
@@ -67,8 +102,14 @@ class AudioSettingsStore {
         if (typeof parsed === 'object' && parsed !== null) {
           const obj = parsed as Record<string, unknown>;
           return {
-            musicVolume: typeof obj['musicVolume'] === 'number' ? obj['musicVolume'] : DEFAULTS.musicVolume,
-            sfxVolume: typeof obj['sfxVolume'] === 'number' ? obj['sfxVolume'] : DEFAULTS.sfxVolume,
+            musicVolume:
+              typeof obj['musicVolume'] === 'number'
+                ? obj['musicVolume']
+                : DEFAULTS.musicVolume,
+            sfxVolume:
+              typeof obj['sfxVolume'] === 'number'
+                ? obj['sfxVolume']
+                : DEFAULTS.sfxVolume,
           };
         }
       }
@@ -89,4 +130,3 @@ class AudioSettingsStore {
 
 /** Global audio settings instance */
 export const audioSettings = new AudioSettingsStore();
-

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -15,7 +15,10 @@ import { GameHUDScreen } from '../ui/screens/GameHUD.ts';
 import { bindHUDToWorld } from '../ui/HUDBindings.ts';
 import { bootstrapWorld } from './WorldBootstrapper.ts';
 import { PauseController } from './PauseController.ts';
-import type { MatchFoundEvent, ReconnectStateEvent } from '@phalanx-engine/client';
+import type {
+  MatchFoundEvent,
+  ReconnectStateEvent,
+} from '@phalanx-engine/client';
 import type { PlatformAdapter } from '../platform/PlatformAdapter.ts';
 import { t } from '../i18n/i18n.ts';
 import { generateBotOpponentDisplayName } from '../util/botOpponentName.ts';
@@ -120,6 +123,17 @@ export class Game {
     const persistedCode = this.recovery!.loadColdStartCode();
     if (persistedCode) {
       void this.privateRoom!.coldStartRecover(persistedCode);
+      return;
+    }
+
+    // Instant Multiplayer (CrazyGames): launched from the Multiplayer landing
+    // page or a party invite with no specific room to join — create a fresh
+    // joinable private room straight away instead of showing the menu, so
+    // friends can join immediately. Checked AFTER deep-link / cold-start so an
+    // explicit room to join always wins over spawning a new empty one.
+    if (this.platform.isInstantMultiplayer?.()) {
+      console.log('[Game] Instant multiplayer — creating room on launch');
+      void this.privateRoom!.createRoom();
       return;
     }
 

--- a/chapaev/src/platform/CrazyGamesAdapter.ts
+++ b/chapaev/src/platform/CrazyGamesAdapter.ts
@@ -16,10 +16,11 @@ const ZERO_INSETS: SafeAreaInsets = { top: 0, right: 0, bottom: 0, left: 0 };
 const GUEST_ID_KEY = 'chapaev_guest_id';
 
 const CRAZYGAMES_SDK_SCRIPT_ID = 'crazygames-sdk';
-const CRAZYGAMES_SDK_SRC = 'https://sdk.crazygames.com/crazygames-sdk-v2.js';
+const CRAZYGAMES_SDK_SRC = 'https://sdk.crazygames.com/crazygames-sdk-v3.js';
 
 /**
- * CrazyGames environment as reported by `SDK.environment`.
+ * CrazyGames environment as reported by `SDK.environment` (synchronous getter
+ * in v3).
  * - `local`      — running the CrazyGames dev/QA harness (or `?useLocalSdk=true`).
  * - `crazygames` — embedded in the real crazygames.com portal iframe. Ads work here.
  * - `disabled`   — served from any other origin (e.g. our own domain
@@ -32,17 +33,29 @@ type AdType = 'midgame' | 'rewarded';
 interface CrazyAdCallbacks {
   adStarted?: () => void;
   adFinished?: () => void;
-  adError?: (error: unknown) => void;
+  adError?: (error: unknown, errorData?: unknown) => void;
 }
+
+/** Subset of `SDK.game.settings` we consume. */
+interface CrazyGameSettings {
+  muteAudio?: boolean;
+  disableChat?: boolean;
+}
+
+type SettingsChangeListener = (newSettings: CrazyGameSettings) => void;
 
 interface CrazyGamesSDK {
   /**
-   * Async environment probe. Resolves to the current environment. Also
-   * supports a `(error, environment)` node-style callback, but we use the
-   * promise form.
+   * v3 requires explicit async initialisation before any module is usable.
+   * The SDK is unusable until this resolves.
    */
-  getEnvironment: () => Promise<CrazyEnvironment>;
+  init: () => Promise<void>;
+
+  /** Synchronous environment getter in v3 (was async `getEnvironment()` in v2). */
+  readonly environment: CrazyEnvironment;
+
   ad: {
+    /** v3 ad request. Callbacks only — promises are not supported for ads. */
     requestAd: (type: AdType, callbacks: CrazyAdCallbacks) => void;
   };
   game: {
@@ -52,6 +65,16 @@ interface CrazyGamesSDK {
     gameplayStart?: () => void;
     /** Mark the end of active gameplay (menu, results, pause). */
     gameplayStop?: () => void;
+    /** Host-controlled game settings (mute, chat). */
+    readonly settings?: CrazyGameSettings;
+    /** Register a listener fired whenever host game settings change. */
+    addSettingsChangeListener?: (listener: SettingsChangeListener) => void;
+    removeSettingsChangeListener?: (listener: SettingsChangeListener) => void;
+    /**
+     * True when the user should be dropped directly into a joinable multiplayer
+     * room (e.g. launched from the Multiplayer landing page or a party).
+     */
+    readonly isInstantMultiplayer?: boolean;
   };
 }
 
@@ -74,14 +97,25 @@ function createGuestUserId(): string {
 }
 
 /**
- * CrazyGamesAdapter — wraps the CrazyGames HTML5 SDK v2.
+ * CrazyGamesAdapter — wraps the CrazyGames HTML5 SDK **v3**.
  *
  * Design rules (mirrors the other adapters):
  * - The SDK script is injected only under this adapter, so it never loads on
  *   our own domain or inside Telegram.
+ * - v3 requires `await SDK.init()` before any module call; `environment` is a
+ *   synchronous getter afterwards.
  * - Ads are shown via `SDK.ad.requestAd('midgame', …)`. Frequency capping is
  *   owned by CrazyGames — we intentionally do NOT use FullscreenAdGate here
  *   (calling requestAd too often just triggers an adError, which we swallow).
+ * - Audio muting has TWO sources, both routed through the transient
+ *   `audioSettings.setMasterMuted()` master flag (never persisted, never
+ *   clobbers the player's own volume sliders):
+ *     1. host `settings.muteAudio` — takes priority over in-game audio settings
+ *        (CrazyGames requirement), synced on init + via settings listener;
+ *     2. an active midgame ad — muted on `adStarted`, restored on
+ *        `adFinished`/`adError`.
+ *   The effective mute is the OR of the two, so an ad ending never un-mutes a
+ *   host that still wants silence, and vice-versa.
  * - No SDK call is ever made from ECS Simulation.step() / System.update().
  * - Ads only actually play when `environment === 'crazygames'`. On our own
  *   domain the environment is `disabled` and every ad call resolves to `false`
@@ -95,12 +129,14 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   private userId: string | null = null;
   private resumeListeners: Array<() => void> = [];
   private visibilityHandler: (() => void) | null = null;
+  private settingsListener: SettingsChangeListener | null = null;
 
   /** True while a midgame ad is on screen — prevents overlapping requests. */
   private adInFlight = false;
 
-  /** Volumes captured before muting for an ad, restored when it ends. */
-  private mutedVolumes: { music: number; sfx: number } | null = null;
+  /** Latched mute state from each source; effective mute is their OR. */
+  private hostMuted = false;
+  private adMuted = false;
 
   /** Tracks whether gameplayStart was emitted, to keep start/stop balanced. */
   private gameplayActive = false;
@@ -108,20 +144,30 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   async init(): Promise<void> {
     this.userId = this.loadOrCreateUserId();
 
-    // Load the SDK best-effort. A failure here must not block the game — we
-    // just fall back to an ad-free experience.
+    // Load + initialise the SDK best-effort. A failure here must not block the
+    // game — we just fall back to an ad-free, unmuted experience.
     try {
       await this.injectSDKScript();
       const sdk = window.CrazyGames?.SDK ?? null;
-      this.sdk = sdk;
-      // getEnvironment() is async in SDK v2 (promise or callback form).
-      this.environment = sdk ? await sdk.getEnvironment() : 'disabled';
-      console.log('[CrazyGames] SDK ready', { environment: this.environment });
+      if (sdk) {
+        // v3: must await init() before touching any module or `environment`.
+        await sdk.init();
+        this.sdk = sdk;
+        this.environment = sdk.environment ?? 'disabled';
+      }
+      console.log('[CrazyGames] SDK v3 ready', {
+        environment: this.environment,
+      });
     } catch (e) {
-      console.warn('[CrazyGames] SDK load failed — running ad-free', e);
+      console.warn('[CrazyGames] SDK load/init failed — running ad-free', e);
       this.sdk = null;
       this.environment = 'disabled';
     }
+
+    // Sync host mute preference and subscribe to changes. Off-portal the
+    // settings object is absent, so this is a clean no-op.
+    this.syncHostMute();
+    this.subscribeToSettingsChanges();
 
     this.visibilityHandler = () => {
       if (document.visibilityState === 'visible') {
@@ -147,7 +193,7 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   }
 
   getAuthScheme(): AuthScheme {
-    // CrazyGames auth (user account SDK) is not integrated yet — treat as guest.
+    // CrazyGames auth (User module) is not integrated yet — treat as guest.
     return 'guest';
   }
 
@@ -167,6 +213,21 @@ export class CrazyGamesAdapter implements PlatformAdapter {
     // Inside the CrazyGames iframe `window.location` is our own embedded URL,
     // so a plain ?ROOM= link still resolves back to a playable instance.
     return defaultInviteShareUrl(roomCode);
+  }
+
+  /**
+   * CrazyGames "instant multiplayer" flag. When true, the launcher (e.g. the
+   * Multiplayer landing page or a party invite) expects us to drop the player
+   * straight into a freshly-created, joinable room instead of the main menu.
+   * False/absent off-portal.
+   */
+  isInstantMultiplayer(): boolean {
+    if (this.environment === 'disabled') return false;
+    try {
+      return this.sdk?.game.isInstantMultiplayer === true;
+    } catch {
+      return false;
+    }
   }
 
   async tryShowFullscreenAd(
@@ -196,24 +257,24 @@ export class CrazyGamesAdapter implements PlatformAdapter {
       try {
         this.sdk!.ad.requestAd('midgame', {
           adStarted: () => {
-            console.log('[CrazyGames] ad started — pausing game');
-            this.setGameMuted(true);
+            console.log('[CrazyGames] ad started — muting game');
+            this.setAdMuted(true);
           },
           adFinished: () => {
             console.log('[CrazyGames] ad finished');
-            this.setGameMuted(false);
+            this.setAdMuted(false);
             finish(true);
           },
-          adError: (error: unknown) => {
+          adError: (error: unknown, errorData?: unknown) => {
             // Fired when no ad is available or the request is throttled.
-            console.warn('[CrazyGames] ad error', error);
-            this.setGameMuted(false);
+            console.warn('[CrazyGames] ad error', error, errorData);
+            this.setAdMuted(false);
             finish(false);
           },
         });
       } catch (e) {
         console.warn('[CrazyGames] requestAd threw', e);
-        this.setGameMuted(false);
+        this.setAdMuted(false);
         finish(false);
       }
     });
@@ -279,36 +340,53 @@ export class CrazyGamesAdapter implements PlatformAdapter {
     // Not applicable inside the portal iframe.
   }
 
-  // ── Private ────────────────────────────────────────────────────────
+  // ── Private: audio muting ──────────────────────────────────────────
 
   /**
-   * Mute the game audio while an ad plays. The CrazyGames iframe keeps our
-   * canvas alive underneath the ad, so we silence sound (rather than pausing
-   * the deterministic sim, which is server-authoritative in online matches).
-   * Volumes are captured on mute and restored on unmute so we never clobber
-   * the player's own settings.
+   * Read the host's `settings.muteAudio` and latch it. CrazyGames requires
+   * this to take priority over in-game audio settings. Off-portal the settings
+   * object is undefined and we leave the host-mute latch false.
    */
-  private setGameMuted(muted: boolean): void {
+  private syncHostMute(): void {
+    let muted = false;
     try {
-      if (muted) {
-        // Guard against double-mute (e.g. adStarted firing twice).
-        if (this.mutedVolumes) return;
-        this.mutedVolumes = {
-          music: audioSettings.musicVolume,
-          sfx: audioSettings.sfxVolume,
-        };
-        audioSettings.musicVolume = 0;
-        audioSettings.sfxVolume = 0;
-      } else {
-        if (!this.mutedVolumes) return;
-        audioSettings.musicVolume = this.mutedVolumes.music;
-        audioSettings.sfxVolume = this.mutedVolumes.sfx;
-        this.mutedVolumes = null;
-      }
+      muted = this.sdk?.game.settings?.muteAudio === true;
     } catch {
-      // ignore
+      muted = false;
+    }
+    this.hostMuted = muted;
+    this.applyMasterMute();
+  }
+
+  private subscribeToSettingsChanges(): void {
+    if (!this.sdk?.game.addSettingsChangeListener) return;
+    this.settingsListener = (newSettings: CrazyGameSettings) => {
+      this.hostMuted = newSettings?.muteAudio === true;
+      this.applyMasterMute();
+    };
+    try {
+      this.sdk.game.addSettingsChangeListener(this.settingsListener);
+    } catch (e) {
+      console.warn('[CrazyGames] addSettingsChangeListener failed', e);
+      this.settingsListener = null;
     }
   }
+
+  private setAdMuted(muted: boolean): void {
+    this.adMuted = muted;
+    this.applyMasterMute();
+  }
+
+  /**
+   * Push the OR of every mute source into the shared transient master mute.
+   * Reading `audioSettings.effective*Volume` elsewhere then reflects it without
+   * ever touching the persisted user volumes.
+   */
+  private applyMasterMute(): void {
+    audioSettings.setMasterMuted(this.hostMuted || this.adMuted);
+  }
+
+  // ── Private: identity & SDK bootstrap ──────────────────────────────
 
   private loadOrCreateUserId(): string {
     try {

--- a/chapaev/src/platform/PlatformAdapter.ts
+++ b/chapaev/src/platform/PlatformAdapter.ts
@@ -123,5 +123,13 @@ export interface PlatformAdapter {
    * Must be balanced with `onGameplayStart`. Optional.
    */
   onGameplayStop?(): void;
-}
 
+  /**
+   * Portal-driven "drop the player straight into a joinable multiplayer room"
+   * signal. CrazyGames sets this when the game is launched from the Multiplayer
+   * landing page or a party invite; when true, the boot flow should create a
+   * fresh private room instead of showing the main menu, so friends can join
+   * immediately. Adapters without this concept omit it (treated as false).
+   */
+  isInstantMultiplayer?(): boolean;
+}

--- a/chapaev/src/systems/SoundSystem.ts
+++ b/chapaev/src/systems/SoundSystem.ts
@@ -391,20 +391,22 @@ export class SoundSystem extends GameSystem {
     if (!this.audioCtx) return;
 
     this.sfxMasterGain = this.audioCtx.createGain();
-    this.sfxMasterGain.gain.value = audioSettings.sfxVolume;
+    this.sfxMasterGain.gain.value = audioSettings.effectiveSfxVolume;
     this.sfxMasterGain.connect(this.audioCtx.destination);
 
     this.bgmMasterGain = this.audioCtx.createGain();
-    this.bgmMasterGain.gain.value = audioSettings.musicVolume;
+    this.bgmMasterGain.gain.value = audioSettings.effectiveMusicVolume;
     this.bgmMasterGain.connect(this.audioCtx.destination);
 
-    // Live-update volumes when the user changes settings
+    // Live-update volumes when the user changes settings OR the platform
+    // master-mute toggles (ads, CrazyGames settings.muteAudio). Reading the
+    // effective volumes folds both concerns into one subscription.
     this.settingsUnsub = audioSettings.onChange(() => {
       if (this.sfxMasterGain) {
-        this.sfxMasterGain.gain.value = audioSettings.sfxVolume;
+        this.sfxMasterGain.gain.value = audioSettings.effectiveSfxVolume;
       }
       if (this.bgmMasterGain) {
-        this.bgmMasterGain.gain.value = audioSettings.musicVolume;
+        this.bgmMasterGain.gain.value = audioSettings.effectiveMusicVolume;
       }
     });
   }


### PR DESCRIPTION
## Что это

PR #1 из серии по подготовке Chapaev к публикации на **CrazyGames**. Безопасный фундамент: миграция SDK на v3 и обязательные не-мультиплеерные требования QA. Room API (invite link/button, updateRoom, join listener) — отдельным PR #2.

## Изменения

### 1. Миграция CrazyGames SDK v2 → v3
- Скрипт `crazygames-sdk-v2.js` → **`crazygames-sdk-v3.js`**.
- v3 требует `await SDK.init()` перед любым обращением к модулям — добавлено в `CrazyGamesAdapter.init()`.
- `environment` в v3 — **синхронный геттер** (был async `getEnvironment()`); типы и логика обновлены.
- `ad.requestAd` — колбэки остаются (промисы для рекламы не поддерживаются), `adError` теперь `(error, errorData)`.

### 2. Поддержка `settings.muteAudio` (обязательное требование)
CrazyGames требует, чтобы host-настройка mute **имела приоритет над внутренними настройками звука**.
- Синк `SDK.game.settings.muteAudio` на init + подписка через `addSettingsChangeListener`.
- Реклама (`adStarted`/`adFinished`) и host-mute сведены к **OR** через единый транзиентный master-mute — окончание рекламы не размьютит host, который всё ещё хочет тишины, и наоборот.

### 3. `AudioSettings`: master-mute без порчи пользовательских настроек
- Добавлен **непистируемый** `masterMuted` + геттеры `effectiveMusicVolume` / `effectiveSfxVolume`.
- Открытие настроек звука во время платформенного mute больше **не затирает** реальные громкости игрока.
- `SoundSystem` читает effective-громкости; слайдеры в настройках по-прежнему показывают пользовательские значения.

### 4. `isInstantMultiplayer`
- Новый опциональный метод в интерфейсе `PlatformAdapter`.
- `CrazyGamesAdapter` читает `SDK.game.isInstantMultiplayer`.
- `Game.start()`: при instant-флаге сразу создаёт joinable-комнату вместо меню — **после** deep-link и cold-start recovery (явная комната для джойна всегда важнее).

## Проверки
- `tsc --noEmit` — чисто
- `vite build` — OK (CrazyGamesAdapter в отдельном чанке ~4.2 kB, SDK грузится только на портале)
- `eslint` — 0 errors (остались только существующие `no-console` warnings, по стилю проекта)

## Не входит (→ PR #2)
- `inviteLink` / `showInviteButton`
- `updateRoom` / `isJoinable` / `leftRoom`
- `addJoinRoomListener` + чтение `inviteParams` на старте

## Как протестировать
Запуск в CrazyGames-харнессе: `?useLocalSdk=true`. Локальная проверка mute: `?muteAudio=true`.
