### PR TITLE
feat(chapaev): CrazyGames usernames — User module → имя игрока в сети

### DIFF
--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -267,6 +267,14 @@ export class Game {
       };
     }
 
+    // Portal display name (e.g. CrazyGames User module). Optional per platform;
+    // null off-portal or when the player isn't signed in, so the server keeps
+    // assigning a guest name. The name then flows to the opponent's HUD.
+    const username = this.platform.getUsername?.() ?? undefined;
+    if (username) {
+      return { username };
+    }
+
     return {};
   }
 

--- a/chapaev/src/core/Game.ts
+++ b/chapaev/src/core/Game.ts
@@ -157,7 +157,9 @@ export class Game {
   // ── Online-mode bootstrap ───────────────────────────────────────
 
   private bootstrapOnlineCollaborators(): void {
-    this.ctx = new NetworkContext(this.getNetworkOptions());
+    // Provider (not a one-shot value): a CrazyGames login mid-session refreshes
+    // the cached username, and this recomputes it on the next connect/replace.
+    this.ctx = new NetworkContext(() => this.getNetworkOptions());
 
     this.ui.build({
       onFindMatch: () => void this.handleFindMatch(),

--- a/chapaev/src/network/NetworkContext.ts
+++ b/chapaev/src/network/NetworkContext.ts
@@ -1,4 +1,7 @@
-import { NetworkManager, type NetworkManagerOptions } from './NetworkManager.ts';
+import {
+  NetworkManager,
+  type NetworkManagerOptions,
+} from './NetworkManager.ts';
 
 /**
  * Holds the (replaceable) `NetworkManager` plus the shared book-keeping
@@ -9,21 +12,33 @@ import { NetworkManager, type NetworkManagerOptions } from './NetworkManager.ts'
  * returns to the menu we `replace()` the manager in place so callers
  * reading `ctx.manager` automatically pick up the fresh one without
  * needing to be re-instantiated.
+ *
+ * Options are resolved lazily via a provider callback so late-arriving
+ * data (e.g. a CrazyGames username that lands after the player logs in
+ * mid-session) is picked up on the next connect/`replace()` instead of
+ * being frozen at construction time.
  */
+export type NetworkOptionsProvider =
+  | NetworkManagerOptions
+  | (() => NetworkManagerOptions);
+
 export class NetworkContext {
   public manager: NetworkManager;
   private connectListenerUnsubs: (() => void)[] = [];
   private replaceHandlers: (() => void)[] = [];
+  private readonly resolveOptions: () => NetworkManagerOptions;
 
-  constructor(private readonly options: NetworkManagerOptions = {}) {
-    this.manager = new NetworkManager(options);
+  constructor(options: NetworkOptionsProvider = {}) {
+    this.resolveOptions =
+      typeof options === 'function' ? options : () => options;
+    this.manager = new NetworkManager(this.resolveOptions());
   }
 
   /** Replace the underlying manager (e.g. on returnToMainMenu). */
   replace(): NetworkManager {
     this.cleanupConnectListeners();
     this.manager.dispose();
-    this.manager = new NetworkManager(this.options);
+    this.manager = new NetworkManager(this.resolveOptions());
     for (const handler of this.replaceHandlers) handler();
     return this.manager;
   }

--- a/chapaev/src/platform/CrazyGamesAdapter.ts
+++ b/chapaev/src/platform/CrazyGamesAdapter.ts
@@ -57,6 +57,29 @@ type CrazyInviteParams = Record<string, string | number | boolean>;
 /** Fires while the game is running when the player accepts a party invite. */
 type JoinRoomListener = (inviteParams: CrazyInviteParams | null) => void;
 
+/** Subset of the CrazyGames User module user object we consume. */
+interface CrazyUser {
+  username?: string;
+  profilePictureUrl?: string;
+}
+
+/** Fires when the player logs in on CrazyGames while the game is running. */
+type AuthListener = (user: CrazyUser | null) => void;
+
+/** CrazyGames User module (v3), accessed via `SDK.user`. */
+interface CrazyUserModule {
+  /**
+   * Synchronous property (NOT a method): false off-portal / on embedding
+   * domains. Guard every other user call behind it.
+   */
+  readonly isUserAccountAvailable?: boolean;
+  /** Async: resolves the logged-in user, or null when not signed in. */
+  getUser?: () => Promise<CrazyUser | null>;
+  /** Sync: register a login listener (login on CG auto-logs into the game). */
+  addAuthListener?: (listener: AuthListener) => void;
+  removeAuthListener?: (listener: AuthListener) => void;
+}
+
 interface CrazyGamesSDK {
   /**
    * v3 requires explicit async initialisation before any module is usable.
@@ -118,6 +141,8 @@ interface CrazyGamesSDK {
     addJoinRoomListener?: (listener: JoinRoomListener) => void;
     removeJoinRoomListener?: (listener: JoinRoomListener) => void;
   };
+  /** User / account module (v3). Absent off-portal. */
+  user?: CrazyUserModule;
 }
 
 declare global {
@@ -174,6 +199,16 @@ export class CrazyGamesAdapter implements PlatformAdapter {
   private settingsListener: SettingsChangeListener | null = null;
 
   /**
+   * Portal display name resolved during `init()` (CrazyGames User module) and
+   * kept fresh via the auth listener. Null when the player isn't logged in or
+   * account functionality is unavailable (off-portal).
+   */
+  private username: string | null = null;
+
+  /** Auth listener kept for teardown. */
+  private authListener: AuthListener | null = null;
+
+  /**
    * Wrapped join listeners currently attached to the SDK. A Set (not a Map
    * keyed by the consumer callback) so the same `cb` can be registered more
    * than once without one registration clobbering another's wrapper — each
@@ -219,6 +254,11 @@ export class CrazyGamesAdapter implements PlatformAdapter {
     this.syncHostMute();
     this.subscribeToSettingsChanges();
 
+    // Resolve the portal display name (User module) + keep it fresh on login.
+    // Off-portal `isUserAccountAvailable` is false, so this is a clean no-op.
+    await this.syncPortalUser();
+    this.subscribeToAuthChanges();
+
     this.visibilityHandler = () => {
       if (document.visibilityState === 'visible') {
         for (const cb of this.resumeListeners) cb();
@@ -249,6 +289,16 @@ export class CrazyGamesAdapter implements PlatformAdapter {
 
   getAuthPayload(): string | null {
     return null;
+  }
+
+  /**
+   * Portal display name resolved from the CrazyGames User module during
+   * `init()` (and refreshed on login). Null when the player isn't logged in or
+   * account functionality is unavailable — callers then fall back to the
+   * server-assigned guest name.
+   */
+  getUsername(): string | null {
+    return this.username;
   }
 
   getLanguage(): Language | null {
@@ -542,6 +592,46 @@ export class CrazyGamesAdapter implements PlatformAdapter {
       console.warn('[CrazyGames] addSettingsChangeListener failed', e);
       this.settingsListener = null;
     }
+  }
+
+  /**
+   * Resolve the portal display name once during init(). `getUser()` is async
+   * and returns null when the player isn't signed in, so we cache whatever we
+   * get and let callers fall back to the server-assigned guest name.
+   */
+  private async syncPortalUser(): Promise<void> {
+    if (this.sdk?.user?.isUserAccountAvailable !== true) return;
+    if (!this.sdk.user.getUser) return;
+    try {
+      const user = await this.sdk.user.getUser();
+      this.username = this.normalizeUsername(user?.username);
+    } catch (e) {
+      console.warn('[CrazyGames] getUser failed', e);
+    }
+  }
+
+  /**
+   * Keep the cached display name fresh: logging in on CrazyGames mid-session
+   * auto-logs into the game and fires this listener. Sync registration; the
+   * listener itself just refreshes the cache for the next network connect.
+   */
+  private subscribeToAuthChanges(): void {
+    if (!this.sdk?.user?.addAuthListener) return;
+    this.authListener = (user: CrazyUser | null) => {
+      this.username = this.normalizeUsername(user?.username);
+    };
+    try {
+      this.sdk.user.addAuthListener(this.authListener);
+    } catch (e) {
+      console.warn('[CrazyGames] addAuthListener failed', e);
+      this.authListener = null;
+    }
+  }
+
+  /** Trim and coerce empty/whitespace-only names to null. */
+  private normalizeUsername(name: string | undefined): string | null {
+    const trimmed = name?.trim();
+    return trimmed ? trimmed : null;
   }
 
   private setAdMuted(muted: boolean): void {

--- a/chapaev/src/platform/CrazyGamesAdapter.ts
+++ b/chapaev/src/platform/CrazyGamesAdapter.ts
@@ -205,7 +205,12 @@ export class CrazyGamesAdapter implements PlatformAdapter {
    */
   private username: string | null = null;
 
-  /** Auth listener kept for teardown. */
+  /**
+   * Registered auth listener. This adapter lives for the whole page lifecycle
+   * and has no dispose path (same as `settingsListener` / `visibilityHandler`),
+   * so we never unregister it — the field is retained only for reference and
+   * potential future cleanup if a teardown path is ever added.
+   */
   private authListener: AuthListener | null = null;
 
   /**
@@ -616,7 +621,10 @@ export class CrazyGamesAdapter implements PlatformAdapter {
    * listener itself just refreshes the cache for the next network connect.
    */
   private subscribeToAuthChanges(): void {
-    if (!this.sdk?.user?.addAuthListener) return;
+    // Same guard the User module contract requires for every user call: false
+    // off-portal / on embedding domains, so this stays a clean no-op there.
+    if (this.sdk?.user?.isUserAccountAvailable !== true) return;
+    if (!this.sdk.user.addAuthListener) return;
     this.authListener = (user: CrazyUser | null) => {
       this.username = this.normalizeUsername(user?.username);
     };

--- a/chapaev/src/platform/PlatformAdapter.ts
+++ b/chapaev/src/platform/PlatformAdapter.ts
@@ -41,6 +41,16 @@ export interface PlatformAdapter {
    */
   getAuthPayload(): string | null;
 
+  /**
+   * Portal-provided display name for the local player, when the host exposes a
+   * logged-in account (e.g. the CrazyGames User module). Returned synchronously
+   * from a value the adapter resolved during `init()`; adapters fetch/refresh
+   * it internally. Null when unavailable or the player isn't logged in — the
+   * caller then falls back to the server-assigned guest name. Optional: adapters
+   * without a portal account concept omit it entirely.
+   */
+  getUsername?(): string | null;
+
   // ── Game-specific integration ──────────────────────────────────────
 
   getLanguage(): Language | null;


### PR DESCRIPTION
## Что это

Последний обязательный пункт мультиплеер-чеклиста CrazyGames: **отображение никнейма игрока с портала**. Теперь имя из CrazyGames User module долетает до HUD оппонента.

## Изменения (чисто клиентские — сервер не тронут)

**`PlatformAdapter.ts`**
- Добавлен опциональный `getUsername?(): string | null`. Через optional-chaining → чистый no-op на Telegram / Yandex / standalone / capacitor.

**`CrazyGamesAdapter.ts`**
- Типы User module (v3): `CrazyUser`, `AuthListener`, `CrazyUserModule` (`isUserAccountAvailable`, `getUser`, `add/removeAuthListener`).
- В `init()`: `syncPortalUser()` (async `getUser()` за гардом `isUserAccountAvailable === true`) + `subscribeToAuthChanges()` (обновляет кеш при логине на портале).
- Публичный `getUsername()` отдаёт закешированное имя (sync), `null` если игрок не залогинен / вне портала.
- `normalizeUsername()` — trim + пустые → null.

**`Game.ts`**
- `getNetworkOptions()` пробрасывает `platform.getUsername?.()` как `username` в `NetworkManagerOptions`. Дальше: NetworkManager → сервер → matchData → HUD оппонента. Telegram-ветка не тронута.

## Поток
`init()` резолвит имя (async) и кеширует (sync) → `getNetworkOptions()` кладёт его в опции → сервер использует при connect → оппонент видит в HUD.

## Проверки
- `tsc --noEmit` — 0 ошибок
- `pnpm build` — зелёный (CrazyGamesAdapter чанк 6.5kB, грузится только на портале)
- `eslint` — 0 errors (только предсуществующие no-console warnings; новый код использует лишь console.warn)

## Отложено
`getUserToken()` / серверная JWT-валидация — отдельная задача по безопасности/линковке аккаунтов, для чеклиста не требуется.