### PR TITLE
feat(chapaev): CrazyGames room API — invite button, updateRoom, join listener

### DIFF
--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -73,6 +73,8 @@ export class Game {
   private flickInputSystem: FlickInputSystem | null = null;
   private commandFlushUnsubscribe: (() => void) | null = null;
   private reconnectStateUnsubscribe: (() => void) | null = null;
+  /** Unsubscribe for the portal live party-invite join listener. */
+  private joinRoomUnsubscribe: (() => void) | null = null;
   private localTeam: TeamTag = TeamTag.White;
   private hasSentClientReady = false;
   private inGameFlag = false;
@@ -123,6 +125,18 @@ export class Game {
     const persistedCode = this.recovery!.loadColdStartCode();
     if (persistedCode) {
       void this.privateRoom!.coldStartRecover(persistedCode);
+      return;
+    }
+
+    // Portal invite cold-launch (CrazyGames): the game was opened from a
+    // friend's party invite carrying a room code. This is a *separate* channel
+    // from the `?ROOM=` / Telegram / Yandex deep-link consumed above, so it
+    // can't double-fire. Join as a guest; wins over instant-multiplayer since
+    // an explicit room to join beats spawning a fresh empty one.
+    const inviteRoomCode = this.platform.getInviteRoomCode?.() ?? null;
+    if (inviteRoomCode) {
+      console.log('[Game] Launched from invite — joining room', inviteRoomCode);
+      void this.privateRoom!.joinRoom(inviteRoomCode);
       return;
     }
 
@@ -202,6 +216,7 @@ export class Game {
     this.privateRoom = new PrivateRoomCoordinator(
       this.ctx,
       this.recovery,
+      this.platform,
       {
         uiManager: this.ui.uiManager,
         matchmaking: this.ui.matchmaking,
@@ -228,6 +243,19 @@ export class Game {
         onQueueTimeoutFallbackAI: () => this.startMatchmakingSubstituteAI(),
       }
     );
+
+    // Live party-invite joins (CrazyGames): the player accepts an invite while
+    // the game is already running (no reload). Ignore it mid-match — Chapaev is
+    // 2/2 and we don't hot-swap an active game — otherwise join the room.
+    this.joinRoomUnsubscribe =
+      this.platform.onJoinRoomRequest?.((roomCode) => {
+        if (this.inGameFlag) {
+          console.log('[Game] Ignoring party invite — already in a match');
+          return;
+        }
+        console.log('[Game] Party invite accepted — joining room', roomCode);
+        void this.privateRoom!.joinRoom(roomCode);
+      }) ?? null;
   }
 
   private getNetworkOptions(): NetworkManagerOptions {
@@ -680,6 +708,8 @@ export class Game {
     this.commandFlushUnsubscribe = null;
     this.reconnectStateUnsubscribe?.();
     this.reconnectStateUnsubscribe = null;
+    this.joinRoomUnsubscribe?.();
+    this.joinRoomUnsubscribe = null;
     if (this.world) {
       this.world.stop();
       this.world.dispose();

--- a/chapaev/src/network/PrivateRoomCoordinator.ts
+++ b/chapaev/src/network/PrivateRoomCoordinator.ts
@@ -1,6 +1,7 @@
 import type { CountdownEvent, MatchFoundEvent } from '@phalanx-engine/client';
 import type { NetworkContext } from './NetworkContext.ts';
 import type { RoomRecoveryManager } from './RoomRecoveryManager.ts';
+import type { PlatformAdapter } from '../platform/PlatformAdapter.ts';
 import type { UIManager } from '../ui/UIManager.ts';
 import type { MatchmakingScreen } from '../ui/screens/Matchmaking.ts';
 import type { PrivateMatchScreen } from '../ui/screens/PrivateMatch.ts';
@@ -31,9 +32,17 @@ interface UIRefs {
  * coordinator does not need its own copy of that timer.
  */
 export class PrivateRoomCoordinator {
+  /**
+   * Room the local player is currently in, tracked so the portal room state
+   * (CrazyGames Multiplayer module) can be announced on join and cleared on
+   * leave. Null when not in any private room.
+   */
+  private currentRoomCode: string | null = null;
+
   constructor(
     private readonly ctx: NetworkContext,
     private readonly recovery: RoomRecoveryManager,
+    private readonly platform: PlatformAdapter,
     private readonly ui: UIRefs,
     private readonly callbacks: PrivateRoomCallbacks
   ) {}
@@ -60,6 +69,10 @@ export class PrivateRoomCoordinator {
       // socket can be torn down at any moment on mobile.
       this.recovery.startTrackingHostRoom(roomCode);
 
+      // Announce the joinable room to the portal + show the native invite CTA
+      // so friends can be pulled in while we sit on the waiting screen.
+      this.enterPortalRoom(roomCode);
+
       uiManager.hideScreen('matchmaking');
       privateMatch.showWaiting(roomCode);
       uiManager.showScreen('private-match');
@@ -76,6 +89,7 @@ export class PrivateRoomCoordinator {
       matchmaking.setStatus(t('net.connectionError'));
       matchmaking.stopTimer();
       this.recovery.stop();
+      this.leavePortalRoom();
       this.callbacks.onCancelled();
     }
   }
@@ -140,6 +154,12 @@ export class PrivateRoomCoordinator {
         gameStartEvent.randomSeed
       );
 
+      // The guest is now in an active, full room. Announce the association so
+      // the portal treats the player as in-room (non-joinable) rather than
+      // free-roaming; no invite button for the joining side.
+      this.currentRoomCode = normalizedCode;
+      this.closePortalRoom();
+
       this.ctx.manager.setMatchData(matchData);
       this.ctx.cleanupConnectListeners();
       this.recovery.stop();
@@ -155,6 +175,7 @@ export class PrivateRoomCoordinator {
       matchmaking.setStatus(t('net.errorPrefix', { message }));
       matchmaking.stopTimer();
       this.recovery.stop();
+      this.leavePortalRoom();
       setTimeout(() => this.callbacks.onCancelled(), 2500);
     }
   }
@@ -187,17 +208,24 @@ export class PrivateRoomCoordinator {
         this.recovery.stop();
         privateMatch.stopWaitingTimer();
         uiManager.hideScreen('private-match');
+        // Recovery as host failed — fall back to joining as a guest, which
+        // manages its own portal room state from scratch.
+        this.leavePortalRoom();
         await this.joinRoom(normalizedCode);
         return;
       }
 
       this.recovery.resumeTrackingHostRoom(normalizedCode);
+      // Reclaimed the room as host — re-announce it as joinable to the portal
+      // (matchPromise will close it once the second player arrives).
+      this.enterPortalRoom(normalizedCode);
       await matchPromise;
     } catch (error) {
       console.error('[PrivateRoom] Deep-link room open failed:', error);
       matchmaking.setStatus(t('net.connectionError'));
       matchmaking.stopTimer();
       this.recovery.stop();
+      this.leavePortalRoom();
       this.callbacks.onCancelled();
     }
   }
@@ -221,6 +249,9 @@ export class PrivateRoomCoordinator {
       this.recovery.resumeTrackingHostRoom(code);
       const matchPromise = this.awaitMatchStart(matchmaking);
 
+      // Reclaimed our host room after a hard reload — re-announce it joinable.
+      this.enterPortalRoom(code);
+
       await this.recovery.tryRecover();
       // Either matchPromise resolves (server's pending-recover replayed
       // match-found → game-start) or we sit on the waiting screen.
@@ -231,6 +262,7 @@ export class PrivateRoomCoordinator {
       // and only `returnToMainMenu`s on terminal outcomes itself. If we
       // get here some unexpected error escaped — fall back.
       this.recovery.stop();
+      this.leavePortalRoom();
       this.callbacks.onCancelled();
     }
   }
@@ -240,7 +272,39 @@ export class PrivateRoomCoordinator {
     this.ui.privateMatch.stopWaitingTimer();
     this.ui.matchmaking.stopTimer();
     this.recovery.stop();
+    this.leavePortalRoom();
     this.callbacks.onCancelled();
+  }
+
+  // ── Portal room-state announcements ──────────────────────────────
+  // Mirror the private-room lifecycle to the platform (CrazyGames Multiplayer
+  // module). Every method is a clean no-op on adapters that don't implement
+  // the optional room API (Telegram, Yandex, standalone).
+
+  /** Player has entered a joinable room: announce it + surface an invite CTA. */
+  private enterPortalRoom(roomCode: string): void {
+    this.currentRoomCode = roomCode;
+    this.platform.updateRoom?.(roomCode, true);
+    this.platform.showInviteButton?.(roomCode);
+  }
+
+  /**
+   * Room can no longer be joined (match starting / room full). Keep the room
+   * association but flip it closed and drop the invite CTA. Chapaev is a fixed
+   * 2-player game, so a started match is always full.
+   */
+  private closePortalRoom(): void {
+    if (this.currentRoomCode) {
+      this.platform.updateRoom?.(this.currentRoomCode, false);
+    }
+    this.platform.hideInviteButton?.();
+  }
+
+  /** Player left the room entirely (cancel / error / return to menu). */
+  private leavePortalRoom(): void {
+    this.currentRoomCode = null;
+    this.platform.hideInviteButton?.();
+    this.platform.leftRoom?.();
   }
 
   // ── Internals ────────────────────────────────────────────────────
@@ -297,6 +361,10 @@ export class PrivateRoomCoordinator {
       const matchData = await matchFoundPromise;
       privateMatch.stopWaitingTimer();
       matchmaking.stopTimer();
+
+      // Second player is in — the room is now full (Chapaev is 2/2). Tell the
+      // portal it's no longer joinable and retire the invite button.
+      this.closePortalRoom();
 
       trackMatchFound('private');
 

--- a/chapaev/src/platform/CrazyGamesAdapter.ts
+++ b/chapaev/src/platform/CrazyGamesAdapter.ts
@@ -9,6 +9,7 @@ import {
   mapLanguageCode,
   defaultInviteShareUrl,
   consumeUrlRoomCode,
+  ROOM_CODE_PATTERN,
 } from './platformUtils.ts';
 import { audioSettings } from '../config/AudioSettings.ts';
 
@@ -17,6 +18,9 @@ const GUEST_ID_KEY = 'chapaev_guest_id';
 
 const CRAZYGAMES_SDK_SCRIPT_ID = 'crazygames-sdk';
 const CRAZYGAMES_SDK_SRC = 'https://sdk.crazygames.com/crazygames-sdk-v3.js';
+
+/** Key under which we round-trip our private-room code in `inviteParams`. */
+const INVITE_ROOM_KEY = 'roomCode';
 
 /**
  * CrazyGames environment as reported by `SDK.environment` (synchronous getter
@@ -43,6 +47,15 @@ interface CrazyGameSettings {
 }
 
 type SettingsChangeListener = (newSettings: CrazyGameSettings) => void;
+
+/**
+ * Free-form invite payload the portal round-trips between the inviter and the
+ * invitee. We only ever put our room code in it, under the `roomCode` key.
+ */
+type CrazyInviteParams = Record<string, string | number | boolean>;
+
+/** Fires while the game is running when the player accepts a party invite. */
+type JoinRoomListener = (inviteParams: CrazyInviteParams | null) => void;
 
 interface CrazyGamesSDK {
   /**
@@ -75,6 +88,35 @@ interface CrazyGamesSDK {
      * room (e.g. launched from the Multiplayer landing page or a party).
      */
     readonly isInstantMultiplayer?: boolean;
+
+    // ── Multiplayer / room module (v3) ───────────────────────────────
+    /**
+     * Invite payload the game was cold-launched with, or null when the launch
+     * was not from an invite. We stash our room code under `roomCode`.
+     */
+    readonly inviteParams?: CrazyInviteParams | null;
+    /**
+     * Announce the current room + joinable state to the portal. Any subset of
+     * fields may be sent; we always send `roomId` + `isJoinable` and, on
+     * create, an `inviteParams` payload so shared links carry the room code.
+     */
+    updateRoom?: (options: {
+      roomId?: string;
+      isJoinable?: boolean;
+      inviteParams?: CrazyInviteParams;
+    }) => void;
+    /** Announce the player left their current room. */
+    leftRoom?: () => void;
+    /** Show the portal's native invite button for a room. */
+    showInviteButton?: (options: {
+      roomId?: string;
+      inviteParams?: CrazyInviteParams;
+    }) => string | void;
+    /** Hide the portal's native invite button. */
+    hideInviteButton?: () => void;
+    /** Register a listener fired when the player accepts a live party invite. */
+    addJoinRoomListener?: (listener: JoinRoomListener) => void;
+    removeJoinRoomListener?: (listener: JoinRoomListener) => void;
   };
 }
 
@@ -130,6 +172,12 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   private resumeListeners: Array<() => void> = [];
   private visibilityHandler: (() => void) | null = null;
   private settingsListener: SettingsChangeListener | null = null;
+
+  /** Wrappers around consumer join callbacks, kept for later removal. */
+  private joinRoomListeners = new Map<
+    (roomCode: string) => void,
+    JoinRoomListener
+  >();
 
   /** True while a midgame ad is on screen — prevents overlapping requests. */
   private adInFlight = false;
@@ -228,6 +276,121 @@ export class CrazyGamesAdapter implements PlatformAdapter {
     } catch {
       return false;
     }
+  }
+
+  // ── Multiplayer room API ───────────────────────────────────────────
+  // Thin wrappers over `SDK.game.*` (the CrazyGames Multiplayer module). All
+  // are guarded so they cleanly no-op off-portal (`disabled`) or when running
+  // against an older SDK that lacks the method. The room code is our own
+  // private-room code, carried to the portal as `inviteParams.roomCode`.
+
+  /**
+   * Room code the game was cold-launched with, when opened from an invite.
+   * Reads `SDK.game.inviteParams.roomCode` and validates it against the shared
+   * room-code pattern so a malformed payload can't drive a bogus join. Null
+   * off-portal or for a normal (non-invite) launch.
+   */
+  getInviteRoomCode(): string | null {
+    if (this.environment === 'disabled') return null;
+    try {
+      return this.extractRoomCode(this.sdk?.game.inviteParams ?? null);
+    } catch (e) {
+      console.warn('[CrazyGames] reading inviteParams failed', e);
+      return null;
+    }
+  }
+
+  updateRoom(roomCode: string, isJoinable: boolean): void {
+    if (this.environment === 'disabled') return;
+    const roomId = roomCode.trim().toUpperCase();
+    try {
+      this.sdk?.game.updateRoom?.({
+        roomId,
+        isJoinable,
+        inviteParams: { [INVITE_ROOM_KEY]: roomId },
+      });
+    } catch (e) {
+      console.warn('[CrazyGames] updateRoom failed', e);
+    }
+  }
+
+  leftRoom(): void {
+    if (this.environment === 'disabled') return;
+    try {
+      this.sdk?.game.leftRoom?.();
+    } catch (e) {
+      console.warn('[CrazyGames] leftRoom failed', e);
+    }
+  }
+
+  showInviteButton(roomCode: string): void {
+    if (this.environment === 'disabled') return;
+    const roomId = roomCode.trim().toUpperCase();
+    try {
+      this.sdk?.game.showInviteButton?.({
+        roomId,
+        inviteParams: { [INVITE_ROOM_KEY]: roomId },
+      });
+    } catch (e) {
+      console.warn('[CrazyGames] showInviteButton failed', e);
+    }
+  }
+
+  hideInviteButton(): void {
+    if (this.environment === 'disabled') return;
+    try {
+      this.sdk?.game.hideInviteButton?.();
+    } catch (e) {
+      console.warn('[CrazyGames] hideInviteButton failed', e);
+    }
+  }
+
+  /**
+   * Subscribe to live party-invite joins. We wrap the consumer callback so the
+   * portal's raw `inviteParams` is decoded to our room code and validated
+   * before the game acts on it; an invite with a missing/invalid code is
+   * ignored rather than driving a bogus join.
+   */
+  onJoinRoomRequest(cb: (roomCode: string) => void): () => void {
+    if (
+      this.environment === 'disabled' ||
+      !this.sdk?.game.addJoinRoomListener
+    ) {
+      return () => {};
+    }
+
+    const wrapped: JoinRoomListener = (inviteParams) => {
+      const roomCode = this.extractRoomCode(inviteParams);
+      if (roomCode) cb(roomCode);
+    };
+    this.joinRoomListeners.set(cb, wrapped);
+
+    try {
+      this.sdk.game.addJoinRoomListener(wrapped);
+    } catch (e) {
+      console.warn('[CrazyGames] addJoinRoomListener failed', e);
+      this.joinRoomListeners.delete(cb);
+      return () => {};
+    }
+
+    return () => {
+      const listener = this.joinRoomListeners.get(cb);
+      if (!listener) return;
+      this.joinRoomListeners.delete(cb);
+      try {
+        this.sdk?.game.removeJoinRoomListener?.(listener);
+      } catch (e) {
+        console.warn('[CrazyGames] removeJoinRoomListener failed', e);
+      }
+    };
+  }
+
+  /** Pull our validated room code out of a portal invite payload. */
+  private extractRoomCode(params: CrazyInviteParams | null): string | null {
+    const raw = params?.[INVITE_ROOM_KEY];
+    if (typeof raw !== 'string') return null;
+    const code = raw.trim().toUpperCase();
+    return ROOM_CODE_PATTERN.test(code) ? code : null;
   }
 
   async tryShowFullscreenAd(

--- a/chapaev/src/platform/CrazyGamesAdapter.ts
+++ b/chapaev/src/platform/CrazyGamesAdapter.ts
@@ -173,11 +173,13 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   private visibilityHandler: (() => void) | null = null;
   private settingsListener: SettingsChangeListener | null = null;
 
-  /** Wrappers around consumer join callbacks, kept for later removal. */
-  private joinRoomListeners = new Map<
-    (roomCode: string) => void,
-    JoinRoomListener
-  >();
+  /**
+   * Wrapped join listeners currently attached to the SDK. A Set (not a Map
+   * keyed by the consumer callback) so the same `cb` can be registered more
+   * than once without one registration clobbering another's wrapper — each
+   * `onJoinRoomRequest` call owns exactly the wrapper it created.
+   */
+  private joinRoomListeners = new Set<JoinRoomListener>();
 
   /** True while a midgame ad is on screen — prevents overlapping requests. */
   private adInFlight = false;
@@ -352,33 +354,40 @@ export class CrazyGamesAdapter implements PlatformAdapter {
    * ignored rather than driving a bogus join.
    */
   onJoinRoomRequest(cb: (roomCode: string) => void): () => void {
+    // Require BOTH add and remove: registering a listener we can't later
+    // detach would violate the "returns an unsubscribe fn" contract and leak.
+    const game = this.sdk?.game;
     if (
       this.environment === 'disabled' ||
-      !this.sdk?.game.addJoinRoomListener
+      !game?.addJoinRoomListener ||
+      !game.removeJoinRoomListener
     ) {
       return () => {};
     }
 
+    // Each call gets its own wrapper, tracked by identity in a Set — so the
+    // same `cb` registered twice yields two independent, separately-removable
+    // subscriptions rather than one clobbering the other.
     const wrapped: JoinRoomListener = (inviteParams) => {
       const roomCode = this.extractRoomCode(inviteParams);
       if (roomCode) cb(roomCode);
     };
-    this.joinRoomListeners.set(cb, wrapped);
 
     try {
-      this.sdk.game.addJoinRoomListener(wrapped);
+      game.addJoinRoomListener(wrapped);
     } catch (e) {
       console.warn('[CrazyGames] addJoinRoomListener failed', e);
-      this.joinRoomListeners.delete(cb);
       return () => {};
     }
+    this.joinRoomListeners.add(wrapped);
 
+    let removed = false;
     return () => {
-      const listener = this.joinRoomListeners.get(cb);
-      if (!listener) return;
-      this.joinRoomListeners.delete(cb);
+      if (removed || !this.joinRoomListeners.has(wrapped)) return;
+      removed = true;
+      this.joinRoomListeners.delete(wrapped);
       try {
-        this.sdk?.game.removeJoinRoomListener?.(listener);
+        this.sdk?.game.removeJoinRoomListener?.(wrapped);
       } catch (e) {
         console.warn('[CrazyGames] removeJoinRoomListener failed', e);
       }

--- a/chapaev/src/platform/PlatformAdapter.ts
+++ b/chapaev/src/platform/PlatformAdapter.ts
@@ -132,4 +132,55 @@ export interface PlatformAdapter {
    * immediately. Adapters without this concept omit it (treated as false).
    */
   isInstantMultiplayer?(): boolean;
+
+  // ── Multiplayer room API (optional, portal-specific) ───────────────
+  //
+  // These mirror the CrazyGames "Multiplayer" module. They let the portal
+  // track which room the player is in, whether that room still accepts new
+  // players, and how to invite friends. Adapters that don't run inside such a
+  // portal (Telegram, Yandex, standalone) omit them entirely — callers reach
+  // them through optional chaining, so absence is a clean no-op.
+
+  /**
+   * Room-launch params captured when the game was cold-started from an invite
+   * (i.e. a friend shared a link and the invitee opened a fresh instance).
+   * Returns the room code to join, or null when the launch was not an invite.
+   * On CrazyGames this reads `SDK.game.inviteParams` and pulls out our room
+   * code. Distinct from `getLaunchRoomCode()`, which covers the `?ROOM=` /
+   * Telegram / Yandex deep-link channels; adapters must not report the same
+   * launch through both to avoid double-joining.
+   */
+  getInviteRoomCode?(): string | null;
+
+  /**
+   * Announce to the portal that the player is now in room `roomCode` and
+   * whether it currently accepts new players (`isJoinable`). Called on room
+   * creation (`isJoinable: true`) and again when the room fills / the match
+   * starts (`isJoinable: false`). Building the portal invite payload from the
+   * room code is the adapter's responsibility.
+   */
+  updateRoom?(roomCode: string, isJoinable: boolean): void;
+
+  /**
+   * Announce that the player has left their current room (cancel, leave match,
+   * return to menu). Clears any portal-side room/invite state. Idempotent.
+   */
+  leftRoom?(): void;
+
+  /**
+   * Show the portal's native "invite friends" button for `roomCode` (e.g.
+   * CrazyGames renders one in its footer). Balanced by `hideInviteButton`.
+   */
+  showInviteButton?(roomCode: string): void;
+
+  /** Hide the portal's native invite button. Idempotent. */
+  hideInviteButton?(): void;
+
+  /**
+   * Subscribe to portal-driven "join this room now" events fired while the
+   * game is already running (e.g. the player accepts a party invite without a
+   * reload). The callback receives the room code to join. Returns an
+   * unsubscribe fn. Adapters without live invites return a no-op unsubscribe.
+   */
+  onJoinRoomRequest?(cb: (roomCode: string) => void): () => void;
 }


### PR DESCRIPTION
## PR #2 — CrazyGames Room API

Продолжение работы по прохождению чеклиста мультиплеера CrazyGames (после PR #1, где мигрировали SDK v2→v3 + muteAudio + isInstantMultiplayer).

Интегрирует **Multiplayer module** CrazyGames SDK v3, чтобы портал знал в какой комнате игрок, можно ли к ней присоединиться, и как пригласить друзей.

### Что сделано

**`PlatformAdapter`** — добавлены опциональные методы room API. Вызываются через optional chaining → на Telegram/Yandex/standalone/capacitor чистый no-op:
- `getInviteRoomCode()` — код комнаты при cold-launch из инвайта
- `updateRoom(roomCode, isJoinable)` — анонс комнаты + joinable-состояния
- `leftRoom()` — игрок покинул комнату
- `showInviteButton(roomCode)` / `hideInviteButton()` — нативная кнопка инвайта портала
- `onJoinRoomRequest(cb)` — live-инвайты во время работы игры

**`CrazyGamesAdapter`** — реализация поверх `SDK.game.*`:
- `updateRoom` / `leftRoom` / `showInviteButton` / `hideInviteButton` / `addJoinRoomListener` / `inviteParams`
- room code round-trip'ится через `inviteParams.roomCode` и валидируется общим `ROOM_CODE_PATTERN` — битый payload не приведёт к join в несуществующую комнату
- все вызовы guard'ятся на `environment === 'disabled'` и наличие метода (совместимость со старым SDK)

**`PrivateRoomCoordinator`** — маппинг жизненного цикла приватной комнаты на портал:
| Событие | Действие |
|---|---|
| create / deep-link / cold-start | `enterPortalRoom` → joinable + invite button |
| match found (2/2 full) | `closePortalRoom` → `isJoinable:false` + hide button |
| cancel / error / leave | `leavePortalRoom` → `leftRoom` + hide button |

**`Game`**:
- cold-launch из инвайта (`getInviteRoomCode`) → `joinRoom`. Отдельный канал от `?ROOM=` / Telegram / Yandex deep-link — **без двойного срабатывания**. Приоритетнее instant-multiplayer (явная комната > создание пустой).
- живой join listener (`onJoinRoomRequest`) для инвайтов во время работы игры; игнорируется в активном матче (2/2, без hot-swap); отписка в `dispose`.

### Чеклист мультиплеера CrazyGames
- ✅ `updateRoom` для room + `isJoinable`
- ✅ `inviteParams` (cold-launch + live join)
- ✅ Lobby size **Min 2 / Max 2** (фиксировано в игре)
- ⏳ CrazyGames usernames — отложено (нужен User module → отдельный PR)
- N/A chat moderation — в Chapaev нет чата

### Проверки
- `tsc --noEmit` — 0 ошибок
- `pnpm build` — успешно (CrazyGamesAdapter отдельный чанк ~5.8kB, грузится только внутри портала)
- `eslint` — 0 errors (только допустимые no-console warnings)