### PR TITLE
feat(missiles): soft engine glow and smoke trail VFX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 
 # Local AI agent rules
 .aiassistant/*
+.cursor/*
 
 # Build output
 dist/

--- a/abilities-playground/src/components/UnitComponents.ts
+++ b/abilities-playground/src/components/UnitComponents.ts
@@ -212,32 +212,56 @@ export class MeshComponent implements IPoolableComponent {
   public static createMissile(): MeshComponent {
     const group = new THREE.Group();
 
+    const bodyLength = 2.0;
     const body = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.25, 0.6, 2.0, 12),
+      new THREE.CylinderGeometry(0.25, 0.6, bodyLength, 12),
       new THREE.MeshStandardMaterial({
         color: 0xdddddd,
         metalness: 0.5,
         roughness: 0.35,
-      })
+      }),
     );
     body.rotation.x = Math.PI / 2;
     body.castShadow = true;
 
-    const flame = new THREE.Mesh(
-      new THREE.ConeGeometry(0.5, 1.2, 12),
-      new THREE.MeshBasicMaterial({
-        color: 0xffaa33,
-        transparent: true,
-        opacity: 0.85,
-        blending: THREE.AdditiveBlending,
-        depthWrite: false,
-      })
-    );
-    flame.rotation.x = -Math.PI / 2;
-    flame.position.z = -(2.0 / 2 + 1.2 / 2);
+    const makeFlame = (
+      radius: number,
+      height: number,
+      color: number,
+      opacity: number,
+    ): THREE.Mesh => {
+      const flame = new THREE.Mesh(
+        new THREE.ConeGeometry(radius, height, 12),
+        new THREE.MeshBasicMaterial({
+          color,
+          transparent: true,
+          opacity,
+          blending: THREE.AdditiveBlending,
+          depthWrite: false,
+          toneMapped: false,
+        }),
+      );
+      flame.rotation.x = -Math.PI / 2;
+      flame.position.z = -(bodyLength / 2 + height / 2);
+      return flame;
+    };
+
+    // Soft realistic stack: hot core + warmer outer wash
+    const flameCore = makeFlame(0.22, 0.7, 0xfff2cc, 0.95);
+    const flameOuter = makeFlame(0.48, 1.15, 0xff8a2a, 0.55);
+
+    const engineLight = new THREE.PointLight(0xffa040, 1.1, 5, 2);
+    engineLight.position.z = -(bodyLength / 2 + 0.15);
 
     group.add(body);
-    group.add(flame);
+    group.add(flameOuter);
+    group.add(flameCore);
+    group.add(engineLight);
+
+    group.userData.flameCore = flameCore;
+    group.userData.flameOuter = flameOuter;
+    group.userData.engineLight = engineLight;
+
     group.visible = false;
     return new MeshComponent(group);
   }

--- a/abilities-playground/src/components/UnitComponents.ts
+++ b/abilities-playground/src/components/UnitComponents.ts
@@ -229,11 +229,16 @@ export class MeshComponent implements IPoolableComponent {
       height: number,
       color: number,
       opacity: number,
+      emissiveIntensity: number,
     ): THREE.Mesh => {
       const flame = new THREE.Mesh(
         new THREE.ConeGeometry(radius, height, 12),
-        new THREE.MeshBasicMaterial({
+        new THREE.MeshStandardMaterial({
           color,
+          emissive: color,
+          emissiveIntensity,
+          metalness: 0,
+          roughness: 1,
           transparent: true,
           opacity,
           blending: THREE.AdditiveBlending,
@@ -246,21 +251,16 @@ export class MeshComponent implements IPoolableComponent {
       return flame;
     };
 
-    // Soft realistic stack: hot core + warmer outer wash
-    const flameCore = makeFlame(0.22, 0.7, 0xfff2cc, 0.95);
-    const flameOuter = makeFlame(0.48, 1.15, 0xff8a2a, 0.55);
-
-    const engineLight = new THREE.PointLight(0xffa040, 1.1, 5, 2);
-    engineLight.position.z = -(bodyLength / 2 + 0.15);
+    // Soft realistic stack: hot core + warmer outer wash (self-lit, no PointLight)
+    const flameCore = makeFlame(0.22, 0.7, 0xfff2cc, 0.95, 3.2);
+    const flameOuter = makeFlame(0.48, 1.15, 0xff8a2a, 0.55, 2.0);
 
     group.add(body);
     group.add(flameOuter);
     group.add(flameCore);
-    group.add(engineLight);
 
     group.userData.flameCore = flameCore;
     group.userData.flameOuter = flameOuter;
-    group.userData.engineLight = engineLight;
 
     group.visible = false;
     return new MeshComponent(group);

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -49,10 +49,11 @@ export const MISSILE_CRUISE_TURN = 0.4;
 /** XZ distance from the target where a cruising missile starts its 3D dive. */
 export const MISSILE_ATTACK_RANGE = 25;
 /**
- * XZ distance below which the launch arc is skipped and cruise altitude scales
- * down linearly to zero (close-range shots home flat instead of looping).
+ * Minimum engagement range (world units, XZ). The rocket is high-arc artillery:
+ * it refuses to fire on enemies closer than this, so every missile always flies
+ * the full launch arc + cruise + dive instead of a flat close-range shot.
  */
-export const MISSILE_LAUNCH_ARC_FALLOFF = 40;
+export const MISSILE_MIN_ENGAGEMENT_RANGE = 35;
 export const MISSILE_RADIUS = 0.6;
 /**
  * Radius (world units) around a missile used to search for a new hostile target

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -50,8 +50,9 @@ export const MISSILE_CRUISE_TURN = 0.4;
 export const MISSILE_ATTACK_RANGE = 25;
 /**
  * Minimum engagement range (world units, XZ). The rocket is high-arc artillery:
- * it refuses to fire on enemies closer than this, so every missile always flies
- * the full launch arc + cruise + dive instead of a flat close-range shot.
+ * it refuses to fire on enemies closer than this, so a missile is never spawned
+ * close enough for a flat close-range shot. A missile that closes to within
+ * MISSILE_ATTACK_RANGE mid-flight may still dive early; this only gates spawning.
  */
 export const MISSILE_MIN_ENGAGEMENT_RANGE = 35;
 export const MISSILE_RADIUS = 0.6;

--- a/abilities-playground/src/core/SimulationContainer.ts
+++ b/abilities-playground/src/core/SimulationContainer.ts
@@ -60,6 +60,7 @@ import {
   HealCrossCue,
   BeamCue,
   MissileImpactCue,
+  MissileExhaustCue,
   ChainLightningCue,
   MachineGunFireCue,
   MachineGunImpactCue,
@@ -123,6 +124,7 @@ export class SimulationContainer {
         'Cue.Beam.Yellow': () =>
           new BeamCue(this.scene, 0xffdd33, CUBE_SPEED_BUFF_TAG),
         'Cue.Missile.Impact': () => new MissileImpactCue(this.scene),
+        'Cue.Missile.Exhaust': () => new MissileExhaustCue(this.scene),
         'Cue.ChainLightning.Primary': () =>
           new ChainLightningCue(this.scene, 0x00ffff, true),
         'Cue.ChainLightning.Jump': () =>

--- a/abilities-playground/src/cues/index.ts
+++ b/abilities-playground/src/cues/index.ts
@@ -6,3 +6,4 @@ export * from './BeamCue.ts';
 export * from './ChainLightningCue.ts';
 export * from './MachineGunFireCue.ts';
 export * from './MachineGunImpactCue.ts';
+export * from './missileExhaustCue.ts';

--- a/abilities-playground/src/cues/missileExhaustCue.ts
+++ b/abilities-playground/src/cues/missileExhaustCue.ts
@@ -17,8 +17,7 @@ const LIFE_MIN = 1.5;
 const LIFE_MAX = 2.5;
 const SIZE_START = 0.9;
 const SIZE_END = 2.4;
-const ALPHA_START = 0.55;
-const POINT_SCALE = 180;
+const ALPHA_START = 0.6;
 const BASE_CORE_OPACITY = 0.95;
 const BASE_OUTER_OPACITY = 0.55;
 const BASE_LIGHT_INTENSITY = 1.1;
@@ -27,6 +26,15 @@ const COLOR_WARM = new THREE.Color('#c4a882');
 const COLOR_COOL = new THREE.Color('#6e6e72');
 
 const LOCAL_EXHAUST = new THREE.Vector3(0, 0, -1);
+
+/**
+ * Matches THREE.PointsMaterial's size attenuation: gl_PointSize is
+ * `size * (0.5 * drawingBufferHeight) / -viewZ`. A hardcoded scale renders
+ * sub-pixel (invisible) sprites at gameplay camera distance.
+ */
+function viewportPointScale(): number {
+  return 0.5 * window.innerHeight * (window.devicePixelRatio || 1);
+}
 
 type ExhaustUserData = {
   flameCore?: THREE.Mesh;
@@ -153,7 +161,7 @@ export class MissileExhaustCue extends Cue {
     this.material = new THREE.ShaderMaterial({
       uniforms: {
         uMap: { value: getSoftCircleTexture() },
-        uScale: { value: POINT_SCALE },
+        uScale: { value: viewportPointScale() },
       },
       vertexShader: VERTEX_SHADER,
       fragmentShader: FRAGMENT_SHADER,
@@ -173,6 +181,9 @@ export class MissileExhaustCue extends Cue {
     if (this.done || !this.context) return;
 
     this.elapsed += deltaTimeSeconds;
+    if (this.material) {
+      this.material.uniforms.uScale!.value = viewportPointScale();
+    }
     const entity = this.context.entityManager.getEntity(this.missileEntityId);
 
     if (!entity || (entity as MaybeActive).active === false) {

--- a/abilities-playground/src/cues/missileExhaustCue.ts
+++ b/abilities-playground/src/cues/missileExhaustCue.ts
@@ -220,6 +220,10 @@ export class MissileExhaustCue extends Cue {
   }
 
   public override dispose(): void {
+    // Restore flame meshes before dropping our refs: dispose() can run while
+    // the missile is still in the scene (teardown/reset), and otherwise the
+    // nozzle would stay stuck in a flickered opacity/emissiveIntensity state.
+    this.restoreNozzleDefaults();
     if (this.points) this.scene.remove(this.points);
     this.geometry?.dispose();
     this.material?.dispose();

--- a/abilities-playground/src/cues/missileExhaustCue.ts
+++ b/abilities-playground/src/cues/missileExhaustCue.ts
@@ -20,10 +20,15 @@ const SIZE_END = 2.4;
 const ALPHA_START = 0.6;
 const BASE_CORE_OPACITY = 0.95;
 const BASE_OUTER_OPACITY = 0.55;
-const BASE_LIGHT_INTENSITY = 1.1;
+const BASE_CORE_EMISSIVE = 3.2;
+const BASE_OUTER_EMISSIVE = 2.0;
 
 const COLOR_WARM = new THREE.Color('#c4a882');
 const COLOR_COOL = new THREE.Color('#6e6e72');
+
+// Smooth per-particle wander so trails curl instead of tracking straight lines.
+const TURB_STRENGTH = 1.2;
+const TURB_FREQ = 2.3;
 
 const LOCAL_EXHAUST = new THREE.Vector3(0, 0, -1);
 
@@ -39,7 +44,6 @@ function viewportPointScale(): number {
 type ExhaustUserData = {
   flameCore?: THREE.Mesh;
   flameOuter?: THREE.Mesh;
-  engineLight?: THREE.PointLight;
 };
 
 type MaybeActive = { active?: boolean };
@@ -93,6 +97,7 @@ export class MissileExhaustCue extends Cue {
   private velocities: Float32Array | null = null;
   private ages: Float32Array | null = null;
   private lifetimes: Float32Array | null = null;
+  private seeds: Float32Array | null = null;
   private sizes: Float32Array | null = null;
   private alphas: Float32Array | null = null;
   private colors: Float32Array | null = null;
@@ -100,7 +105,6 @@ export class MissileExhaustCue extends Cue {
 
   private flameCore: THREE.Mesh | null = null;
   private flameOuter: THREE.Mesh | null = null;
-  private engineLight: THREE.PointLight | null = null;
   private readonly nozzleWorld = new THREE.Vector3();
   private readonly exhaustDir = new THREE.Vector3();
   private readonly tmpColor = new THREE.Color();
@@ -129,12 +133,12 @@ export class MissileExhaustCue extends Cue {
     const data = mesh.root.userData as ExhaustUserData;
     this.flameCore = data.flameCore ?? null;
     this.flameOuter = data.flameOuter ?? null;
-    this.engineLight = data.engineLight ?? null;
 
     this.positions = new Float32Array(PARTICLE_CAPACITY * 3);
     this.velocities = new Float32Array(PARTICLE_CAPACITY * 3);
     this.ages = new Float32Array(PARTICLE_CAPACITY);
     this.lifetimes = new Float32Array(PARTICLE_CAPACITY);
+    this.seeds = new Float32Array(PARTICLE_CAPACITY);
     this.sizes = new Float32Array(PARTICLE_CAPACITY);
     this.alphas = new Float32Array(PARTICLE_CAPACITY);
     this.colors = new Float32Array(PARTICLE_CAPACITY * 3);
@@ -188,7 +192,7 @@ export class MissileExhaustCue extends Cue {
 
     if (!entity || (entity as MaybeActive).active === false) {
       this.emitting = false;
-      this.restoreNozzleDefaults(false);
+      this.restoreNozzleDefaults();
     } else if (this.emitting) {
       if (!this.resolveNozzle(entity)) {
         this.emitting = false;
@@ -226,12 +230,12 @@ export class MissileExhaustCue extends Cue {
     this.velocities = null;
     this.ages = null;
     this.lifetimes = null;
+    this.seeds = null;
     this.sizes = null;
     this.alphas = null;
     this.colors = null;
     this.flameCore = null;
     this.flameOuter = null;
-    this.engineLight = null;
   }
 
   private resolveNozzle(entity: Entity): boolean {
@@ -274,6 +278,7 @@ export class MissileExhaustCue extends Cue {
       !this.velocities ||
       !this.ages ||
       !this.lifetimes ||
+      !this.seeds ||
       !this.sizes ||
       !this.alphas ||
       !this.colors
@@ -307,6 +312,7 @@ export class MissileExhaustCue extends Cue {
 
     this.ages[i] = 0;
     this.lifetimes[i] = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN);
+    this.seeds[i] = Math.random() * Math.PI * 2;
     this.writeVisuals(i, 0);
     this.syncDrawRange();
   }
@@ -333,6 +339,7 @@ export class MissileExhaustCue extends Cue {
       !this.velocities ||
       !this.ages ||
       !this.lifetimes ||
+      !this.seeds ||
       !this.sizes ||
       !this.alphas ||
       !this.colors ||
@@ -354,6 +361,16 @@ export class MissileExhaustCue extends Cue {
       this.velocities[ro + 1] *= damp;
       this.velocities[ro + 2] *= damp;
 
+      // Smooth curl: gentle wander that grows as the puff slows, bending paths.
+      const seed = this.seeds[read]!;
+      const swirl = TURB_STRENGTH * age;
+      this.velocities[ro] +=
+        Math.sin(age * TURB_FREQ + seed) * swirl * dt;
+      this.velocities[ro + 1] +=
+        Math.sin(age * TURB_FREQ * 0.8 + seed * 1.7) * swirl * 0.6 * dt;
+      this.velocities[ro + 2] +=
+        Math.cos(age * TURB_FREQ * 1.3 + seed * 2.3) * swirl * dt;
+
       this.positions[wo] = this.positions[ro]! + this.velocities[ro]! * dt;
       this.positions[wo + 1] =
         this.positions[ro + 1]! + this.velocities[ro + 1]! * dt;
@@ -364,6 +381,7 @@ export class MissileExhaustCue extends Cue {
       this.velocities[wo + 2] = this.velocities[ro + 2]!;
       this.ages[write] = age;
       this.lifetimes[write] = life;
+      this.seeds[write] = seed;
       this.writeVisuals(write, age / life);
       write++;
     }
@@ -382,33 +400,35 @@ export class MissileExhaustCue extends Cue {
   private flickerNozzle(): void {
     const pulse = 0.85 + 0.15 * Math.sin(this.elapsed * 18 + Math.random());
     const coreMat = this.flameCore?.material as
-      | THREE.MeshBasicMaterial
+      | THREE.MeshStandardMaterial
       | undefined;
     const outerMat = this.flameOuter?.material as
-      | THREE.MeshBasicMaterial
+      | THREE.MeshStandardMaterial
       | undefined;
-    if (coreMat) coreMat.opacity = BASE_CORE_OPACITY * pulse;
+    if (coreMat) {
+      coreMat.opacity = BASE_CORE_OPACITY * pulse;
+      coreMat.emissiveIntensity = BASE_CORE_EMISSIVE * pulse;
+    }
     if (outerMat) {
       outerMat.opacity = BASE_OUTER_OPACITY * (0.9 + 0.1 * pulse);
-    }
-    if (this.engineLight) {
-      this.engineLight.intensity = BASE_LIGHT_INTENSITY * pulse;
-      this.engineLight.visible = true;
+      outerMat.emissiveIntensity = BASE_OUTER_EMISSIVE * (0.9 + 0.1 * pulse);
     }
   }
 
-  private restoreNozzleDefaults(lightOn: boolean): void {
+  private restoreNozzleDefaults(): void {
     const coreMat = this.flameCore?.material as
-      | THREE.MeshBasicMaterial
+      | THREE.MeshStandardMaterial
       | undefined;
     const outerMat = this.flameOuter?.material as
-      | THREE.MeshBasicMaterial
+      | THREE.MeshStandardMaterial
       | undefined;
-    if (coreMat) coreMat.opacity = BASE_CORE_OPACITY;
-    if (outerMat) outerMat.opacity = BASE_OUTER_OPACITY;
-    if (this.engineLight) {
-      this.engineLight.intensity = BASE_LIGHT_INTENSITY;
-      this.engineLight.visible = lightOn;
+    if (coreMat) {
+      coreMat.opacity = BASE_CORE_OPACITY;
+      coreMat.emissiveIntensity = BASE_CORE_EMISSIVE;
+    }
+    if (outerMat) {
+      outerMat.opacity = BASE_OUTER_OPACITY;
+      outerMat.emissiveIntensity = BASE_OUTER_EMISSIVE;
     }
   }
 }

--- a/abilities-playground/src/cues/missileExhaustCue.ts
+++ b/abilities-playground/src/cues/missileExhaustCue.ts
@@ -8,15 +8,25 @@ import type { Entity } from '@phalanx-engine/ecs';
 import { FPVector3 } from '@phalanx-engine/math';
 import type { TransformComponent } from '@phalanx-engine/physics';
 import { ComponentType, MeshComponent } from '../components';
+import { clamp01, getSoftCircleTexture } from './vfxHelpers';
 
-const PARTICLE_CAPACITY = 96;
-const EMIT_PER_SECOND = 28;
+const PARTICLE_CAPACITY = 128;
+const EMIT_PER_SECOND = 52;
+const PARTICLES_PER_EMIT = 2;
 const LIFE_MIN = 1.5;
 const LIFE_MAX = 2.5;
-const SMOKE_SIZE = 0.55;
+const SIZE_START = 0.9;
+const SIZE_END = 2.4;
+const ALPHA_START = 0.55;
+const POINT_SCALE = 180;
 const BASE_CORE_OPACITY = 0.95;
 const BASE_OUTER_OPACITY = 0.55;
 const BASE_LIGHT_INTENSITY = 1.1;
+
+const COLOR_WARM = new THREE.Color('#c4a882');
+const COLOR_COOL = new THREE.Color('#6e6e72');
+
+const LOCAL_EXHAUST = new THREE.Vector3(0, 0, -1);
 
 type ExhaustUserData = {
   flameCore?: THREE.Mesh;
@@ -25,6 +35,39 @@ type ExhaustUserData = {
 };
 
 type MaybeActive = { active?: boolean };
+
+const VERTEX_SHADER = /* glsl */ `
+attribute float aSize;
+attribute float aAlpha;
+attribute vec3 aColor;
+
+uniform float uScale;
+
+varying float vAlpha;
+varying vec3 vColor;
+
+void main() {
+  vAlpha = aAlpha;
+  vColor = aColor;
+  vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+  gl_PointSize = aSize * (uScale / max(0.15, -mvPosition.z));
+  gl_Position = projectionMatrix * mvPosition;
+}
+`;
+
+const FRAGMENT_SHADER = /* glsl */ `
+uniform sampler2D uMap;
+
+varying float vAlpha;
+varying vec3 vColor;
+
+void main() {
+  float mask = texture2D(uMap, gl_PointCoord).a;
+  float alpha = mask * vAlpha;
+  if (alpha < 0.01) discard;
+  gl_FragColor = vec4(vColor, alpha);
+}
+`;
 
 export class MissileExhaustCue extends Cue {
   private readonly scene: THREE.Scene;
@@ -37,17 +80,22 @@ export class MissileExhaustCue extends Cue {
 
   private points: THREE.Points | null = null;
   private geometry: THREE.BufferGeometry | null = null;
-  private material: THREE.PointsMaterial | null = null;
+  private material: THREE.ShaderMaterial | null = null;
   private positions: Float32Array | null = null;
   private velocities: Float32Array | null = null;
   private ages: Float32Array | null = null;
   private lifetimes: Float32Array | null = null;
+  private sizes: Float32Array | null = null;
+  private alphas: Float32Array | null = null;
+  private colors: Float32Array | null = null;
   private aliveCount = 0;
 
   private flameCore: THREE.Mesh | null = null;
   private flameOuter: THREE.Mesh | null = null;
   private engineLight: THREE.PointLight | null = null;
   private readonly nozzleWorld = new THREE.Vector3();
+  private readonly exhaustDir = new THREE.Vector3();
+  private readonly tmpColor = new THREE.Color();
 
   public constructor(scene: THREE.Scene) {
     super();
@@ -79,22 +127,40 @@ export class MissileExhaustCue extends Cue {
     this.velocities = new Float32Array(PARTICLE_CAPACITY * 3);
     this.ages = new Float32Array(PARTICLE_CAPACITY);
     this.lifetimes = new Float32Array(PARTICLE_CAPACITY);
+    this.sizes = new Float32Array(PARTICLE_CAPACITY);
+    this.alphas = new Float32Array(PARTICLE_CAPACITY);
+    this.colors = new Float32Array(PARTICLE_CAPACITY * 3);
 
     this.geometry = new THREE.BufferGeometry();
     this.geometry.setAttribute(
       'position',
       new THREE.BufferAttribute(this.positions, 3),
     );
+    this.geometry.setAttribute(
+      'aSize',
+      new THREE.BufferAttribute(this.sizes, 1),
+    );
+    this.geometry.setAttribute(
+      'aAlpha',
+      new THREE.BufferAttribute(this.alphas, 1),
+    );
+    this.geometry.setAttribute(
+      'aColor',
+      new THREE.BufferAttribute(this.colors, 3),
+    );
     this.geometry.setDrawRange(0, 0);
 
-    this.material = new THREE.PointsMaterial({
-      color: new THREE.Color('#9a9a9a'),
-      size: SMOKE_SIZE,
-      sizeAttenuation: true,
+    this.material = new THREE.ShaderMaterial({
+      uniforms: {
+        uMap: { value: getSoftCircleTexture() },
+        uScale: { value: POINT_SCALE },
+      },
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
       transparent: true,
-      opacity: 0.45,
       depthWrite: false,
       blending: THREE.NormalBlending,
+      toneMapped: false,
     });
 
     this.points = new THREE.Points(this.geometry, this.material);
@@ -120,7 +186,9 @@ export class MissileExhaustCue extends Cue {
         this.emitAccumulator += EMIT_PER_SECOND * deltaTimeSeconds;
         while (this.emitAccumulator >= 1) {
           this.emitAccumulator -= 1;
-          this.spawnParticle();
+          for (let n = 0; n < PARTICLES_PER_EMIT; n++) {
+            this.spawnParticle(entity);
+          }
         }
       }
     }
@@ -147,6 +215,9 @@ export class MissileExhaustCue extends Cue {
     this.velocities = null;
     this.ages = null;
     this.lifetimes = null;
+    this.sizes = null;
+    this.alphas = null;
+    this.colors = null;
     this.flameCore = null;
     this.flameOuter = null;
     this.engineLight = null;
@@ -174,31 +245,75 @@ export class MissileExhaustCue extends Cue {
     return true;
   }
 
-  private spawnParticle(): void {
+  private updateExhaustDir(entity: Entity): void {
+    const mesh = entity.getComponent<MeshComponent>(ComponentType.Mesh);
+    if (mesh) {
+      this.exhaustDir
+        .copy(LOCAL_EXHAUST)
+        .applyQuaternion(mesh.root.quaternion)
+        .normalize();
+      return;
+    }
+    this.exhaustDir.set(0, 0.2, -1).normalize();
+  }
+
+  private spawnParticle(entity: Entity): void {
     if (
       !this.positions ||
       !this.velocities ||
       !this.ages ||
-      !this.lifetimes
+      !this.lifetimes ||
+      !this.sizes ||
+      !this.alphas ||
+      !this.colors
     ) {
       return;
     }
     if (this.aliveCount >= PARTICLE_CAPACITY) return;
 
+    this.updateExhaustDir(entity);
+
     const i = this.aliveCount++;
     const o = i * 3;
-    this.positions[o] = this.nozzleWorld.x + (Math.random() - 0.5) * 0.25;
+    const jitter = 0.18;
+    this.positions[o] = this.nozzleWorld.x + (Math.random() - 0.5) * jitter;
     this.positions[o + 1] =
-      this.nozzleWorld.y + (Math.random() - 0.5) * 0.25;
-    this.positions[o + 2] = this.nozzleWorld.z + (Math.random() - 0.5) * 0.25;
+      this.nozzleWorld.y + (Math.random() - 0.5) * jitter;
+    this.positions[o + 2] =
+      this.nozzleWorld.z + (Math.random() - 0.5) * jitter;
 
-    this.velocities[o] = (Math.random() - 0.5) * 0.35;
-    this.velocities[o + 1] = 0.35 + Math.random() * 0.45;
-    this.velocities[o + 2] = (Math.random() - 0.5) * 0.35;
+    const backSpeed = 1.4 + Math.random() * 1.8;
+    const spread = 0.55;
+    this.velocities[o] =
+      this.exhaustDir.x * backSpeed + (Math.random() - 0.5) * spread;
+    this.velocities[o + 1] =
+      this.exhaustDir.y * backSpeed +
+      0.15 +
+      Math.random() * 0.35 +
+      (Math.random() - 0.5) * spread * 0.5;
+    this.velocities[o + 2] =
+      this.exhaustDir.z * backSpeed + (Math.random() - 0.5) * spread;
 
     this.ages[i] = 0;
     this.lifetimes[i] = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN);
+    this.writeVisuals(i, 0);
     this.syncDrawRange();
+  }
+
+  private writeVisuals(index: number, ageRatio: number): void {
+    if (!this.sizes || !this.alphas || !this.colors) return;
+
+    const t = clamp01(ageRatio);
+    // Ease out: grow and fade as smoke ages
+    const fade = 1 - t * t;
+    this.sizes[index] = SIZE_START + (SIZE_END - SIZE_START) * t;
+    this.alphas[index] = ALPHA_START * fade;
+
+    this.tmpColor.copy(COLOR_WARM).lerp(COLOR_COOL, t);
+    const co = index * 3;
+    this.colors[co] = this.tmpColor.r;
+    this.colors[co + 1] = this.tmpColor.g;
+    this.colors[co + 2] = this.tmpColor.b;
   }
 
   private ageParticles(dt: number): void {
@@ -207,11 +322,15 @@ export class MissileExhaustCue extends Cue {
       !this.velocities ||
       !this.ages ||
       !this.lifetimes ||
+      !this.sizes ||
+      !this.alphas ||
+      !this.colors ||
       !this.geometry
     ) {
       return;
     }
 
+    const damp = Math.exp(-1.4 * dt);
     let write = 0;
     for (let read = 0; read < this.aliveCount; read++) {
       const life = this.lifetimes[read]!;
@@ -220,8 +339,11 @@ export class MissileExhaustCue extends Cue {
 
       const ro = read * 3;
       const wo = write * 3;
-      this.positions[wo] =
-        this.positions[ro]! + this.velocities[ro]! * dt;
+      this.velocities[ro] *= damp;
+      this.velocities[ro + 1] *= damp;
+      this.velocities[ro + 2] *= damp;
+
+      this.positions[wo] = this.positions[ro]! + this.velocities[ro]! * dt;
       this.positions[wo + 1] =
         this.positions[ro + 1]! + this.velocities[ro + 1]! * dt;
       this.positions[wo + 2] =
@@ -231,15 +353,15 @@ export class MissileExhaustCue extends Cue {
       this.velocities[wo + 2] = this.velocities[ro + 2]!;
       this.ages[write] = age;
       this.lifetimes[write] = life;
+      this.writeVisuals(write, age / life);
       write++;
     }
     this.aliveCount = write;
     this.geometry.attributes.position.needsUpdate = true;
+    this.geometry.attributes.aSize.needsUpdate = true;
+    this.geometry.attributes.aAlpha.needsUpdate = true;
+    this.geometry.attributes.aColor.needsUpdate = true;
     this.syncDrawRange();
-
-    if (this.material) {
-      this.material.opacity = this.emitting ? 0.45 : 0.35;
-    }
   }
 
   private syncDrawRange(): void {

--- a/abilities-playground/src/cues/missileExhaustCue.ts
+++ b/abilities-playground/src/cues/missileExhaustCue.ts
@@ -1,0 +1,281 @@
+import * as THREE from 'three';
+import {
+  Cue,
+  type CueContext,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import type { Entity } from '@phalanx-engine/ecs';
+import { FPVector3 } from '@phalanx-engine/math';
+import type { TransformComponent } from '@phalanx-engine/physics';
+import { ComponentType, MeshComponent } from '../components';
+
+const PARTICLE_CAPACITY = 96;
+const EMIT_PER_SECOND = 28;
+const LIFE_MIN = 1.5;
+const LIFE_MAX = 2.5;
+const SMOKE_SIZE = 0.55;
+const BASE_CORE_OPACITY = 0.95;
+const BASE_OUTER_OPACITY = 0.55;
+const BASE_LIGHT_INTENSITY = 1.1;
+
+type ExhaustUserData = {
+  flameCore?: THREE.Mesh;
+  flameOuter?: THREE.Mesh;
+  engineLight?: THREE.PointLight;
+};
+
+type MaybeActive = { active?: boolean };
+
+export class MissileExhaustCue extends Cue {
+  private readonly scene: THREE.Scene;
+  private context: CueContext | null = null;
+  private missileEntityId = -1;
+  private emitting = true;
+  private done = false;
+  private emitAccumulator = 0;
+  private elapsed = 0;
+
+  private points: THREE.Points | null = null;
+  private geometry: THREE.BufferGeometry | null = null;
+  private material: THREE.PointsMaterial | null = null;
+  private positions: Float32Array | null = null;
+  private velocities: Float32Array | null = null;
+  private ages: Float32Array | null = null;
+  private lifetimes: Float32Array | null = null;
+  private aliveCount = 0;
+
+  private flameCore: THREE.Mesh | null = null;
+  private flameOuter: THREE.Mesh | null = null;
+  private engineLight: THREE.PointLight | null = null;
+  private readonly nozzleWorld = new THREE.Vector3();
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    this.context = context;
+    this.missileEntityId = event.sourceEntityId;
+
+    const entity = context.entityManager.getEntity(this.missileEntityId);
+    if (!entity) {
+      this.done = true;
+      return;
+    }
+
+    const mesh = entity.getComponent<MeshComponent>(ComponentType.Mesh);
+    if (!mesh) {
+      this.done = true;
+      return;
+    }
+
+    const data = mesh.root.userData as ExhaustUserData;
+    this.flameCore = data.flameCore ?? null;
+    this.flameOuter = data.flameOuter ?? null;
+    this.engineLight = data.engineLight ?? null;
+
+    this.positions = new Float32Array(PARTICLE_CAPACITY * 3);
+    this.velocities = new Float32Array(PARTICLE_CAPACITY * 3);
+    this.ages = new Float32Array(PARTICLE_CAPACITY);
+    this.lifetimes = new Float32Array(PARTICLE_CAPACITY);
+
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(this.positions, 3),
+    );
+    this.geometry.setDrawRange(0, 0);
+
+    this.material = new THREE.PointsMaterial({
+      color: new THREE.Color('#9a9a9a'),
+      size: SMOKE_SIZE,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.45,
+      depthWrite: false,
+      blending: THREE.NormalBlending,
+    });
+
+    this.points = new THREE.Points(this.geometry, this.material);
+    this.points.frustumCulled = false;
+    this.points.renderOrder = 8500;
+    this.scene.add(this.points);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.context) return;
+
+    this.elapsed += deltaTimeSeconds;
+    const entity = this.context.entityManager.getEntity(this.missileEntityId);
+
+    if (!entity || (entity as MaybeActive).active === false) {
+      this.emitting = false;
+      this.restoreNozzleDefaults(false);
+    } else if (this.emitting) {
+      if (!this.resolveNozzle(entity)) {
+        this.emitting = false;
+      } else {
+        this.flickerNozzle();
+        this.emitAccumulator += EMIT_PER_SECOND * deltaTimeSeconds;
+        while (this.emitAccumulator >= 1) {
+          this.emitAccumulator -= 1;
+          this.spawnParticle();
+        }
+      }
+    }
+
+    this.ageParticles(deltaTimeSeconds);
+
+    if (!this.emitting && this.aliveCount === 0) {
+      this.done = true;
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.points) this.scene.remove(this.points);
+    this.geometry?.dispose();
+    this.material?.dispose();
+    this.points = null;
+    this.geometry = null;
+    this.material = null;
+    this.positions = null;
+    this.velocities = null;
+    this.ages = null;
+    this.lifetimes = null;
+    this.flameCore = null;
+    this.flameOuter = null;
+    this.engineLight = null;
+  }
+
+  private resolveNozzle(entity: Entity): boolean {
+    const mesh = entity.getComponent<MeshComponent>(ComponentType.Mesh);
+    if (mesh) {
+      const core =
+        (mesh.root.userData as ExhaustUserData).flameCore ?? this.flameCore;
+      if (core) {
+        core.getWorldPosition(this.nozzleWorld);
+        return true;
+      }
+      this.nozzleWorld.copy(mesh.root.position);
+      return true;
+    }
+
+    const transform = entity.getComponent<TransformComponent>(
+      ComponentType.Transform,
+    );
+    if (!transform) return false;
+    const p = FPVector3.ToFloat(transform.fpPosition);
+    this.nozzleWorld.set(p.x, p.y, p.z);
+    return true;
+  }
+
+  private spawnParticle(): void {
+    if (
+      !this.positions ||
+      !this.velocities ||
+      !this.ages ||
+      !this.lifetimes
+    ) {
+      return;
+    }
+    if (this.aliveCount >= PARTICLE_CAPACITY) return;
+
+    const i = this.aliveCount++;
+    const o = i * 3;
+    this.positions[o] = this.nozzleWorld.x + (Math.random() - 0.5) * 0.25;
+    this.positions[o + 1] =
+      this.nozzleWorld.y + (Math.random() - 0.5) * 0.25;
+    this.positions[o + 2] = this.nozzleWorld.z + (Math.random() - 0.5) * 0.25;
+
+    this.velocities[o] = (Math.random() - 0.5) * 0.35;
+    this.velocities[o + 1] = 0.35 + Math.random() * 0.45;
+    this.velocities[o + 2] = (Math.random() - 0.5) * 0.35;
+
+    this.ages[i] = 0;
+    this.lifetimes[i] = LIFE_MIN + Math.random() * (LIFE_MAX - LIFE_MIN);
+    this.syncDrawRange();
+  }
+
+  private ageParticles(dt: number): void {
+    if (
+      !this.positions ||
+      !this.velocities ||
+      !this.ages ||
+      !this.lifetimes ||
+      !this.geometry
+    ) {
+      return;
+    }
+
+    let write = 0;
+    for (let read = 0; read < this.aliveCount; read++) {
+      const life = this.lifetimes[read]!;
+      const age = this.ages[read]! + dt;
+      if (age >= life) continue;
+
+      const ro = read * 3;
+      const wo = write * 3;
+      this.positions[wo] =
+        this.positions[ro]! + this.velocities[ro]! * dt;
+      this.positions[wo + 1] =
+        this.positions[ro + 1]! + this.velocities[ro + 1]! * dt;
+      this.positions[wo + 2] =
+        this.positions[ro + 2]! + this.velocities[ro + 2]! * dt;
+      this.velocities[wo] = this.velocities[ro]!;
+      this.velocities[wo + 1] = this.velocities[ro + 1]!;
+      this.velocities[wo + 2] = this.velocities[ro + 2]!;
+      this.ages[write] = age;
+      this.lifetimes[write] = life;
+      write++;
+    }
+    this.aliveCount = write;
+    this.geometry.attributes.position.needsUpdate = true;
+    this.syncDrawRange();
+
+    if (this.material) {
+      this.material.opacity = this.emitting ? 0.45 : 0.35;
+    }
+  }
+
+  private syncDrawRange(): void {
+    this.geometry?.setDrawRange(0, this.aliveCount);
+  }
+
+  private flickerNozzle(): void {
+    const pulse = 0.85 + 0.15 * Math.sin(this.elapsed * 18 + Math.random());
+    const coreMat = this.flameCore?.material as
+      | THREE.MeshBasicMaterial
+      | undefined;
+    const outerMat = this.flameOuter?.material as
+      | THREE.MeshBasicMaterial
+      | undefined;
+    if (coreMat) coreMat.opacity = BASE_CORE_OPACITY * pulse;
+    if (outerMat) {
+      outerMat.opacity = BASE_OUTER_OPACITY * (0.9 + 0.1 * pulse);
+    }
+    if (this.engineLight) {
+      this.engineLight.intensity = BASE_LIGHT_INTENSITY * pulse;
+      this.engineLight.visible = true;
+    }
+  }
+
+  private restoreNozzleDefaults(lightOn: boolean): void {
+    const coreMat = this.flameCore?.material as
+      | THREE.MeshBasicMaterial
+      | undefined;
+    const outerMat = this.flameOuter?.material as
+      | THREE.MeshBasicMaterial
+      | undefined;
+    if (coreMat) coreMat.opacity = BASE_CORE_OPACITY;
+    if (outerMat) outerMat.opacity = BASE_OUTER_OPACITY;
+    if (this.engineLight) {
+      this.engineLight.intensity = BASE_LIGHT_INTENSITY;
+      this.engineLight.visible = lightOn;
+    }
+  }
+}

--- a/abilities-playground/src/cues/vfxHelpers.ts
+++ b/abilities-playground/src/cues/vfxHelpers.ts
@@ -1,5 +1,32 @@
+import * as THREE from 'three';
+
 export function clamp01(x: number): number {
   return Math.max(0, Math.min(1, x));
+}
+
+/** Soft radial alpha disc for Points sprites (shared, do not dispose per-cue). */
+let softCircleTexture: THREE.CanvasTexture | null = null;
+
+export function getSoftCircleTexture(): THREE.CanvasTexture {
+  if (softCircleTexture) return softCircleTexture;
+
+  const size = 64;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d')!;
+  const mid = size * 0.5;
+  const gradient = ctx.createRadialGradient(mid, mid, 0, mid, mid, mid);
+  gradient.addColorStop(0, 'rgba(255,255,255,0.85)');
+  gradient.addColorStop(0.35, 'rgba(255,255,255,0.45)');
+  gradient.addColorStop(0.7, 'rgba(255,255,255,0.12)');
+  gradient.addColorStop(1, 'rgba(255,255,255,0)');
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, size, size);
+
+  softCircleTexture = new THREE.CanvasTexture(canvas);
+  softCircleTexture.needsUpdate = true;
+  return softCircleTexture;
 }
 
 export function easeOutCubic(t: number): number {

--- a/abilities-playground/src/hooks/MissileVolley.ts
+++ b/abilities-playground/src/hooks/MissileVolley.ts
@@ -11,7 +11,14 @@ import {
 } from '../components';
 import { MissileEntity } from '../entities/Missile';
 import { ROCKET_MAX_TARGETS } from '../config/abilityDefinitions';
+import { MISSILE_MIN_ENGAGEMENT_RANGE } from '../config/constants';
 import { dispatchMissileExhaustCue } from './dispatchMissileExhaustCue';
+
+/** Squared minimum engagement range: rockets ignore enemies closer than this. */
+const MIN_ENGAGE_RANGE_SQ = FP.Mul(
+  FP.FromFloat(MISSILE_MIN_ENGAGEMENT_RANGE),
+  FP.FromFloat(MISSILE_MIN_ENGAGEMENT_RANGE)
+);
 
 /**
  * Missile volley activation hook.
@@ -82,9 +89,9 @@ export const missileVolley = (
 
 /**
  * Deterministic nearest-enemy selection: filters the spatial-grid result to
- * alive, hostile, typed units, sorts by squared XZ distance (ties broken by
- * ascending entity id), and returns up to `max` ids. Pure function of its
- * inputs — lockstep-safe.
+ * alive, hostile, typed units beyond the minimum engage range, sorts by squared
+ * XZ distance (ties broken by ascending entity id), and returns up to `max` ids.
+ * Pure function of its inputs — lockstep-safe.
  */
 function pickNearestEnemies(
   selfId: number,
@@ -113,7 +120,10 @@ function pickNearestEnemies(
 
     const dx = FP.Sub(targetTransform.fpPosition.x, cx);
     const dz = FP.Sub(targetTransform.fpPosition.z, cz);
-    candidates.push({ id, d2: FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz)) });
+    const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+    // Artillery has a dead zone: skip enemies inside the minimum engage range.
+    if (FP.Lt(d2, MIN_ENGAGE_RANGE_SQ)) continue;
+    candidates.push({ id, d2 });
   }
 
   candidates.sort((a, b) =>

--- a/abilities-playground/src/hooks/MissileVolley.ts
+++ b/abilities-playground/src/hooks/MissileVolley.ts
@@ -11,6 +11,7 @@ import {
 } from '../components';
 import { MissileEntity } from '../entities/Missile';
 import { ROCKET_MAX_TARGETS } from '../config/abilityDefinitions';
+import { dispatchMissileExhaustCue } from './dispatchMissileExhaustCue';
 
 /**
  * Missile volley activation hook.
@@ -67,7 +68,7 @@ export const missileVolley = (
   );
 
   for (let i = 0; i < targets.length; i++) {
-    world.pools.spawn<MissileEntity>('missile', {
+    const missile = world.pools.spawn<MissileEntity>('missile', {
       fpPosition: origin,
       targetEntityId: targets[i],
       teamId: team.teamId,
@@ -75,6 +76,7 @@ export const missileVolley = (
       volleyCount: targets.length,
       launcherRotation: transform.fpRotation,
     });
+    dispatchMissileExhaustCue(world, missile.id, ctx.tick);
   }
 };
 

--- a/abilities-playground/src/hooks/dispatchMissileExhaustCue.ts
+++ b/abilities-playground/src/hooks/dispatchMissileExhaustCue.ts
@@ -1,0 +1,22 @@
+import {
+  gameplayCueKey,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import type { GameWorld } from '@phalanx-engine/ecs';
+
+export const MISSILE_EXHAUST_CUE_ID = 'Cue.Missile.Exhaust';
+
+export function dispatchMissileExhaustCue(
+  world: GameWorld,
+  missileId: number,
+  tick: number,
+): void {
+  const event: GameplayCueDispatchedEvent = {
+    tick,
+    cueId: MISSILE_EXHAUST_CUE_ID,
+    sourceEntityId: missileId,
+    targetEntityId: missileId,
+    phase: 'OnApplied',
+  };
+  world.eventBus.emit(gameplayCueKey(MISSILE_EXHAUST_CUE_ID), event);
+}

--- a/abilities-playground/src/systems/MissileMovementSystem.ts
+++ b/abilities-playground/src/systems/MissileMovementSystem.ts
@@ -96,7 +96,10 @@ export class MissileMovementSystem extends GameSystem {
     this.physicsStore.arrays.velocityZ[pIdx] = 0n;
   }
 
-  /** Full cruise altitude above spawn. Every missile flies the complete arc. */
+  /**
+   * Full cruise altitude above spawn. Reached once the launch arc completes;
+   * a missile may dive early if it closes to within MISSILE_ATTACK_RANGE first.
+   */
   private cruiseAltitude(mc: MissileComponent): FixedPoint {
     const height = FP.Mul(
       FP.FromFloat(MISSILE_LAUNCH_HEIGHT),

--- a/abilities-playground/src/systems/MissileMovementSystem.ts
+++ b/abilities-playground/src/systems/MissileMovementSystem.ts
@@ -15,7 +15,6 @@ import {
   MISSILE_SPEED,
   MISSILE_LAUNCH_HEIGHT,
   MISSILE_ATTACK_RANGE,
-  MISSILE_LAUNCH_ARC_FALLOFF,
   PROJECTILE_DESPAWN_DELAY_TICKS,
   MISSILE_RETARGET_RANGE,
 } from '../config/constants';
@@ -37,8 +36,6 @@ const FP_SPEED = FP.FromFloat(MISSILE_SPEED);
 const FP_STEP = FP.Mul(FP_SPEED, FP_TICK);
 const FP_ATTACK_RANGE = FP.FromFloat(MISSILE_ATTACK_RANGE);
 const FP_ATTACK_RANGE_SQ = FP.Mul(FP_ATTACK_RANGE, FP_ATTACK_RANGE);
-const FP_ARC_FALLOFF = FP.FromFloat(MISSILE_LAUNCH_ARC_FALLOFF);
-const FP_ARC_FALLOFF_SQ = FP.Mul(FP_ARC_FALLOFF, FP_ARC_FALLOFF);
 const FP_RETARGET_RANGE = FP.FromFloat(MISSILE_RETARGET_RANGE);
 
 type FlatOffset = { dx: FixedPoint; dz: FixedPoint; distSq: FixedPoint };
@@ -99,23 +96,12 @@ export class MissileMovementSystem extends GameSystem {
     this.physicsStore.arrays.velocityZ[pIdx] = 0n;
   }
 
-  /** Scales launch/cruise altitude down as the target gets closer. */
-  private cruiseAltitude(
-    mc: MissileComponent,
-    flatDistSq: FixedPoint | null
-  ): FixedPoint {
-    let height = FP.Mul(
+  /** Full cruise altitude above spawn. Every missile flies the complete arc. */
+  private cruiseAltitude(mc: MissileComponent): FixedPoint {
+    const height = FP.Mul(
       FP.FromFloat(MISSILE_LAUNCH_HEIGHT),
       mc.launchHeightScale
     );
-    if (
-      flatDistSq !== null &&
-      FP.Lt(flatDistSq, FP_ARC_FALLOFF_SQ) &&
-      FP.Gt(flatDistSq, FP._0)
-    ) {
-      const ratio = FP.Div(FP.Sqrt(flatDistSq), FP_ARC_FALLOFF);
-      height = FP.Mul(height, ratio);
-    }
     return FP.Add(mc.spawnY, height);
   }
 
@@ -149,12 +135,8 @@ export class MissileMovementSystem extends GameSystem {
     );
   }
 
-  private clampMinAltitude(
-    mc: MissileComponent,
-    tIdx: number,
-    flatDistSq: FixedPoint | null
-  ): void {
-    const minY = this.cruiseAltitude(mc, flatDistSq);
+  private clampMinAltitude(mc: MissileComponent, tIdx: number): void {
+    const minY = this.cruiseAltitude(mc);
     const currentY = FP.FromRaw(this.transformStore.arrays.fpPositionY[tIdx]);
     if (FP.Lt(currentY, minY)) {
       this.transformStore.arrays.fpPositionY[tIdx] = FP.ToRaw(minY);
@@ -213,15 +195,11 @@ export class MissileMovementSystem extends GameSystem {
     this.disablePhysics(pIdx);
 
     const flat = this.flatOffsetToTarget(mc, tIdx);
-    if (flat !== null) {
-      if (this.tryEnterAttack(missile, mc, tIdx, pIdx, tick, flat.distSq)) {
-        return;
-      }
-      if (FP.Lte(flat.distSq, FP_ARC_FALLOFF_SQ)) {
-        mc.phase = 'approach';
-        this.tickApproach(missile, mc, tIdx, pIdx, tick);
-        return;
-      }
+    if (
+      flat !== null &&
+      this.tryEnterAttack(missile, mc, tIdx, pIdx, tick, flat.distSq)
+    ) {
+      return;
     }
 
     this.moveAlongForward(tIdx, FP_STEP);
@@ -255,7 +233,7 @@ export class MissileMovementSystem extends GameSystem {
       return;
     }
 
-    this.clampMinAltitude(mc, tIdx, flat.distSq);
+    this.clampMinAltitude(mc, tIdx);
     this.stepFlatTowardTarget(flat, tIdx);
   }
 

--- a/abilities-playground/tests/MissileQuaternion.test.ts
+++ b/abilities-playground/tests/MissileQuaternion.test.ts
@@ -24,7 +24,8 @@ import { MissileMovementSystem } from '../src/systems/MissileMovementSystem';
 import { MissileTargetingSystem } from '../src/systems/MissileTargetingSystem';
 import {
   MISSILE_ATTACK_RANGE,
-  MISSILE_LAUNCH_ARC_FALLOFF,
+  MISSILE_MIN_ENGAGEMENT_RANGE,
+  MISSILE_LAUNCH_TICKS,
 } from '../src/config/constants';
 
 function readRotation(
@@ -265,10 +266,10 @@ describe('Missile FP quaternion migration', () => {
       expect(mc.phase).toBe('attack');
     });
 
-    it('skips launch and enters approach when the target is within arc falloff', () => {
+    it('flies the full launch arc for a target beyond attack range', () => {
       const target = addTarget(
         entityManager,
-        FPVector3.FromFloat(MISSILE_LAUNCH_ARC_FALLOFF - 5, 0, 0),
+        FPVector3.FromFloat(MISSILE_MIN_ENGAGEMENT_RANGE - 5, 0, 0),
       );
 
       const missile = new MissileEntity();
@@ -286,11 +287,15 @@ describe('Missile FP quaternion migration', () => {
       mc.targetEntityId = target.id;
       mc.spawnY = FP._0;
       mc.launchHeightScale = FP._1;
+      mc.launchTicksRemaining = MISSILE_LAUNCH_TICKS;
       missile.active = true;
 
       movementSystem.processTick(0);
 
-      expect(mc.phase).toBe('approach');
+      // Close-range flat-homing was removed: the missile keeps flying its launch
+      // arc instead of dropping straight into an approach.
+      expect(mc.phase).toBe('launch');
+      expect(mc.launchTicksRemaining).toBe(MISSILE_LAUNCH_TICKS - 1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- Soft realistic missile nozzle glow (layered additive cones + short-range PointLight) on `createMissile`
- New presentation-only `MissileExhaustCue` with non-deterministic gray smoke trails (~1.5–2.5s) and nozzle flicker
- Dispatch `Cue.Missile.Exhaust` from missile volley spawn via the existing gameplay-cue event-bus path

## Test plan
- [ ] `npx tsc --noEmit` in abilities-playground
- [ ] Run playground, fire a missile volley — soft warm glow at nozzle
- [ ] Confirm gray smoke trails linger roughly 1.5–2.5s
- [ ] Confirm impact cue still plays
- [ ] Confirm no leftover smoke Points after missiles clear / battle reset
