### PR TITLE
feat(physics): add generic gravity and 3D impulse

### DIFF
--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -3,7 +3,7 @@ name: phalanx-physics
 description: Add deterministic fixed-point physics to a game using the phalanx-physics library from the phalanx-engine repository. Use when the user wants to set up collision detection, velocity integration, spatial hashing, or physics bodies. Covers PhysicsWorld facade, TransformComponent, InterpolationSystem, PhysicsBodyComponent, SpatialHashGrid, NarrowPhase, PhysicsSystem, and collision filtering patterns.
 metadata:
   author: phaeton2040-AI
-  version: '1.3'
+  version: '1.4'
 ---
 
 # Phalanx Physics Skill
@@ -20,6 +20,7 @@ Use this skill when the user asks to:
 - Add game-specific collision filtering (e.g., team-based rules)
 - Query entities by spatial proximity (range queries)
 - Add gravity or launch arcing/ballistic ordnance (artillery, shrapnel, projectiles)
+- Detect a 3D collision — e.g. ordnance hitting a static obstacle like a building — via a swept-segment raycast (workaround until full 3D body-body collision exists)
 - Wire physics systems into a GameWorld tick pipeline
 - Set up tick-to-frame interpolation for rendering
 
@@ -418,7 +419,7 @@ import type { PhysicsBodyConfig } from '@phalanx-engine/physics';
 
 // Collision primitives
 import { SpatialHashGrid, NarrowPhase, segmentVsAABB } from '@phalanx-engine/physics';
-import type { CollisionManifold, AABB3, RayHit } from '@phalanx-engine/physics';
+import type { CollisionManifold, RayHit, Vec3FP, AABB } from '@phalanx-engine/physics';
 
 // Systems
 import { PhysicsSystem, GravitySystem, InterpolationSystem } from '@phalanx-engine/physics';
@@ -503,27 +504,47 @@ physicsWorld.applyImpulse3D(
 - Need gravity along X or Z? → not supported in v1 (`GravitySystem` throws). X/Z are owned by `PhysicsSystem`'s integrator; ceding an axis is a v2 change.
 - Gravity magnitude is applied per whole tick (`gravity * tickDt`), not per sub-step, so very high gravity + few ticks is a coarse approximation — increase tick rate for smoother arcs.
 
-### 3D collision workaround (raycast)
+## Raycast / Swept-Segment Queries (3D collision workaround)
 
-The body-vs-body narrow phase is **2D/XZ only** (circles, no height). For 3D
-collision — e.g. a fast ordnance (shrapnel / shell / projectile) hitting a static
-obstacle (building) where you need the impact point + surface normal — use the
-**swept-segment raycast** as a **workaround** until full 3D body-body collision
-ships (v2: `BoxColliderComponent` + grid raycast + 3D sphere/box resolution).
+> ⚠️ **Workaround for 3D collisions.** The core pipeline is 2D/XZ and does not
+> detect Y-axis collisions. For 3D collisions — e.g. ordnance hitting a static
+> obstacle like a building — use this swept-segment raycast query as a workaround
+> until full 3D body-body collision is implemented (planned for v2).
 
-- `physicsWorld.raycastSegment(prev, cur, boxes)` — scans caller-supplied static
-  `AABB3` boxes, returns nearest `{ t, point, normal }` or `null`.
-- `segmentVsAABB(prev, cur, box)` — pure slab-method primitive (`t` in `[0,1]`,
-  `point = lerp(prev,cur,t)`, `normal` = outward entry-face normal).
-- Swept segment (not point-in-box) prevents tunneling through thin walls.
-- Unit-vs-unit 2D circle pipeline is untouched.
-- Decision tree:
-  - Need to know where a fast ordnance hit a static obstacle (point + normal)?
-    → `raycastSegment(prevPos, curPos, buildingBoxes)` each tick; on hit, react
-    (secondary AoE at `hit.point`, ricochet along `hit.normal`, despawn).
-  - Ground landing? → model ground as a big flat `AABB3` (same query) or a plane check.
-  - Obstacle count in the hundreds+? → v1 linear scan still works; v2 will add a
-    spatial grid once `BoxColliderComponent` exists.
+`raycastSegment` sweeps a moving point (a body's previous → current position)
+against caller-supplied AABBs and returns the nearest hit — impact point and
+outward face normal — or `null`. `segmentVsAABB` is the single-box primitive.
+
+```typescript
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import type { Vec3FP, AABB, RayHit } from '@phalanx-engine/physics';
+
+const hit: RayHit | null = physicsWorld.raycastSegment(prevPos, curPos, buildingBoxes);
+if (hit) {
+  // hit.t ∈ [0,1] (0 at prev, 1 at cur); hit.point = lerp(prev, cur, t)
+  // hit.normal = outward entry-face normal (±X/±Y/±Z), fixed-point
+  detonateAt(hit.point, hit.normal);
+}
+```
+
+Semantics: `t ∈ [0,1]`; segment starting inside a box → `t=0`, `point=prev`,
+`normal` = nearest face. Fully deterministic `FP.*` math — degenerate cases
+(parallel-to-slab, zero-length) never divide-by-zero or produce `NaN`.
+
+### Raycast decision tree
+
+- Need to detect ordnance/projectile hitting a static 3D obstacle (building,
+  wall)? → build the obstacle `AABB[]` and call `raycastSegment(prev, cur, boxes)`
+  each tick. **This is the sanctioned 3D-collision workaround.**
+- Need unit-vs-unit collision? → that stays in the 2D/XZ `PhysicsSystem`
+  circle-vs-circle pipeline; do **not** use raycast for it.
+- Testing a single box? → use `segmentVsAABB` directly.
+
+**v1 limitations (workaround scope):** pure linear scan over caller-supplied
+boxes (no broad-phase / spatial-hash acceleration); the moving body is a point
+(radius not swept — inflate the box for a margin); unit-vs-unit stays 2D/XZ.
+**v2 path:** `BoxColliderComponent`, grid-accelerated raycasts, and true 3D
+body-body collision resolution.
 
 ## Best Practices
 

--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -417,8 +417,8 @@ import {
 import type { PhysicsBodyConfig } from '@phalanx-engine/physics';
 
 // Collision primitives
-import { SpatialHashGrid, NarrowPhase } from '@phalanx-engine/physics';
-import type { CollisionManifold } from '@phalanx-engine/physics';
+import { SpatialHashGrid, NarrowPhase, segmentVsAABB } from '@phalanx-engine/physics';
+import type { CollisionManifold, AABB3, RayHit } from '@phalanx-engine/physics';
 
 // Systems
 import { PhysicsSystem, GravitySystem, InterpolationSystem } from '@phalanx-engine/physics';
@@ -502,6 +502,28 @@ physicsWorld.applyImpulse3D(
 - Body is static (`isStatic=1`)? → `GravitySystem` skips it, so `static + useGravity` is a clean no-op (statics never integrate position).
 - Need gravity along X or Z? → not supported in v1 (`GravitySystem` throws). X/Z are owned by `PhysicsSystem`'s integrator; ceding an axis is a v2 change.
 - Gravity magnitude is applied per whole tick (`gravity * tickDt`), not per sub-step, so very high gravity + few ticks is a coarse approximation — increase tick rate for smoother arcs.
+
+### 3D collision workaround (raycast)
+
+The body-vs-body narrow phase is **2D/XZ only** (circles, no height). For 3D
+collision — e.g. a fast ordnance (shrapnel / shell / projectile) hitting a static
+obstacle (building) where you need the impact point + surface normal — use the
+**swept-segment raycast** as a **workaround** until full 3D body-body collision
+ships (v2: `BoxColliderComponent` + grid raycast + 3D sphere/box resolution).
+
+- `physicsWorld.raycastSegment(prev, cur, boxes)` — scans caller-supplied static
+  `AABB3` boxes, returns nearest `{ t, point, normal }` or `null`.
+- `segmentVsAABB(prev, cur, box)` — pure slab-method primitive (`t` in `[0,1]`,
+  `point = lerp(prev,cur,t)`, `normal` = outward entry-face normal).
+- Swept segment (not point-in-box) prevents tunneling through thin walls.
+- Unit-vs-unit 2D circle pipeline is untouched.
+- Decision tree:
+  - Need to know where a fast ordnance hit a static obstacle (point + normal)?
+    → `raycastSegment(prevPos, curPos, buildingBoxes)` each tick; on hit, react
+    (secondary AoE at `hit.point`, ricochet along `hit.normal`, despawn).
+  - Ground landing? → model ground as a big flat `AABB3` (same query) or a plane check.
+  - Obstacle count in the hundreds+? → v1 linear scan still works; v2 will add a
+    spatial grid once `BoxColliderComponent` exists.
 
 ## Best Practices
 

--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -3,7 +3,7 @@ name: phalanx-physics
 description: Add deterministic fixed-point physics to a game using the phalanx-physics library from the phalanx-engine repository. Use when the user wants to set up collision detection, velocity integration, spatial hashing, or physics bodies. Covers PhysicsWorld facade, TransformComponent, InterpolationSystem, PhysicsBodyComponent, SpatialHashGrid, NarrowPhase, PhysicsSystem, and collision filtering patterns.
 metadata:
   author: phaeton2040-AI
-  version: '1.2'
+  version: '1.3'
 ---
 
 # Phalanx Physics Skill
@@ -19,6 +19,7 @@ Use this skill when the user asks to:
 - Implement deterministic collision resolution for lockstep multiplayer
 - Add game-specific collision filtering (e.g., team-based rules)
 - Query entities by spatial proximity (range queries)
+- Add gravity or launch arcing/ballistic ordnance (artillery, shrapnel, projectiles)
 - Wire physics systems into a GameWorld tick pipeline
 - Set up tick-to-frame interpolation for rendering
 
@@ -32,6 +33,7 @@ Use this skill when the user asks to:
 
 ```
 PhysicsWorld (Facade)
+├── GravitySystem         ← Applies acceleration to velocityY (runs BEFORE PhysicsSystem)
 ├── PhysicsSystem         ← Velocity integration + collision pipeline (sub-stepped)
 │   ├── SpatialHashGrid   ← O(n) broad-phase via spatial hashing
 │   └── NarrowPhase       ← Circle vs Circle collision tests
@@ -43,6 +45,8 @@ PhysicsWorld (Facade)
 Pipeline per tick (all deterministic, fixed-point):
 ```
 MovementSystem (game-specific, sets velocities)
+    ↓
+GravitySystem.processTick()   ← velocityY -= gravity * dt (only bodies with useGravity=1)
     ↓
 PhysicsSystem.processTick()
     for each sub-step:
@@ -349,6 +353,7 @@ Attach `InterpolationComponent` on any entity that needs render smoothing alongs
 | `friction`      | `i64` | `BigInt64Array`  | Surface friction (raw FixedPoint)     |
 | `isStatic`      | `u8`  | `Uint8Array`     | 1 = immovable, 0 = dynamic           |
 | `ignorePhysics` | `u8`  | `Uint8Array`     | 1 = skip all physics, 0 = active     |
+| `useGravity`    | `u8`  | `Uint8Array`     | 1 = GravitySystem applies gravity, 0 = ignore (default) |
 | `lastX`         | `f64` | `Float64Array`   | Cached float X position               |
 | `lastZ`         | `f64` | `Float64Array`   | Cached float Z position               |
 
@@ -369,6 +374,8 @@ interface PhysicsWorldConfig {
   tickProvider?: IPhysicsTickProvider;
   ejectOnBoundsExit?: boolean;
   settleThreshold?: FixedPoint;
+  gravity?: FixedPoint;             // Acceleration magnitude (default: FP._0 = disabled)
+  gravityAxis?: 'x' | 'y' | 'z';   // Gravity axis (default: 'y'; only 'y' supported in v1)
 }
 ```
 
@@ -414,7 +421,7 @@ import { SpatialHashGrid, NarrowPhase } from '@phalanx-engine/physics';
 import type { CollisionManifold } from '@phalanx-engine/physics';
 
 // Systems
-import { PhysicsSystem, InterpolationSystem } from '@phalanx-engine/physics';
+import { PhysicsSystem, GravitySystem, InterpolationSystem } from '@phalanx-engine/physics';
 import type { InterpolatedTransformSample } from '@phalanx-engine/physics';
 
 // Facade
@@ -439,6 +446,61 @@ import type {
 ```
 
 > Note: `TransformFieldMapping` and `setTransformStore()` have been removed. Use the built-in `TransformComponent` instead.
+
+## Gravity & Ballistic Ordnance
+
+`GravitySystem` adds optional deterministic gravity. It follows a strict **one-owner-per-axis** rule:
+
+- **GravitySystem applies ACCELERATION only**: `velocityY -= gravity * dt` for bodies with `useGravity = 1`. It never writes position.
+- **PhysicsSystem owns position integration**: `posY += velY * dt` happens in `applyVelocities`, alongside X/Z.
+- Collisions remain 2D/XZ — Y never affects broad/narrow phase. `maxVelocity` and `worldBounds` clamps stay XZ-only.
+
+Enable it by passing `gravity` (and optionally `gravityAxis`) to `PhysicsWorld`, then flag individual bodies:
+
+```typescript
+const physicsWorld = new PhysicsWorld({
+  // ...
+  gravity: FP.FromFloat(9.8),   // acceleration magnitude; default FP._0 disables gravity
+  gravityAxis: 'y',              // default 'y'; 'x'/'z' throw in v1
+});
+
+// Per-body opt-in (default false — existing bodies are unaffected):
+entity.addComponent(new PhysicsBodyComponent(entity.id, {
+  radius: FP.FromFloat(0.5),
+  mass: FP.FromFloat(1.0),
+  useGravity: true,
+}));
+```
+
+Register `gravitySystem` as a tick system **before** `physicsSystem`:
+
+```typescript
+const { gravitySystem, physicsSystem, interpolationSystem } = physicsWorld.getSystems();
+world.registerSystems([gravitySystem, physicsSystem, /* ... */], [interpolationSystem]);
+```
+
+### Firing arcing ordnance (artillery / shrapnel)
+
+Use `applyImpulse3D` to launch a body on a ballistic arc in one call — it sets all three velocity components and clears `ignorePhysics`:
+
+```typescript
+// Launch a shell up and forward; gravity pulls it back into a parabola.
+physicsWorld.applyImpulse3D(
+  shellId,
+  FP.FromFloat(0),    // vx
+  FP.FromFloat(20),   // vy (up)
+  FP.FromFloat(30),   // vz (forward)
+);
+```
+
+> `applyImpulse` (XZ-only) is unchanged for grounded knockback. Use `applyImpulse3D` when the Y component matters.
+
+### Gravity decision tree
+
+- Body should fall / arc (projectile, shell, fragment, jump)? → set `useGravity: true` and give it a launch velocity (`applyImpulse3D`).
+- Body is ground-plane only (units, most gameplay)? → leave `useGravity` false (default); it never moves on Y.
+- Need gravity along X or Z? → not supported in v1 (`GravitySystem` throws). X/Z are owned by `PhysicsSystem`'s integrator; ceding an axis is a v2 change.
+- Gravity magnitude is applied per whole tick (`gravity * tickDt`), not per sub-step, so very high gravity + few ticks is a coarse approximation — increase tick rate for smoother arcs.
 
 ## Best Practices
 

--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -499,6 +499,7 @@ physicsWorld.applyImpulse3D(
 
 - Body should fall / arc (projectile, shell, fragment, jump)? → set `useGravity: true` and give it a launch velocity (`applyImpulse3D`).
 - Body is ground-plane only (units, most gameplay)? → leave `useGravity` false (default); it never moves on Y.
+- Body is static (`isStatic=1`)? → `GravitySystem` skips it, so `static + useGravity` is a clean no-op (statics never integrate position).
 - Need gravity along X or Z? → not supported in v1 (`GravitySystem` throws). X/Z are owned by `PhysicsSystem`'s integrator; ceding an axis is a v2 change.
 - Gravity magnitude is applied per whole tick (`gravity * tickDt`), not per sub-step, so very high gravity + few ticks is a coarse approximation — increase tick rate for smoother arcs.
 

--- a/abilities-playground/index.html
+++ b/abilities-playground/index.html
@@ -294,6 +294,9 @@
           <button id="unit-btn-plasma-tank" type="button" data-unit-type="plasmaTank">
             Plasma Tank
           </button>
+          <button id="unit-btn-sau" type="button" data-unit-type="sau">
+            SAU
+          </button>
         </div>
       </div>
 

--- a/abilities-playground/src/components/ArtilleryShellComponent.ts
+++ b/abilities-playground/src/components/ArtilleryShellComponent.ts
@@ -1,0 +1,52 @@
+import type { IComponent } from './Component.ts';
+import { ComponentType } from './Component.ts';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import type { FPVector3 as FPVector3Type } from '@phalanx-engine/math';
+import type { TeamId } from './UnitComponents';
+
+/** Deterministic shrapnel spray configuration carried by a shell. */
+export interface ShrapnelConfig {
+  /** Number of fragments to spawn on detonation. */
+  count: number;
+  /** Half-angle (radians) of the upward launch cone. */
+  cone: FixedPoint;
+  /** Launch speed (world units/s) of each fragment. */
+  speed: FixedPoint;
+}
+
+/**
+ * ArtilleryShellComponent — logic-only marker for an in-flight SAU shell.
+ *
+ * The shell is NOT a visible flying projectile: it has no PhysicsBody and no
+ * mesh. It is a delayed-detonation timer that records the snapshotted impact
+ * point and the parameters ArtilleryShellSystem needs to resolve the blast and
+ * spawn shrapnel at `detonateTick`.
+ */
+export class ArtilleryShellComponent implements IComponent {
+  public readonly type = ComponentType.ArtilleryShell;
+
+  /** World-space point where the shell detonates (snapshotted at fire time). */
+  public readonly impactPoint: FPVector3Type = { x: FP._0, y: FP._0, z: FP._0 };
+
+  /** Firing unit (source of the resulting damage effects). */
+  public sourceEntityId = -1;
+  /** Firing unit's team; enemy-only blasts filter against this. */
+  public teamId: TeamId = 0;
+
+  /** Tick at which the shell detonates. */
+  public detonateTick = 0;
+
+  public primaryRadius: FixedPoint = FP._0;
+  public primaryEffectId = 'Effect.Damage.SAU.Primary';
+  public secondaryRadius: FixedPoint = FP._0;
+  public secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+
+  public shrapnelConfig: ShrapnelConfig = {
+    count: 0,
+    cone: FP._0,
+    speed: FP._0,
+  };
+
+  /** One-shot latch so the falling-shadow cue is emitted exactly once. */
+  public shadowEmitted = false;
+}

--- a/abilities-playground/src/components/Component.ts
+++ b/abilities-playground/src/components/Component.ts
@@ -28,6 +28,8 @@ export const ComponentType = createComponentTypeRegistry({
   AutoAttackTimer: 'AutoAttackTimer',
   Missile: 'Missile',
   SupportUnitTargeting: 'SupportUnitTargeting',
+  ArtilleryShell: 'ArtilleryShell',
+  ShrapnelPayload: 'ShrapnelPayload',
 });
 
 (ComponentType as Record<string, symbol>).PhysicsBody =

--- a/abilities-playground/src/components/ShrapnelPayloadComponent.ts
+++ b/abilities-playground/src/components/ShrapnelPayloadComponent.ts
@@ -1,0 +1,31 @@
+import type { IComponent } from './Component.ts';
+import { ComponentType } from './Component.ts';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import type { TeamId } from './UnitComponents';
+
+/**
+ * ShrapnelPayloadComponent — secondary-blast data carried by a flying shrapnel
+ * fragment plus the previous-tick position needed for swept landing detection.
+ *
+ * ShrapnelLandingSystem sweeps prev→cur each tick to find the exact ground
+ * crossing (v1: ground plane only), then applies the secondary AoE from the
+ * original firing unit — resolved even if that unit has since died.
+ */
+export class ShrapnelPayloadComponent implements IComponent {
+  public readonly type = ComponentType.ShrapnelPayload;
+
+  /** Firing unit (source of the secondary damage; may be dead by landing). */
+  public sourceEntityId = -1;
+  public teamId: TeamId = 0;
+
+  public secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+  public secondaryRadius: FixedPoint = FP._0;
+
+  /** Previous-tick world position, for the prev→cur landing sweep. */
+  public prevPosX: FixedPoint = FP._0;
+  public prevPosY: FixedPoint = FP._0;
+  public prevPosZ: FixedPoint = FP._0;
+
+  /** Set true once the fragment has landed and resolved its blast. */
+  public landed = false;
+}

--- a/abilities-playground/src/components/UnitComponents.ts
+++ b/abilities-playground/src/components/UnitComponents.ts
@@ -266,6 +266,61 @@ export class MeshComponent implements IPoolableComponent {
     return new MeshComponent(group);
   }
 
+  /**
+   * Shared shard geometry/material for all SAU shrapnel fragments. A single
+   * squashed tetrahedron reads as a jagged metal chunk; sharing one geometry
+   * and one material across every fragment keeps pooled spawns allocation-free.
+   * Never disposed — shrapnel is pooled, and this pair lives for the app's
+   * lifetime.
+   */
+  private static shrapnelGeometry?: THREE.BufferGeometry;
+  private static shrapnelMaterial?: THREE.MeshStandardMaterial;
+
+  /**
+   * Shared incendiary shard material. Exposed so the cosmetic ShrapnelSpinSystem
+   * can pulse its emissive intensity (the "about to blow" glow) once per frame
+   * for every fragment at once. Undefined until the first shard is created.
+   */
+  public static getShrapnelMaterial(): THREE.MeshStandardMaterial | undefined {
+    return MeshComponent.shrapnelMaterial;
+  }
+
+  /**
+   * Jagged incendiary shard for SAU shrapnel fragments — dark scorched metal
+   * with a hot glowing core, so it reads as live ordnance about to detonate
+   * rather than inert debris (its emissive glow is pulsed by ShrapnelSpinSystem).
+   * Root is a Group to match the RenderSync contract (world quaternion set on
+   * the root); the inner shard mesh stays free for cosmetic spin. Visibility is
+   * toggled by the pool hooks: hidden while dormant, shown on spawn.
+   */
+  public static createShrapnel(radius: number): MeshComponent {
+    if (!MeshComponent.shrapnelGeometry) {
+      const geometry = new THREE.TetrahedronGeometry(radius, 0);
+      // Non-uniform squash turns the regular tetrahedron into an irregular
+      // splinter silhouette from every angle.
+      geometry.scale(1.5, 0.55, 0.9);
+      MeshComponent.shrapnelGeometry = geometry;
+      MeshComponent.shrapnelMaterial = new THREE.MeshStandardMaterial({
+        color: 0x2b1a12,
+        roughness: 0.4,
+        metalness: 0.8,
+        emissive: 0xff5a1e,
+        emissiveIntensity: 1.6,
+        toneMapped: false,
+      });
+    }
+
+    const group = new THREE.Group();
+    const shard = new THREE.Mesh(
+      MeshComponent.shrapnelGeometry,
+      MeshComponent.shrapnelMaterial
+    );
+    shard.castShadow = true;
+    group.add(shard);
+    group.visible = false;
+    return new MeshComponent(group);
+  }
+
   constructor(root: THREE.Object3D) {
     this.root = root;
 

--- a/abilities-playground/src/components/index.ts
+++ b/abilities-playground/src/components/index.ts
@@ -23,3 +23,6 @@ export {
 export type { TeamId } from './UnitComponents';
 export { SpawnPointComponent } from './SpawnPointComponent';
 export { MissileComponent } from './MissileComponent';
+export { ArtilleryShellComponent } from './ArtilleryShellComponent';
+export type { ShrapnelConfig } from './ArtilleryShellComponent';
+export { ShrapnelPayloadComponent } from './ShrapnelPayloadComponent';

--- a/abilities-playground/src/config/abilityDefinitions.ts
+++ b/abilities-playground/src/config/abilityDefinitions.ts
@@ -132,7 +132,7 @@ export const SAU_PRIMARY_RADIUS = 10;
 /** Radius (world units) of each shrapnel fragment's secondary blast. */
 export const SAU_SECONDARY_RADIUS = 5;
 /** Number of shrapnel fragments sprayed on detonation. */
-export const SAU_SHRAPNEL_COUNT = 6;
+export const SAU_SHRAPNEL_COUNT = 3;
 /** Attack cooldown in ticks (80 ticks = 4 s @ 20 TPS) — deliberately slow siege cadence. */
 export const SAU_COOLDOWN_TICKS = 80;
 export const SAU_DETECTION_RANGE = 80;
@@ -252,7 +252,9 @@ export const combatDefs = defineAbilitySystem({
           magnitude: FP.FromFloat(-SAU_ATTACK_DAMAGE),
         },
       ],
-      cues: ['Cue.SAU.Impact'],
+      // No effect-attached cue: ArtilleryShellSystem emits Cue.SAU.Impact at the
+      // snapshotted impact point. An effect cue would dispatch from the effect
+      // source (the SAU), rendering a phantom blast on the firing unit.
     }),
     defineEffect({
       id: 'Effect.Damage.SAU.Secondary',
@@ -264,7 +266,8 @@ export const combatDefs = defineAbilitySystem({
           magnitude: FP.FromFloat(-SAU_SECONDARY_DAMAGE),
         },
       ],
-      cues: ['Cue.SAU.SecondaryImpact'],
+      // No effect-attached cue: ShrapnelLandingSystem emits
+      // Cue.SAU.SecondaryImpact at each fragment's landing point.
     }),
     defineEffect({
       id: 'Effect.Damage.Volt.Primary',

--- a/abilities-playground/src/config/abilityDefinitions.ts
+++ b/abilities-playground/src/config/abilityDefinitions.ts
@@ -116,6 +116,40 @@ export const VOLT_COOLDOWN_TAG = 'Cooldown.Ability.VoltAttack';
  */
 export const MISSILE_VOLLEY_COOLDOWN_TAG = 'Cooldown.Ability.MissileVolley';
 
+/**
+ * SAU (self-propelled artillery). A slow, long-range siege unit that lobs a
+ * delayed-detonation shell onto a snapshotted impact point. On detonation it
+ * deals a primary AoE and sprays gravity-affected shrapnel that deals a smaller
+ * secondary AoE where each fragment lands.
+ */
+export const SAU_MAX_HEALTH = 140;
+/** Primary AoE damage dealt to enemies inside {@link SAU_PRIMARY_RADIUS} at detonation. */
+export const SAU_ATTACK_DAMAGE = 45;
+/** Secondary AoE damage dealt where each shrapnel fragment lands. */
+export const SAU_SECONDARY_DAMAGE = 20;
+/** Radius (world units) of the primary blast around the impact point. */
+export const SAU_PRIMARY_RADIUS = 10;
+/** Radius (world units) of each shrapnel fragment's secondary blast. */
+export const SAU_SECONDARY_RADIUS = 5;
+/** Number of shrapnel fragments sprayed on detonation. */
+export const SAU_SHRAPNEL_COUNT = 6;
+/** Attack cooldown in ticks (80 ticks = 4 s @ 20 TPS) — deliberately slow siege cadence. */
+export const SAU_COOLDOWN_TICKS = 80;
+export const SAU_DETECTION_RANGE = 80;
+export const SAU_STOP_RANGE = 70;
+/** Minimum engagement range (world units, XZ): the SAU refuses to fire on enemies inside this dead zone. */
+export const SAU_MIN_ENGAGEMENT_RANGE = 30;
+
+/**
+ * Whether SAU blasts (primary + secondary) hit allied units. Enemy-only by
+ * default; flip to true to enable friendly fire. Named so the intent is explicit
+ * at every call site rather than a bare boolean literal.
+ */
+export const SAU_FRIENDLY_FIRE = false;
+
+/** Tag granted to a SAU while its artillery ability is on cooldown. */
+export const SAU_COOLDOWN_TAG = 'Cooldown.Ability.SAU';
+
 export const combatDefs = defineAbilitySystem({
   attributes: [
     defineAttribute({
@@ -200,6 +234,37 @@ export const combatDefs = defineAbilitySystem({
       durationTicks: VOLT_ATTACK_COOLDOWN_TICKS,
       modifiers: [],
       tagsGranted: [VOLT_COOLDOWN_TAG],
+    }),
+    defineEffect({
+      id: 'Effect.SAU.Cooldown',
+      type: 'Duration',
+      durationTicks: SAU_COOLDOWN_TICKS,
+      modifiers: [],
+      tagsGranted: [SAU_COOLDOWN_TAG],
+    }),
+    defineEffect({
+      id: 'Effect.Damage.SAU.Primary',
+      type: 'Instant',
+      modifiers: [
+        {
+          attributeId: 'Health',
+          op: 'Add',
+          magnitude: FP.FromFloat(-SAU_ATTACK_DAMAGE),
+        },
+      ],
+      cues: ['Cue.SAU.Impact'],
+    }),
+    defineEffect({
+      id: 'Effect.Damage.SAU.Secondary',
+      type: 'Instant',
+      modifiers: [
+        {
+          attributeId: 'Health',
+          op: 'Add',
+          magnitude: FP.FromFloat(-SAU_SECONDARY_DAMAGE),
+        },
+      ],
+      cues: ['Cue.SAU.SecondaryImpact'],
     }),
     defineEffect({
       id: 'Effect.Damage.Volt.Primary',
@@ -329,6 +394,16 @@ export const combatDefs = defineAbilitySystem({
       hookId: 'Hook.Volt.ChainLightning',
       cooldownEffectId: 'Effect.Volt.Cooldown',
       activationBlockedTags: [VOLT_COOLDOWN_TAG],
+    }),
+    defineAbility({
+      id: 'Ability.SAU.Artillery',
+      // Entity target from the caller-supplied lock; the hook snapshots the
+      // target's position into a fixed impact point (no targetEffectIds — all
+      // damage is AoE, applied later by ArtilleryShellSystem/ShrapnelLandingSystem).
+      target: { kind: 'Entity', origin: { kind: 'Caller' } },
+      hookId: 'Hook.SAU.Fire',
+      cooldownEffectId: 'Effect.SAU.Cooldown',
+      activationBlockedTags: [SAU_COOLDOWN_TAG],
     }),
   ],
 });

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -24,13 +24,25 @@ export const UNIT_TURN_SPEED_RADIANS_PER_TICK = Math.PI / 15;
  * useGravity — no per-shrapnel gravity is faked. The shrapnel config therefore
  * carries count/cone/speed only; gravity lives here on the world config.
  */
-export const SAU_SHRAPNEL_GRAVITY = 30;
-/** Launch speed (world units/s) of each shrapnel fragment along its cone ray. */
-export const SAU_SHRAPNEL_SPEED = 42;
+export const SAU_SHRAPNEL_GRAVITY = 80;
+/**
+ * Launch speed (world units/s) of each shrapnel fragment along its cone ray.
+ *
+ * Caps the ballistic scatter radius. Fragments are launched in an upward cone of
+ * half-angle {@link SAU_SHRAPNEL_CONE} and arc back to the ground under
+ * {@link SAU_SHRAPNEL_GRAVITY}, so the max horizontal landing distance is
+ * roughly `speed² · sin(2·cone) / gravity`. Speed and gravity are tuned as a
+ * pair: 26 u/s with gravity 60 lands fragments ≈11 units out (≈13 including
+ * launch height, within the intended ≤15-unit spread) after only ≈0.7 s of
+ * flight — a snappy burst rather than a slow lob. To widen/narrow the spread
+ * change speed (effect is quadratic); to speed up/slow down the burst change
+ * both proportionally (range scales with speed²/gravity).
+ */
+export const SAU_SHRAPNEL_SPEED = 32;
 /** Half-angle (radians) of the upward cone the shrapnel fragments fan out into. */
 export const SAU_SHRAPNEL_CONE = Math.PI / 5;
 /** Ticks between the shell being fired and its detonation (4–6 = 0.2–0.3 s @ 20 TPS). */
-export const SAU_SHELL_DELAY_TICKS = 5;
+export const SAU_SHELL_DELAY_TICKS = 8;
 /** Ground plane Y (world units) shrapnel fragments land on in v1 (no building AABBs yet). */
 export const SAU_GROUND_Y = 0;
 
@@ -41,7 +53,7 @@ export const physicsConfig = {
    * Physics clamps every body's velocity magnitude to this value during integration.
    * Must be >= {@link PROJECTILE_SPEED} or projectiles will not reach their configured speed.
    */
-  maxVelocity: Math.max(PROJECTILE_SPEED, 18),
+  maxVelocity: Math.max(PROJECTILE_SPEED, SAU_SHRAPNEL_SPEED),
   pushStrength: 12,
   /** Global downward acceleration applied to useGravity bodies (SAU shrapnel). */
   gravity: SAU_SHRAPNEL_GRAVITY,

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -24,9 +24,13 @@ export const UNIT_TURN_SPEED_RADIANS_PER_TICK = Math.PI / 15;
  * useGravity — no per-shrapnel gravity is faked. The shrapnel config therefore
  * carries count/cone/speed only; gravity lives here on the world config.
  */
-export const SAU_SHRAPNEL_GRAVITY = 80;
+export const SAU_SHRAPNEL_GRAVITY = 10;
+/** Mass of each shrapnel fragment (scales launch velocity from applyImpulse3D). */
+export const SHRAPNEL_MASS = 2.1;
+/** Per-body gravity scale on top of global {@link SAU_SHRAPNEL_GRAVITY}. */
+export const SHRAPNEL_GRAVITY_MULTIPLIER = 8;
 /**
- * Launch speed (world units/s) of each shrapnel fragment along its cone ray.
+ * Launch impulse magnitude (world units·kg/s) of each shrapnel fragment along its cone ray.
  *
  * Caps the ballistic scatter radius. Fragments are launched in an upward cone of
  * half-angle {@link SAU_SHRAPNEL_CONE} and arc back to the ground under
@@ -38,7 +42,7 @@ export const SAU_SHRAPNEL_GRAVITY = 80;
  * change speed (effect is quadratic); to speed up/slow down the burst change
  * both proportionally (range scales with speed²/gravity).
  */
-export const SAU_SHRAPNEL_SPEED = 32;
+export const SAU_SHRAPNEL_SPEED = 58;
 /** Half-angle (radians) of the upward cone the shrapnel fragments fan out into. */
 export const SAU_SHRAPNEL_CONE = Math.PI / 5;
 /** Ticks between the shell being fired and its detonation (4–6 = 0.2–0.3 s @ 20 TPS). */

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -14,6 +14,26 @@ export const PROJECTILE_SPEED = 180;
 /** Radians of Y rotation applied per simulation tick when turning to face a target. */
 export const UNIT_TURN_SPEED_RADIANS_PER_TICK = Math.PI / 15;
 
+/**
+ * SAU (self-propelled artillery) shrapnel physics tuning.
+ *
+ * Gravity in phalanx-physics v1 is GLOBAL (a single PhysicsWorldConfig.gravity
+ * applied by GravitySystem to every body with useGravity=true). Shrapnel is the
+ * only body in the playground that opts into gravity, so we set the world's
+ * global gravity to {@link SAU_SHRAPNEL_GRAVITY} and mark only shrapnel bodies
+ * useGravity — no per-shrapnel gravity is faked. The shrapnel config therefore
+ * carries count/cone/speed only; gravity lives here on the world config.
+ */
+export const SAU_SHRAPNEL_GRAVITY = 30;
+/** Launch speed (world units/s) of each shrapnel fragment along its cone ray. */
+export const SAU_SHRAPNEL_SPEED = 42;
+/** Half-angle (radians) of the upward cone the shrapnel fragments fan out into. */
+export const SAU_SHRAPNEL_CONE = Math.PI / 5;
+/** Ticks between the shell being fired and its detonation (4–6 = 0.2–0.3 s @ 20 TPS). */
+export const SAU_SHELL_DELAY_TICKS = 5;
+/** Ground plane Y (world units) shrapnel fragments land on in v1 (no building AABBs yet). */
+export const SAU_GROUND_Y = 0;
+
 export const physicsConfig = {
   subSteps: 3,
   gridCellSize: 8,
@@ -23,6 +43,8 @@ export const physicsConfig = {
    */
   maxVelocity: Math.max(PROJECTILE_SPEED, 18),
   pushStrength: 12,
+  /** Global downward acceleration applied to useGravity bodies (SAU shrapnel). */
+  gravity: SAU_SHRAPNEL_GRAVITY,
 };
 
 /** Seconds before an active projectile is returned to the pool. */
@@ -108,6 +130,7 @@ export const arenaParams = {
     rocket: '#B6A8FF',
     volt: '#9DB8FF',
     plasmaTank: '#A3C9F9',
+    sau: '#8FA98C',
   } as Record<string, string>,
   team2Palette: {
     sphere: '#FF8A8A',
@@ -116,6 +139,7 @@ export const arenaParams = {
     rocket: '#FFA37A',
     volt: '#FF9E7A',
     plasmaTank: '#FFB08A',
+    sau: '#C9A98F',
   } as Record<string, string>,
   /**
    * Local formation grid dimensions. The grid is centered on each team's spawn line

--- a/abilities-playground/src/core/GameUI.ts
+++ b/abilities-playground/src/core/GameUI.ts
@@ -39,6 +39,7 @@ export class GameUI {
       { id: 'unit-btn-rocket', type: 'rocket', label: 'Rocket' },
       { id: 'unit-btn-volt', type: 'volt', label: 'Volt' },
       { id: 'unit-btn-plasma-tank', type: 'plasmaTank', label: 'Plasma Tank' },
+      { id: 'unit-btn-sau', type: 'sau', label: 'SAU' },
     ];
 
     for (const { id, type, label } of unitButtonIds) {

--- a/abilities-playground/src/core/SimulationContainer.ts
+++ b/abilities-playground/src/core/SimulationContainer.ts
@@ -41,6 +41,7 @@ import {
   RenderSyncSystem,
   RotationSystem,
   ShrapnelLandingSystem,
+  ShrapnelSpinSystem,
   TargetingSystem,
   VoltAttackSystem,
 } from '../systems';
@@ -251,7 +252,10 @@ export class SimulationContainer {
         new CubeTargetingSystem(),
         new ProjectileDespawnQueueSystem(),
       ],
-      [interpolationSystem, new RenderSyncSystem()]
+      // ShrapnelSpinSystem is cosmetic-only (rotates the shard mesh inside the
+      // MeshComponent root) and must run after RenderSyncSystem has positioned
+      // the roots for the frame.
+      [interpolationSystem, new RenderSyncSystem(), new ShrapnelSpinSystem()]
     );
 
     this.spawnSimulationState();

--- a/abilities-playground/src/core/SimulationContainer.ts
+++ b/abilities-playground/src/core/SimulationContainer.ts
@@ -27,6 +27,7 @@ import {
 } from '../components';
 
 import {
+  ArtilleryShellSystem,
   AttackSystem,
   ChainLightningJumpSystem,
   CubeTargetingSystem,
@@ -39,16 +40,20 @@ import {
   MovementSystem,
   RenderSyncSystem,
   RotationSystem,
+  ShrapnelLandingSystem,
   TargetingSystem,
   VoltAttackSystem,
 } from '../systems';
 import { UnitFactory } from '../units';
 import { ProjectileEntity } from '../entities/Projectile.ts';
 import { MissileEntity } from '../entities/Missile';
+import { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import { ShrapnelEntity } from '../entities/Shrapnel';
 import { autoAttack } from '../hooks/AutoAttack.ts';
 import { missileVolley } from '../hooks/MissileVolley';
 import { voltChainLightning } from '../hooks/VoltChainLightning';
 import { plasmaTankMachineGun } from '../hooks/PlasmaTankMachineGun';
+import { sauArtillery } from '../hooks/SauArtillery';
 import {
   ProjectileDespawnQueueSystem,
   ProjectileCollisionSystem,
@@ -64,6 +69,10 @@ import {
   ChainLightningCue,
   MachineGunFireCue,
   MachineGunImpactCue,
+  SauMuzzleFlashCue,
+  SauImpactCue,
+  SauSecondaryImpactCue,
+  SauFallingShadowCue,
 } from '../cues';
 
 export class SimulationContainer {
@@ -95,6 +104,14 @@ export class SimulationContainer {
             factory: () => new MissileEntity(),
             pool: { initialSize: 30, maxSize: 120 },
           },
+          artilleryShell: {
+            factory: () => new ArtilleryShellEntity(),
+            pool: { initialSize: 12, maxSize: 60 },
+          },
+          shrapnel: {
+            factory: () => new ShrapnelEntity(),
+            pool: { initialSize: 60, maxSize: 300 },
+          },
         },
       },
     });
@@ -105,6 +122,9 @@ export class SimulationContainer {
       tickRate: networkConfig.tickRate,
       maxVelocity: FP.FromFloat(physicsConfig.maxVelocity),
       pushStrength: FP.FromFloat(physicsConfig.pushStrength),
+      // Global gravity (v1): only shrapnel bodies opt in via useGravity, so this
+      // affects nothing else in the playground. See config/constants.ts.
+      gravity: FP.FromFloat(physicsConfig.gravity),
       worldBounds: {
         minX: FP.FromFloat(-arenaParams.width / 2),
         maxX: FP.FromFloat(arenaParams.width / 2),
@@ -133,6 +153,10 @@ export class SimulationContainer {
           new MachineGunFireCue(this.scene),
         'Cue.PlasmaTank.MachineGun.Impact': () =>
           new MachineGunImpactCue(this.scene),
+        'Cue.SAU.MuzzleFlash': () => new SauMuzzleFlashCue(this.scene),
+        'Cue.SAU.Impact': () => new SauImpactCue(this.scene),
+        'Cue.SAU.SecondaryImpact': () => new SauSecondaryImpactCue(this.scene),
+        'Cue.SAU.FallingShadow': () => new SauFallingShadowCue(this.scene),
       },
       hooks: {
         'Hook.AutoAttack': (ctx: AbilityActivationContext) =>
@@ -143,6 +167,8 @@ export class SimulationContainer {
           voltChainLightning(ctx, this.world, this.abilities),
         'Hook.PlasmaTank.MachineGun': (ctx: AbilityActivationContext) =>
           plasmaTankMachineGun(ctx, this.world),
+        'Hook.SAU.Fire': (ctx: AbilityActivationContext) =>
+          sauArtillery(ctx, this.world),
       },
     });
 
@@ -156,6 +182,15 @@ export class SimulationContainer {
       if (statsA && !statsA.alive) return false;
       const statsB = eB.getComponent<StatsComponent>(ComponentType.UnitStats);
       if (statsB && !statsB.alive) return false;
+
+      // Shrapnel is gravity-affected and physics-integrated, but it must not be
+      // pushed around by (or push) units or other fragments — its only job is to
+      // arc and land. Exclude shrapnel↔unit and shrapnel↔shrapnel pairs so the
+      // collision filter (not ignorePhysics) protects it. Ground landing is
+      // resolved geometrically by ShrapnelLandingSystem.
+      const aShrapnel = eA.hasComponent(ComponentType.ShrapnelPayload);
+      const bShrapnel = eB.hasComponent(ComponentType.ShrapnelPayload);
+      if (aShrapnel || bShrapnel) return false;
 
       const aProjectile = eA.hasComponent(ComponentType.Projectile);
       const bProjectile = eB.hasComponent(ComponentType.Projectile);
@@ -185,8 +220,14 @@ export class SimulationContainer {
     this.unitFactory = new UnitFactory(this.scene, this.abilities);
     this.formationSystem = new FormationSystem(this.unitFactory);
 
-    const { physicsSystem, interpolationSystem } =
+    const { physicsSystem, gravitySystem, interpolationSystem } =
       this.physicsWorld.getSystems();
+    // SAU order (documented): AttackSystem → abilities (Hook.SAU.Fire) →
+    // ArtilleryShellSystem → GravitySystem → physicsSystem →
+    // ShrapnelLandingSystem. The shell system spawns shrapnel before gravity +
+    // integration so fragments get their first arc step on their birth tick;
+    // the landing system runs after integration to sweep prev→cur for ground
+    // crossings.
     this.world.registerSystems(
       [
         this.formationSystem,
@@ -199,7 +240,10 @@ export class SimulationContainer {
         new ProjectileMovementSystem(),
         new MissileTargetingSystem(),
         new MissileMovementSystem(),
+        new ArtilleryShellSystem(),
+        gravitySystem,
         physicsSystem,
+        new ShrapnelLandingSystem(),
         new HealingAuraSystem(),
         new ProjectileCollisionSystem(),
         new RotationSystem(),
@@ -265,7 +309,9 @@ export class SimulationContainer {
 
       const isPooled =
         entity.hasComponent(ComponentType.Projectile) ||
-        entity.hasComponent(ComponentType.Missile);
+        entity.hasComponent(ComponentType.Missile) ||
+        entity.hasComponent(ComponentType.ArtilleryShell) ||
+        entity.hasComponent(ComponentType.ShrapnelPayload);
 
       if (pools && isPooled) {
         pools.despawn(entity);

--- a/abilities-playground/src/cues/SauFallingShadowCue.ts
+++ b/abilities-playground/src/cues/SauFallingShadowCue.ts
@@ -1,0 +1,118 @@
+import * as THREE from 'three';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { clamp01 } from './vfxHelpers';
+import { tryGetSourcePoint } from './SauImpactCue';
+
+/**
+ * Duration of the ground warning marker. Emitted a couple of ticks before
+ * detonation, it should read as a brief "incoming" telegraph and then fade as
+ * the shell lands.
+ */
+const DURATION_SECONDS = 0.5;
+const MARKER_RADIUS = 4.5;
+
+/**
+ * SAU falling-shadow VFX: a pulsing red targeting reticle on the ground where
+ * the shell is about to land — an incoming-fire telegraph. Render-only. The
+ * impact point is snapshotted in `onSpawn` from the shell's Transform.
+ */
+export class SauFallingShadowCue extends Cue {
+  private readonly scene: THREE.Scene;
+  private group: THREE.Group | null = null;
+  private ringMaterial: THREE.MeshBasicMaterial | null = null;
+  private discMaterial: THREE.MeshBasicMaterial | null = null;
+  private disc: THREE.Mesh | null = null;
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.group) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+    // Pulse the outline; shrink the inner disc as if the shell is closing in.
+    const pulse = 0.6 + 0.4 * Math.sin(this.elapsed * 24);
+    if (this.ringMaterial) this.ringMaterial.opacity = 0.85 * pulse;
+    if (this.disc && this.discMaterial) {
+      this.disc.scale.setScalar(clamp01(1 - t));
+      this.discMaterial.opacity = 0.5 * (1 - t);
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.group) this.scene.remove(this.group);
+    this.group?.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose();
+      }
+    });
+    this.ringMaterial?.dispose();
+    this.discMaterial?.dispose();
+    this.group = null;
+    this.ringMaterial = null;
+    this.discMaterial = null;
+    this.disc = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    this.group = new THREE.Group();
+    this.group.position.set(point.x, point.y + 0.05, point.z);
+    this.group.renderOrder = 9_998;
+
+    this.ringMaterial = new THREE.MeshBasicMaterial({
+      color: 0xff3322,
+      transparent: true,
+      opacity: 0.85,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+    const ring = new THREE.Mesh(
+      new THREE.RingGeometry(MARKER_RADIUS * 0.85, MARKER_RADIUS, 48),
+      this.ringMaterial
+    );
+    ring.rotation.x = -Math.PI / 2;
+    this.group.add(ring);
+
+    this.discMaterial = new THREE.MeshBasicMaterial({
+      color: 0xff5533,
+      transparent: true,
+      opacity: 0.5,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+    });
+    this.disc = new THREE.Mesh(
+      new THREE.CircleGeometry(MARKER_RADIUS * 0.8, 40),
+      this.discMaterial
+    );
+    this.disc.rotation.x = -Math.PI / 2;
+    this.group.add(this.disc);
+
+    this.scene.add(this.group);
+  }
+}

--- a/abilities-playground/src/cues/SauImpactCue.ts
+++ b/abilities-playground/src/cues/SauImpactCue.ts
@@ -1,0 +1,210 @@
+import * as THREE from 'three';
+import { FPVector3 } from '@phalanx-engine/math';
+import type { EntityManager } from '@phalanx-engine/ecs';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { ComponentType, TransformComponent } from '../components';
+import { easeOutCubic, easeOutExpo } from './vfxHelpers';
+
+const DURATION_SECONDS = 0.6;
+const PARTICLE_COUNT = 120;
+const DEBRIS_SPEED = 16;
+/** Ground shockwave ring final radius (world units). */
+const RING_MAX_RADIUS = 9;
+
+/**
+ * SAU primary-impact VFX: a bright ground flash, an expanding shockwave ring,
+ * and an upward debris/smoke burst at the shell impact point. Render-only; the
+ * damage is applied by {@link ArtilleryShellSystem}.
+ *
+ * The impact point is snapshotted in `onSpawn` from the shell's Transform: the
+ * shell is returned to the pool on the detonation tick, so re-reading it later
+ * would be unsafe.
+ */
+export class SauImpactCue extends Cue {
+  private readonly scene: THREE.Scene;
+
+  private debris: THREE.Points | null = null;
+  private debrisGeometry: THREE.BufferGeometry | null = null;
+  private debrisMaterial: THREE.PointsMaterial | null = null;
+  private readonly velocities = new Float32Array(PARTICLE_COUNT * 3);
+
+  private ring: THREE.Mesh | null = null;
+  private ringMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private flash: THREE.Mesh | null = null;
+  private flashMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+
+    if (this.debris && this.debrisMaterial && this.debrisGeometry) {
+      const positions = this.debrisGeometry.getAttribute(
+        'position'
+      ) as THREE.BufferAttribute;
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const ix = i * 3;
+        positions.setXYZ(
+          i,
+          positions.getX(i) + this.velocities[ix] * deltaTimeSeconds,
+          positions.getY(i) + this.velocities[ix + 1] * deltaTimeSeconds,
+          positions.getZ(i) + this.velocities[ix + 2] * deltaTimeSeconds
+        );
+        this.velocities[ix + 1] -= 22 * deltaTimeSeconds;
+      }
+      positions.needsUpdate = true;
+      this.debrisMaterial.opacity = 0.95 * (1 - easeOutCubic(t));
+    }
+
+    if (this.ring && this.ringMaterial) {
+      const r = RING_MAX_RADIUS * easeOutExpo(t);
+      this.ring.scale.setScalar(Math.max(0.001, r));
+      this.ringMaterial.opacity = 0.7 * (1 - t);
+    }
+
+    if (this.flash && this.flashMaterial) {
+      const flashT = Math.min(1, this.elapsed / 0.1);
+      this.flash.scale.setScalar(1 + flashT * 3);
+      this.flashMaterial.opacity = 0.95 * (1 - flashT);
+      if (flashT >= 1) this.flash.visible = false;
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.debris) this.scene.remove(this.debris);
+    if (this.ring) this.scene.remove(this.ring);
+    if (this.flash) this.scene.remove(this.flash);
+    this.debrisGeometry?.dispose();
+    this.debrisMaterial?.dispose();
+    this.ring?.geometry.dispose();
+    this.ringMaterial?.dispose();
+    this.flash?.geometry.dispose();
+    this.flashMaterial?.dispose();
+    this.debris = null;
+    this.debrisGeometry = null;
+    this.debrisMaterial = null;
+    this.ring = null;
+    this.ringMaterial = null;
+    this.flash = null;
+    this.flashMaterial = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    const positions = new Float32Array(PARTICLE_COUNT * 3);
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      let x = 0;
+      let y = 0;
+      let z = 0;
+      do {
+        x = Math.random() * 2 - 1;
+        y = Math.random() * 2 - 1;
+        z = Math.random() * 2 - 1;
+      } while (x * x + y * y + z * z > 1);
+      const len = Math.sqrt(x * x + y * y + z * z) || 1;
+      positions[i * 3] = (x / len) * 0.2;
+      positions[i * 3 + 1] = Math.abs(y / len) * 0.2;
+      positions[i * 3 + 2] = (z / len) * 0.2;
+      const speed = DEBRIS_SPEED * (0.4 + Math.random() * 0.9);
+      this.velocities[i * 3] = (x / len) * speed;
+      this.velocities[i * 3 + 1] = Math.abs(y / len) * speed + 6;
+      this.velocities[i * 3 + 2] = (z / len) * speed;
+    }
+    this.debrisGeometry = new THREE.BufferGeometry();
+    this.debrisGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.debrisMaterial = new THREE.PointsMaterial({
+      color: new THREE.Color(0xff8833),
+      size: 0.9,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.95,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.debris = new THREE.Points(this.debrisGeometry, this.debrisMaterial);
+    this.debris.position.copy(point);
+    this.debris.frustumCulled = false;
+    this.debris.renderOrder = 10_000;
+    this.scene.add(this.debris);
+
+    this.ringMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffc060,
+      transparent: true,
+      opacity: 0.7,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+    });
+    this.ring = new THREE.Mesh(
+      new THREE.RingGeometry(0.85, 1, 40),
+      this.ringMaterial
+    );
+    this.ring.rotation.x = -Math.PI / 2;
+    this.ring.position.set(point.x, point.y + 0.1, point.z);
+    this.ring.renderOrder = 9_999;
+    this.scene.add(this.ring);
+
+    this.flashMaterial = new THREE.MeshBasicMaterial({
+      color: 0xfff0c0,
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.flash = new THREE.Mesh(
+      new THREE.SphereGeometry(1, 12, 10),
+      this.flashMaterial
+    );
+    this.flash.position.set(point.x, point.y + 0.5, point.z);
+    this.flash.renderOrder = 10_001;
+    this.scene.add(this.flash);
+  }
+}
+
+/** Read the source entity's Transform world position, or null if unavailable. */
+export function tryGetSourcePoint(
+  entityManager: EntityManager,
+  event: GameplayCueDispatchedEvent
+): THREE.Vector3 | null {
+  const source = entityManager.getEntity(event.sourceEntityId);
+  const transform = source?.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  if (!transform) return null;
+  const p = FPVector3.ToFloat(transform.fpPosition);
+  return new THREE.Vector3(p.x, p.y, p.z);
+}

--- a/abilities-playground/src/cues/SauMuzzleFlashCue.ts
+++ b/abilities-playground/src/cues/SauMuzzleFlashCue.ts
@@ -1,0 +1,203 @@
+import * as THREE from 'three';
+import { FPQuaternion, FPVector3 } from '@phalanx-engine/math';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { ComponentType, TransformComponent } from '../components';
+
+const LIFETIME_SECONDS = 0.18;
+const SPARK_COUNT = 16;
+
+/**
+ * SAU muzzle-flash VFX: a bright additive flash plus a short directional flare
+ * and spark spray at the artillery barrel tip. Like the machine-gun fire cue but
+ * without tracers (the shell is a delayed-detonation logic entity that never
+ * visibly flies). The muzzle world position/orientation is snapshotted in
+ * `onSpawn` from the caster Transform, so the flash stays put even if the unit
+ * rotates or dies afterward.
+ *
+ * The local muzzle offset is expressed in caster-mesh space and must track the
+ * barrel tip built by `createSauBody`.
+ */
+const MUZZLE_LOCAL = { x: 0, y: 2.6, z: 7.8 };
+
+export class SauMuzzleFlashCue extends Cue {
+  private readonly scene: THREE.Scene;
+
+  private group: THREE.Group | null = null;
+  private core: THREE.Mesh | null = null;
+  private halo: THREE.Mesh | null = null;
+  private coreMaterial: THREE.MeshBasicMaterial | null = null;
+  private haloMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private sparks: THREE.Points | null = null;
+  private sparkGeometry: THREE.BufferGeometry | null = null;
+  private sparkMaterial: THREE.PointsMaterial | null = null;
+  private readonly sparkVelocities = new Float32Array(SPARK_COUNT * 3);
+
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const caster = context.entityManager.getEntity(event.sourceEntityId);
+    const transform = caster?.getComponent<TransformComponent>(
+      ComponentType.Transform
+    );
+    if (!transform) {
+      this.done = true;
+      return;
+    }
+
+    const local = FPVector3.FromFloat(
+      MUZZLE_LOCAL.x,
+      MUZZLE_LOCAL.y,
+      MUZZLE_LOCAL.z
+    );
+    const world = FPVector3.ToFloat(
+      FPVector3.Add(
+        transform.fpPosition,
+        FPQuaternion.RotateVector(transform.fpRotation, local)
+      )
+    );
+    const forward = FPVector3.ToFloat(
+      FPQuaternion.RotateVector(
+        transform.fpRotation,
+        FPVector3.FromFloat(0, 0, 1)
+      )
+    );
+    const dir = new THREE.Vector3(forward.x, 0, forward.z);
+    if (dir.lengthSq() < 1e-6) dir.set(0, 0, 1);
+    dir.normalize();
+
+    this.build(new THREE.Vector3(world.x, world.y, world.z), dir);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.group) return;
+    this.elapsed += deltaTimeSeconds;
+    const k = this.elapsed / LIFETIME_SECONDS;
+    if (k >= 1) {
+      this.done = true;
+      return;
+    }
+    const fade = 1 - k;
+    const scale = 0.7 + 1.6 * Math.sin(Math.min(1, k * 1.6) * Math.PI * 0.5);
+    if (this.core && this.coreMaterial) {
+      this.core.scale.setScalar(scale);
+      this.coreMaterial.opacity = fade;
+    }
+    if (this.halo && this.haloMaterial) {
+      this.halo.scale.setScalar(scale * 1.4);
+      this.haloMaterial.opacity = 0.75 * fade;
+    }
+    if (this.sparks && this.sparkMaterial && this.sparkGeometry) {
+      this.sparkMaterial.opacity = fade;
+      const positions = this.sparkGeometry.getAttribute(
+        'position'
+      ) as THREE.BufferAttribute;
+      for (let i = 0; i < SPARK_COUNT; i++) {
+        const ix = i * 3;
+        positions.setXYZ(
+          i,
+          positions.getX(i) + this.sparkVelocities[ix] * deltaTimeSeconds,
+          positions.getY(i) + this.sparkVelocities[ix + 1] * deltaTimeSeconds,
+          positions.getZ(i) + this.sparkVelocities[ix + 2] * deltaTimeSeconds
+        );
+      }
+      positions.needsUpdate = true;
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.group) this.scene.remove(this.group);
+    this.core?.geometry.dispose();
+    this.halo?.geometry.dispose();
+    this.coreMaterial?.dispose();
+    this.haloMaterial?.dispose();
+    this.sparkGeometry?.dispose();
+    this.sparkMaterial?.dispose();
+    this.group = null;
+    this.core = null;
+    this.halo = null;
+    this.coreMaterial = null;
+    this.haloMaterial = null;
+    this.sparks = null;
+    this.sparkGeometry = null;
+    this.sparkMaterial = null;
+  }
+
+  private build(muzzle: THREE.Vector3, dir: THREE.Vector3): void {
+    this.group = new THREE.Group();
+    this.group.position.copy(muzzle);
+    this.group.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir);
+    this.group.renderOrder = 10_000;
+
+    this.haloMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffaa44,
+      transparent: true,
+      opacity: 0.85,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.halo = new THREE.Mesh(
+      new THREE.SphereGeometry(0.7, 10, 8),
+      this.haloMaterial
+    );
+    this.group.add(this.halo);
+
+    this.coreMaterial = new THREE.MeshBasicMaterial({
+      color: 0xfff6d0,
+      transparent: true,
+      opacity: 1,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.core = new THREE.Mesh(
+      new THREE.SphereGeometry(0.36, 10, 8),
+      this.coreMaterial
+    );
+    this.group.add(this.core);
+
+    this.sparkMaterial = new THREE.PointsMaterial({
+      color: 0xffe8a0,
+      size: 0.5,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 1,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.sparkGeometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(SPARK_COUNT * 3);
+    for (let i = 0; i < SPARK_COUNT; i++) {
+      const angle = (i / SPARK_COUNT) * Math.PI * 2;
+      const spread = 0.35 + (i % 3) * 0.15;
+      this.sparkVelocities[i * 3] = Math.cos(angle) * spread * 4;
+      this.sparkVelocities[i * 3 + 1] = Math.sin(angle) * spread * 3;
+      this.sparkVelocities[i * 3 + 2] = 7 + (i % 4) * 1.5;
+    }
+    this.sparkGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.sparks = new THREE.Points(this.sparkGeometry, this.sparkMaterial);
+    this.sparks.frustumCulled = false;
+    this.group.add(this.sparks);
+
+    this.scene.add(this.group);
+  }
+}

--- a/abilities-playground/src/cues/SauSecondaryImpactCue.ts
+++ b/abilities-playground/src/cues/SauSecondaryImpactCue.ts
@@ -1,0 +1,123 @@
+import * as THREE from 'three';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { easeOutCubic } from './vfxHelpers';
+import { tryGetSourcePoint } from './SauImpactCue';
+
+const DURATION_SECONDS = 0.35;
+const PARTICLE_COUNT = 36;
+const SPARK_SPEED = 9;
+
+/**
+ * SAU secondary-impact VFX: a compact spark burst where a shrapnel fragment
+ * lands. Render-only; damage is applied by {@link ShrapnelLandingSystem}. The
+ * landing point is snapshotted in `onSpawn` from the fragment's Transform (the
+ * fragment is pooled immediately after landing).
+ */
+export class SauSecondaryImpactCue extends Cue {
+  private readonly scene: THREE.Scene;
+  private points: THREE.Points | null = null;
+  private geometry: THREE.BufferGeometry | null = null;
+  private material: THREE.PointsMaterial | null = null;
+  private readonly velocities = new Float32Array(PARTICLE_COUNT * 3);
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.points || !this.material || !this.geometry) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+    const positions = this.geometry.getAttribute(
+      'position'
+    ) as THREE.BufferAttribute;
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const ix = i * 3;
+      positions.setXYZ(
+        i,
+        positions.getX(i) + this.velocities[ix] * deltaTimeSeconds,
+        positions.getY(i) + this.velocities[ix + 1] * deltaTimeSeconds,
+        positions.getZ(i) + this.velocities[ix + 2] * deltaTimeSeconds
+      );
+      this.velocities[ix + 1] -= 14 * deltaTimeSeconds;
+    }
+    positions.needsUpdate = true;
+    this.material.opacity = 0.9 * (1 - easeOutCubic(t));
+    this.material.size = 0.5 * (1 - t * 0.5);
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.points) this.scene.remove(this.points);
+    this.geometry?.dispose();
+    this.material?.dispose();
+    this.points = null;
+    this.geometry = null;
+    this.material = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    const positions = new Float32Array(PARTICLE_COUNT * 3);
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      let x = 0;
+      let y = 0;
+      let z = 0;
+      do {
+        x = Math.random() * 2 - 1;
+        y = Math.random() * 2 - 1;
+        z = Math.random() * 2 - 1;
+      } while (x * x + y * y + z * z > 1);
+      const len = Math.sqrt(x * x + y * y + z * z) || 1;
+      positions[i * 3] = (x / len) * 0.1;
+      positions[i * 3 + 1] = Math.abs(y / len) * 0.1;
+      positions[i * 3 + 2] = (z / len) * 0.1;
+      const speed = SPARK_SPEED * (0.5 + Math.random() * 0.8);
+      this.velocities[i * 3] = (x / len) * speed;
+      this.velocities[i * 3 + 1] = Math.abs(y / len) * speed + 3;
+      this.velocities[i * 3 + 2] = (z / len) * speed;
+    }
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.material = new THREE.PointsMaterial({
+      color: new THREE.Color(0xffd24d),
+      size: 0.5,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.points = new THREE.Points(this.geometry, this.material);
+    this.points.position.copy(point);
+    this.points.frustumCulled = false;
+    this.points.renderOrder = 10_000;
+    this.scene.add(this.points);
+  }
+}

--- a/abilities-playground/src/cues/index.ts
+++ b/abilities-playground/src/cues/index.ts
@@ -7,3 +7,7 @@ export * from './ChainLightningCue.ts';
 export * from './MachineGunFireCue.ts';
 export * from './MachineGunImpactCue.ts';
 export * from './missileExhaustCue.ts';
+export * from './SauMuzzleFlashCue.ts';
+export * from './SauImpactCue.ts';
+export * from './SauSecondaryImpactCue.ts';
+export * from './SauFallingShadowCue.ts';

--- a/abilities-playground/src/entities/ArtilleryShell.ts
+++ b/abilities-playground/src/entities/ArtilleryShell.ts
@@ -1,0 +1,74 @@
+import { Entity, type IPoolableEntity } from '@phalanx-engine/ecs';
+import type { FixedPoint, FPVector3 as FPVector3Type } from '@phalanx-engine/math';
+import { TransformComponent } from '@phalanx-engine/physics';
+import {
+  ArtilleryShellComponent,
+  type ShrapnelConfig,
+} from '../components/ArtilleryShellComponent';
+import type { TeamId } from '../components';
+
+export interface ArtilleryShellSpawnArgs {
+  impactPoint: FPVector3Type;
+  sourceEntityId: number;
+  teamId: TeamId;
+  detonateTick: number;
+  primaryRadius: FixedPoint;
+  primaryEffectId: string;
+  secondaryRadius: FixedPoint;
+  secondaryEffectId: string;
+  shrapnelConfig: ShrapnelConfig;
+}
+
+/**
+ * ArtilleryShellEntity — pooled, logic-only delayed-detonation marker.
+ *
+ * No PhysicsBody, no mesh: nothing flies. It just carries the snapshotted
+ * impact point and blast parameters until ArtilleryShellSystem detonates it at
+ * `detonateTick`, then it is returned to the pool.
+ */
+export class ArtilleryShellEntity
+  extends Entity
+  implements IPoolableEntity<ArtilleryShellSpawnArgs>
+{
+  private _active = false;
+
+  public get active() {
+    return this._active;
+  }
+
+  public set active(value: boolean) {
+    this._active = value;
+  }
+
+  private readonly shell: ArtilleryShellComponent;
+  // Transform (no PhysicsBody, no mesh) so falling-shadow/impact cues can read
+  // the impact point; the shell never moves and never renders a body.
+  private readonly transform: TransformComponent;
+
+  constructor() {
+    super();
+    this.shell = this.addComponent(new ArtilleryShellComponent());
+    this.transform = this.addComponent(new TransformComponent(this.id));
+  }
+
+  onSpawn(args: ArtilleryShellSpawnArgs): void {
+    this._active = true;
+    this.transform.fpPosition = args.impactPoint;
+    this.shell.impactPoint.x = args.impactPoint.x;
+    this.shell.impactPoint.y = args.impactPoint.y;
+    this.shell.impactPoint.z = args.impactPoint.z;
+    this.shell.sourceEntityId = args.sourceEntityId;
+    this.shell.teamId = args.teamId;
+    this.shell.detonateTick = args.detonateTick;
+    this.shell.primaryRadius = args.primaryRadius;
+    this.shell.primaryEffectId = args.primaryEffectId;
+    this.shell.secondaryRadius = args.secondaryRadius;
+    this.shell.secondaryEffectId = args.secondaryEffectId;
+    this.shell.shrapnelConfig = args.shrapnelConfig;
+    this.shell.shadowEmitted = false;
+  }
+
+  onDespawn(): void {
+    this._active = false;
+  }
+}

--- a/abilities-playground/src/entities/Shrapnel.ts
+++ b/abilities-playground/src/entities/Shrapnel.ts
@@ -9,12 +9,15 @@ import {
   PhysicsBodyComponent,
   TransformComponent,
 } from '@phalanx-engine/physics';
-import { TeamComponent } from '../components';
+import { MeshComponent, TeamComponent } from '../components';
 import type { TeamId } from '../components';
 import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
 
 /** Physics radius of a shrapnel fragment (small; landing is by ground sweep). */
 export const SHRAPNEL_RADIUS = 0.25;
+
+/** Visual size (world units) of the shared shard mesh. */
+export const SHRAPNEL_VISUAL_RADIUS = 0.5;
 
 export interface ShrapnelSpawnArgs {
   fpPosition: FPVector3Type;
@@ -52,10 +55,13 @@ export class ShrapnelEntity
   private readonly transform: TransformComponent;
   private readonly body: PhysicsBodyComponent;
   private readonly payload: ShrapnelPayloadComponent;
-
   constructor() {
     super();
     this.team = this.addComponent(new TeamComponent(0));
+    // Visibility is driven by MeshComponent's own IPoolableComponent hooks
+    // (hidden in the pool, shown on spawn). RenderSyncSystem positions the
+    // root each frame; ShrapnelSpinSystem tumbles the shard inside it.
+    this.addComponent(MeshComponent.createShrapnel(SHRAPNEL_VISUAL_RADIUS));
     this.interpolation = this.addComponent(new InterpolationComponent());
     this.transform = this.addComponent(new TransformComponent(this.id));
     this.body = this.addComponent(

--- a/abilities-playground/src/entities/Shrapnel.ts
+++ b/abilities-playground/src/entities/Shrapnel.ts
@@ -1,0 +1,100 @@
+import { Entity, type IPoolableEntity } from '@phalanx-engine/ecs';
+import { FP, FPQuaternion } from '@phalanx-engine/math';
+import type {
+  FixedPoint,
+  FPVector3 as FPVector3Type,
+} from '@phalanx-engine/math';
+import {
+  InterpolationComponent,
+  PhysicsBodyComponent,
+  TransformComponent,
+} from '@phalanx-engine/physics';
+import { TeamComponent } from '../components';
+import type { TeamId } from '../components';
+import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
+
+/** Physics radius of a shrapnel fragment (small; landing is by ground sweep). */
+export const SHRAPNEL_RADIUS = 0.25;
+
+export interface ShrapnelSpawnArgs {
+  fpPosition: FPVector3Type;
+  /** Full 3D launch velocity (world units/s); applied via applyImpulse3D by the caller. */
+  sourceEntityId: number;
+  teamId: TeamId;
+  secondaryEffectId: string;
+  secondaryRadius: FixedPoint;
+}
+
+/**
+ * ShrapnelEntity — pooled gravity-affected fragment sprayed on shell detonation.
+ *
+ * Has a real PhysicsBody with useGravity=true so the global GravitySystem arcs
+ * it back to the ground. friction=FP._1 keeps horizontal drift tight. It is NOT
+ * ignorePhysics — it stays in the pipeline but is excluded from unit/shrapnel
+ * collisions by the collision filter, so it never shoves units around.
+ */
+export class ShrapnelEntity
+  extends Entity
+  implements IPoolableEntity<ShrapnelSpawnArgs>
+{
+  private _active = false;
+
+  public get active() {
+    return this._active;
+  }
+
+  public set active(value: boolean) {
+    this._active = value;
+  }
+
+  private readonly team: TeamComponent;
+  private readonly interpolation: InterpolationComponent;
+  private readonly transform: TransformComponent;
+  private readonly body: PhysicsBodyComponent;
+  private readonly payload: ShrapnelPayloadComponent;
+
+  constructor() {
+    super();
+    this.team = this.addComponent(new TeamComponent(0));
+    this.interpolation = this.addComponent(new InterpolationComponent());
+    this.transform = this.addComponent(new TransformComponent(this.id));
+    this.body = this.addComponent(
+      new PhysicsBodyComponent(this.id, {
+        radius: FP.FromFloat(SHRAPNEL_RADIUS),
+        mass: FP._1,
+        friction: FP._1,
+        restitution: FP._0,
+        useGravity: true,
+      })
+    );
+    this.payload = this.addComponent(new ShrapnelPayloadComponent());
+  }
+
+  onSpawn(args: ShrapnelSpawnArgs): void {
+    this._active = true;
+    this.transform.fpPosition = args.fpPosition;
+    this.transform.fpRotation = FPQuaternion.Identity();
+
+    this.team.teamId = args.teamId;
+    this.payload.sourceEntityId = args.sourceEntityId;
+    this.payload.teamId = args.teamId;
+    this.payload.secondaryEffectId = args.secondaryEffectId;
+    this.payload.secondaryRadius = args.secondaryRadius;
+    this.payload.prevPosX = args.fpPosition.x;
+    this.payload.prevPosY = args.fpPosition.y;
+    this.payload.prevPosZ = args.fpPosition.z;
+    this.payload.landed = false;
+
+    // Fragments spawn with gravity on and velocity zeroed; the caller applies
+    // the cone impulse via PhysicsWorld.applyImpulse3D right after spawn.
+    this.body.useGravity = true;
+    this.body.stopVelocity();
+
+    this.interpolation.capture(args.fpPosition, FPQuaternion.Identity());
+    this.interpolation.snapshot();
+  }
+
+  onDespawn(): void {
+    this._active = false;
+  }
+}

--- a/abilities-playground/src/entities/Shrapnel.ts
+++ b/abilities-playground/src/entities/Shrapnel.ts
@@ -15,7 +15,7 @@ import { SHRAPNEL_GRAVITY_MULTIPLIER, SHRAPNEL_MASS } from '../config/constants'
 import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
 
 /** Physics radius of a shrapnel fragment (small; landing is by ground sweep). */
-export const SHRAPNEL_RADIUS = 0.25;
+export const SHRAPNEL_RADIUS = 0.7;
 
 /** Visual size (world units) of the shared shard mesh. */
 export const SHRAPNEL_VISUAL_RADIUS = 0.8;

--- a/abilities-playground/src/entities/Shrapnel.ts
+++ b/abilities-playground/src/entities/Shrapnel.ts
@@ -11,17 +11,18 @@ import {
 } from '@phalanx-engine/physics';
 import { MeshComponent, TeamComponent } from '../components';
 import type { TeamId } from '../components';
+import { SHRAPNEL_GRAVITY_MULTIPLIER, SHRAPNEL_MASS } from '../config/constants';
 import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
 
 /** Physics radius of a shrapnel fragment (small; landing is by ground sweep). */
 export const SHRAPNEL_RADIUS = 0.25;
 
 /** Visual size (world units) of the shared shard mesh. */
-export const SHRAPNEL_VISUAL_RADIUS = 0.5;
+export const SHRAPNEL_VISUAL_RADIUS = 0.8;
 
 export interface ShrapnelSpawnArgs {
   fpPosition: FPVector3Type;
-  /** Full 3D launch velocity (world units/s); applied via applyImpulse3D by the caller. */
+  /** Full 3D launch impulse (world units·kg/s); applied via applyImpulse3D by the caller. */
   sourceEntityId: number;
   teamId: TeamId;
   secondaryEffectId: string;
@@ -67,10 +68,11 @@ export class ShrapnelEntity
     this.body = this.addComponent(
       new PhysicsBodyComponent(this.id, {
         radius: FP.FromFloat(SHRAPNEL_RADIUS),
-        mass: FP._1,
+        mass: FP.FromFloat(SHRAPNEL_MASS),
         friction: FP._1,
         restitution: FP._0,
         useGravity: true,
+        gravityMultiplier: FP.FromFloat(SHRAPNEL_GRAVITY_MULTIPLIER),
       })
     );
     this.payload = this.addComponent(new ShrapnelPayloadComponent());

--- a/abilities-playground/src/hooks/SauArtillery.ts
+++ b/abilities-playground/src/hooks/SauArtillery.ts
@@ -1,0 +1,98 @@
+import type { TransformComponent } from '@phalanx-engine/physics';
+import { FP } from '@phalanx-engine/math';
+import {
+  gameplayCueKey,
+  type AbilityActivationContext,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { GameWorld } from '@phalanx-engine/ecs';
+import { ComponentType, TeamComponent } from '../components';
+import { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import {
+  SAU_PRIMARY_RADIUS,
+  SAU_SECONDARY_RADIUS,
+  SAU_SHRAPNEL_COUNT,
+  SAU_MIN_ENGAGEMENT_RANGE,
+} from '../config/abilityDefinitions';
+import {
+  SAU_SHELL_DELAY_TICKS,
+  SAU_SHRAPNEL_CONE,
+  SAU_SHRAPNEL_SPEED,
+} from '../config/constants';
+
+export const SAU_MUZZLE_FLASH_CUE_ID = 'Cue.SAU.MuzzleFlash';
+
+/** Squared minimum engagement range: the SAU ignores enemies closer than this. */
+const MIN_ENGAGE_RANGE_SQ = FP.Mul(
+  FP.FromFloat(SAU_MIN_ENGAGEMENT_RANGE),
+  FP.FromFloat(SAU_MIN_ENGAGEMENT_RANGE)
+);
+
+/**
+ * SAU artillery fire hook.
+ *
+ * Snapshots the current target position into a fixed impact point (so the shell
+ * lands where the target *was* when fired, independent of later movement),
+ * enforces the minimum engagement dead zone, emits the muzzle-flash cue, and
+ * spawns a logic-only {@link ArtilleryShellEntity} that detonates after
+ * {@link SAU_SHELL_DELAY_TICKS}.
+ */
+export const sauArtillery = (
+  ctx: AbilityActivationContext,
+  world: GameWorld
+): void => {
+  const target = world.entityManager.getEntity(ctx.resolvedTargets[0]);
+  const caster = world.entityManager.getEntity(ctx.casterEntityId);
+  if (!target || !caster) return;
+  if (!world.pools) return;
+
+  const targetTransform = target.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  const casterTransform = caster.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  const casterTeam = caster.getComponent<TeamComponent>(ComponentType.Team);
+  if (!targetTransform || !casterTransform || !casterTeam) return;
+
+  const casterPos = casterTransform.fpPosition;
+  const targetPos = targetTransform.fpPosition;
+
+  // Dead zone: refuse to fire on enemies inside the minimum engage range.
+  const dx = FP.Sub(targetPos.x, casterPos.x);
+  const dz = FP.Sub(targetPos.z, casterPos.z);
+  const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+  if (FP.Lt(d2, MIN_ENGAGE_RANGE_SQ)) return;
+
+  // Snapshot the impact point by value — decoupled from later target movement.
+  const impactPoint = {
+    x: targetPos.x,
+    y: targetPos.y,
+    z: targetPos.z,
+  };
+
+  const muzzleEvent: GameplayCueDispatchedEvent = {
+    tick: ctx.tick,
+    cueId: SAU_MUZZLE_FLASH_CUE_ID,
+    sourceEntityId: caster.id,
+    targetEntityId: target.id,
+    phase: 'OnApplied',
+  };
+  world.eventBus.emit(gameplayCueKey(SAU_MUZZLE_FLASH_CUE_ID), muzzleEvent);
+
+  world.pools.spawn<ArtilleryShellEntity>('artilleryShell', {
+    impactPoint,
+    sourceEntityId: caster.id,
+    teamId: casterTeam.teamId,
+    detonateTick: ctx.tick + SAU_SHELL_DELAY_TICKS,
+    primaryRadius: FP.FromFloat(SAU_PRIMARY_RADIUS),
+    primaryEffectId: 'Effect.Damage.SAU.Primary',
+    secondaryRadius: FP.FromFloat(SAU_SECONDARY_RADIUS),
+    secondaryEffectId: 'Effect.Damage.SAU.Secondary',
+    shrapnelConfig: {
+      count: SAU_SHRAPNEL_COUNT,
+      cone: FP.FromFloat(SAU_SHRAPNEL_CONE),
+      speed: FP.FromFloat(SAU_SHRAPNEL_SPEED),
+    },
+  });
+};

--- a/abilities-playground/src/systems/ArtilleryShellSystem.ts
+++ b/abilities-playground/src/systems/ArtilleryShellSystem.ts
@@ -1,0 +1,198 @@
+import { GameSystem } from '@phalanx-engine/ecs';
+import type { AbilitySystem } from '@phalanx-engine/abilities';
+import {
+  gameplayCueKey,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+} from '../components';
+import { ArtilleryShellComponent } from '../components/ArtilleryShellComponent';
+import type { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import { ShrapnelEntity } from '../entities/Shrapnel';
+import { SAU_FRIENDLY_FIRE } from '../config/abilityDefinitions';
+import { GameRandom } from '../core/GameRandom';
+
+export const SAU_IMPACT_CUE_ID = 'Cue.SAU.Impact';
+export const SAU_FALLING_SHADOW_CUE_ID = 'Cue.SAU.FallingShadow';
+
+/** Ticks before detonation that the falling-shadow warning cue is emitted. */
+const SAU_SHADOW_LEAD_TICKS = 2;
+
+/**
+ * ArtilleryShellSystem — detonates SAU shells and sprays shrapnel.
+ *
+ * System order (documented): AttackSystem → abilities (Hook.SAU.Fire spawns the
+ * shell) → **ArtilleryShellSystem** → GravitySystem → physicsSystem →
+ * ShrapnelLandingSystem. Running before GravitySystem/physicsSystem means
+ * shrapnel spawned this tick gets its first gravity + integration step in the
+ * same tick it is born.
+ *
+ * On the detonation tick it applies the primary AoE (enemy-only by default; see
+ * {@link SAU_FRIENDLY_FIRE}) around the snapshotted impact point, spawns N
+ * gravity-affected shrapnel fragments along a deterministic cone (seeded via
+ * {@link GameRandom} so replays match), emits the impact cue, and returns the
+ * shell to the pool. A one-shot falling-shadow cue fires
+ * {@link SAU_SHADOW_LEAD_TICKS} ticks earlier.
+ */
+export class ArtilleryShellSystem extends GameSystem {
+  private get _abilities(): AbilitySystem | undefined {
+    return this.abilities as AbilitySystem | undefined;
+  }
+
+  public override processTick(tick: number): void {
+    const physics = this.physics as PhysicsWorld | undefined;
+    if (!physics) return;
+
+    const shells = this.entityManager.queryEntities(
+      ComponentType.ArtilleryShell
+    );
+
+    for (const entity of shells) {
+      const shell = entity.getComponent<ArtilleryShellComponent>(
+        ComponentType.ArtilleryShell
+      );
+      if (!shell) continue;
+      if ((entity as { active?: boolean }).active === false) continue;
+
+      // One-shot falling-shadow warning ahead of detonation.
+      if (
+        !shell.shadowEmitted &&
+        tick >= shell.detonateTick - SAU_SHADOW_LEAD_TICKS
+      ) {
+        this.emitCue(SAU_FALLING_SHADOW_CUE_ID, entity.id, tick);
+        shell.shadowEmitted = true;
+      }
+
+      if (tick < shell.detonateTick) continue;
+
+      this.detonate(entity as ArtilleryShellEntity, shell, physics, tick);
+    }
+  }
+
+  private detonate(
+    entity: ArtilleryShellEntity,
+    shell: ArtilleryShellComponent,
+    physics: PhysicsWorld,
+    tick: number
+  ): void {
+    const ip = shell.impactPoint;
+
+    // Primary AoE around the impact point.
+    this.applyAoE(
+      ip.x,
+      ip.z,
+      shell.primaryRadius,
+      shell.teamId,
+      shell.primaryEffectId,
+      shell.sourceEntityId,
+      physics
+    );
+
+    this.emitCue(SAU_IMPACT_CUE_ID, entity.id, tick);
+
+    this.spawnShrapnel(shell, physics);
+
+    this.pools?.despawn(entity);
+  }
+
+  private spawnShrapnel(
+    shell: ArtilleryShellComponent,
+    physics: PhysicsWorld
+  ): void {
+    const pools = this.pools;
+    if (!pools) return;
+
+    const { count, cone, speed } = shell.shrapnelConfig;
+    const speedF = FP.ToFloat(speed);
+    const coneF = FP.ToFloat(cone);
+    const useRng = GameRandom.isInitialized();
+
+    for (let i = 0; i < count; i++) {
+      // Deterministic cone direction (upward-biased). Seeded RNG keeps replays
+      // in lockstep; when uninitialized (e.g. isolated tests) fall back to an
+      // even fan so behaviour stays deterministic without a seed.
+      const azimuth = useRng
+        ? GameRandom.rng.floatRange(0, Math.PI * 2)
+        : (Math.PI * 2 * i) / count;
+      const polar = useRng
+        ? GameRandom.rng.floatRange(0, coneF)
+        : coneF * 0.5;
+
+      const sinP = Math.sin(polar);
+      const dirX = sinP * Math.cos(azimuth);
+      const dirZ = sinP * Math.sin(azimuth);
+      const dirY = Math.cos(polar); // mostly upward
+
+      const shrapnel = pools.spawn<ShrapnelEntity>('shrapnel', {
+        fpPosition: shell.impactPoint,
+        sourceEntityId: shell.sourceEntityId,
+        teamId: shell.teamId,
+        secondaryEffectId: shell.secondaryEffectId,
+        secondaryRadius: shell.secondaryRadius,
+      });
+
+      physics.applyImpulse3D(
+        shrapnel.id,
+        FP.FromFloat(dirX * speedF),
+        FP.FromFloat(dirY * speedF),
+        FP.FromFloat(dirZ * speedF)
+      );
+    }
+  }
+
+  private applyAoE(
+    cx: FixedPoint,
+    cz: FixedPoint,
+    radius: FixedPoint,
+    sourceTeam: number,
+    effectId: string,
+    sourceEntityId: number,
+    physics: PhysicsWorld
+  ): void {
+    const abilities = this._abilities;
+    if (!abilities) return;
+
+    const radiusSq = FP.Mul(radius, radius);
+    const nearby = physics.spatialGrid.queryRadius(cx, cz, radius);
+
+    for (const id of nearby) {
+      const entity = this.entityManager.getEntity(id);
+      if (!entity) continue;
+
+      const stats = entity.getComponent<StatsComponent>(
+        ComponentType.UnitStats
+      );
+      if (!stats?.alive) continue;
+
+      const team = entity.getComponent<TeamComponent>(ComponentType.Team);
+      if (!SAU_FRIENDLY_FIRE && team && team.teamId === sourceTeam) continue;
+
+      // queryRadius is grid-cell coarse; confirm the true XZ distance.
+      const pos = physics.getEntityPosition(id);
+      if (pos) {
+        const dx = FP.Sub(pos.x, cx);
+        const dz = FP.Sub(pos.z, cz);
+        const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+        if (FP.Gt(d2, radiusSq)) continue;
+      }
+
+      abilities.applyEffect(id, effectId, sourceEntityId);
+    }
+  }
+
+  private emitCue(cueId: string, sourceEntityId: number, tick: number): void {
+    const event: GameplayCueDispatchedEvent = {
+      tick,
+      cueId,
+      sourceEntityId,
+      targetEntityId: sourceEntityId,
+      phase: 'OnApplied',
+    };
+    this.eventBus.emit(gameplayCueKey(cueId), event);
+  }
+}

--- a/abilities-playground/src/systems/FormationSystem.ts
+++ b/abilities-playground/src/systems/FormationSystem.ts
@@ -117,7 +117,8 @@ export class FormationSystem extends GameSystem {
             cmd.type !== 'support' &&
             cmd.type !== 'rocket' &&
             cmd.type !== 'volt' &&
-            cmd.type !== 'plasmaTank') ||
+            cmd.type !== 'plasmaTank' &&
+            cmd.type !== 'sau') ||
           typeof cmd.gridX !== 'number' ||
           !Number.isInteger(cmd.gridX) ||
           typeof cmd.gridZ !== 'number' ||

--- a/abilities-playground/src/systems/MovementSystem.ts
+++ b/abilities-playground/src/systems/MovementSystem.ts
@@ -43,6 +43,13 @@ export class MovementSystem extends GameSystem {
 
     for (const entityId of this.physicsStore.entityIds()) {
       const physicsIndex = this.physicsStore.indexOf(entityId);
+
+      // Ballistic bodies (useGravity=true, e.g. SAU shrapnel) own all three
+      // velocity axes: GravitySystem accelerates them and PhysicsSystem
+      // integrates the arc. The unit-movement controller must not touch them,
+      // otherwise it flattens the arc by zeroing velocity every tick.
+      if (this.physicsStore.arrays.useGravity[physicsIndex] === 1) continue;
+
       velocityY[physicsIndex] = zeroRaw;
 
       const shouldFreeze =

--- a/abilities-playground/src/systems/ShrapnelLandingSystem.ts
+++ b/abilities-playground/src/systems/ShrapnelLandingSystem.ts
@@ -1,0 +1,180 @@
+import { GameSystem } from '@phalanx-engine/ecs';
+import type { AbilitySystem } from '@phalanx-engine/abilities';
+import {
+  gameplayCueKey,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import type { TransformComponent } from '@phalanx-engine/physics';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+} from '../components';
+import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
+import type { ShrapnelEntity } from '../entities/Shrapnel';
+import { SAU_FRIENDLY_FIRE } from '../config/abilityDefinitions';
+import { SAU_GROUND_Y } from '../config/constants';
+
+export const SAU_SECONDARY_IMPACT_CUE_ID = 'Cue.SAU.SecondaryImpact';
+
+const GROUND_Y = FP.FromFloat(SAU_GROUND_Y);
+
+/** A world-space ground landing point. */
+export interface GroundLanding {
+  x: FixedPoint;
+  y: FixedPoint;
+  z: FixedPoint;
+}
+
+/**
+ * Pure swept ground-plane crossing test for a prev→cur segment.
+ *
+ * Returns the interpolated landing point when the segment crosses `groundY`
+ * downward (prevY > groundY && curY <= groundY), else `null`. The lerp
+ * denominator (prevY - curY) is strictly positive under that condition, but we
+ * still guard it explicitly because `FP.Div` throws on divide-by-zero.
+ *
+ * TODO(v2): raycast the prev→cur segment against building AABBs first (via
+ * PhysicsWorld.raycastSegment) and prefer the nearer of building-hit vs ground.
+ */
+export function computeGroundLanding(
+  prevX: FixedPoint,
+  prevY: FixedPoint,
+  prevZ: FixedPoint,
+  curX: FixedPoint,
+  curY: FixedPoint,
+  curZ: FixedPoint,
+  groundY: FixedPoint = GROUND_Y
+): GroundLanding | null {
+  if (!(FP.Gt(prevY, groundY) && FP.Lte(curY, groundY))) return null;
+
+  const denom = FP.Sub(prevY, curY);
+  if (FP.Eq(denom, FP._0)) {
+    // Degenerate (should not happen given the crossing condition) — land at cur.
+    return { x: curX, y: groundY, z: curZ };
+  }
+
+  const t = FP.Div(FP.Sub(prevY, groundY), denom);
+  return {
+    x: FP.Lerp(prevX, curX, t),
+    y: groundY,
+    z: FP.Lerp(prevZ, curZ, t),
+  };
+}
+
+/**
+ * ShrapnelLandingSystem — resolves shrapnel fragments when they hit the ground.
+ *
+ * Runs after physicsSystem (which integrated this tick's position). For each
+ * fragment it sweeps its previous→current position for a ground-plane crossing;
+ * on landing it applies the secondary AoE (enemy-only by default) around the
+ * exact landing point, emits the secondary-impact cue, and returns the fragment
+ * to the pool. The secondary is resolved from the original firing unit's id, so
+ * it still lands even if that unit has since died (applyEffect only needs the
+ * source id for attribution, not a live entity).
+ *
+ * v1 lands on the ground plane only; there is no building-AABB infrastructure in
+ * the playground yet — see {@link computeGroundLanding} for the v2 extension.
+ */
+export class ShrapnelLandingSystem extends GameSystem {
+  private get _abilities(): AbilitySystem | undefined {
+    return this.abilities as AbilitySystem | undefined;
+  }
+
+  public override processTick(tick: number): void {
+    const physics = this.physics as PhysicsWorld | undefined;
+    if (!physics) return;
+
+    const fragments = this.entityManager.queryEntities(
+      ComponentType.ShrapnelPayload,
+      ComponentType.Transform
+    );
+
+    for (const entity of fragments) {
+      if ((entity as { active?: boolean }).active === false) continue;
+
+      const payload = entity.getComponent<ShrapnelPayloadComponent>(
+        ComponentType.ShrapnelPayload
+      );
+      const transform = entity.getComponent<TransformComponent>(
+        ComponentType.Transform
+      );
+      if (!payload || !transform || payload.landed) continue;
+
+      const cur = transform.fpPosition;
+      const landing = computeGroundLanding(
+        payload.prevPosX,
+        payload.prevPosY,
+        payload.prevPosZ,
+        cur.x,
+        cur.y,
+        cur.z
+      );
+
+      if (!landing) {
+        // No crossing yet: advance the swept-segment origin for next tick.
+        payload.prevPosX = cur.x;
+        payload.prevPosY = cur.y;
+        payload.prevPosZ = cur.z;
+        continue;
+      }
+
+      payload.landed = true;
+      this.resolveSecondary(payload, landing, physics);
+      this.emitCue(SAU_SECONDARY_IMPACT_CUE_ID, entity.id, tick);
+      this.pools?.despawn(entity as ShrapnelEntity);
+    }
+  }
+
+  private resolveSecondary(
+    payload: ShrapnelPayloadComponent,
+    landing: GroundLanding,
+    physics: PhysicsWorld
+  ): void {
+    const abilities = this._abilities;
+    if (!abilities) return;
+
+    const radiusSq = FP.Mul(payload.secondaryRadius, payload.secondaryRadius);
+    const nearby = physics.spatialGrid.queryRadius(
+      landing.x,
+      landing.z,
+      payload.secondaryRadius
+    );
+
+    for (const id of nearby) {
+      const entity = this.entityManager.getEntity(id);
+      if (!entity) continue;
+
+      const stats = entity.getComponent<StatsComponent>(
+        ComponentType.UnitStats
+      );
+      if (!stats?.alive) continue;
+
+      const team = entity.getComponent<TeamComponent>(ComponentType.Team);
+      if (!SAU_FRIENDLY_FIRE && team && team.teamId === payload.teamId) continue;
+
+      const pos = physics.getEntityPosition(id);
+      if (pos) {
+        const dx = FP.Sub(pos.x, landing.x);
+        const dz = FP.Sub(pos.z, landing.z);
+        const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+        if (FP.Gt(d2, radiusSq)) continue;
+      }
+
+      abilities.applyEffect(id, payload.secondaryEffectId, payload.sourceEntityId);
+    }
+  }
+
+  private emitCue(cueId: string, sourceEntityId: number, tick: number): void {
+    const event: GameplayCueDispatchedEvent = {
+      tick,
+      cueId,
+      sourceEntityId,
+      targetEntityId: sourceEntityId,
+      phase: 'OnApplied',
+    };
+    this.eventBus.emit(gameplayCueKey(cueId), event);
+  }
+}

--- a/abilities-playground/src/systems/ShrapnelSpinSystem.ts
+++ b/abilities-playground/src/systems/ShrapnelSpinSystem.ts
@@ -1,0 +1,94 @@
+import { GameSystem } from '@phalanx-engine/ecs';
+import * as THREE from 'three';
+import { ComponentType, MeshComponent } from '../components';
+
+/** Angular speed range (rad/s) for a fragment's cosmetic tumble. */
+const SPIN_SPEED_MIN = 6;
+const SPIN_SPEED_MAX = 14;
+
+/** Emissive-glow pulse (the "armed / about to blow" flicker) tuning. */
+const GLOW_BASE = 1.4;
+const GLOW_AMPLITUDE = 1.1;
+const GLOW_PULSE_HZ = 6;
+
+/**
+ * ShrapnelSpinSystem — purely cosmetic tumbling for SAU shrapnel fragments.
+ *
+ * Frame system (not a tick system): it spins the shard mesh INSIDE the
+ * MeshComponent root, never touching TransformComponent or the physics store,
+ * so it cannot affect the deterministic simulation. RenderSyncSystem owns the
+ * root's position/quaternion; this system only rotates the child shard.
+ *
+ * Uses Math.random deliberately — spin is visual-only and is allowed to differ
+ * between clients without breaking lockstep.
+ */
+export class ShrapnelSpinSystem extends GameSystem {
+  /** Per-fragment angular velocity (rad/s), assigned on first sight. */
+  private readonly spins = new Map<number, THREE.Vector3>();
+
+  /** Accumulated time (s) driving the shared emissive pulse. */
+  private elapsed = 0;
+
+  public override update(deltaTime: number): void {
+    const fragments = this.entityManager.queryEntities(
+      ComponentType.ShrapnelPayload,
+      ComponentType.Mesh
+    );
+
+    // Pulse the shared incendiary material once per frame (all fragments glow
+    // in unison — cheap and reads as "armed"). Only while fragments exist.
+    if (fragments.length > 0) {
+      this.elapsed += deltaTime;
+      const material = MeshComponent.getShrapnelMaterial();
+      if (material) {
+        const pulse = Math.sin(this.elapsed * GLOW_PULSE_HZ * Math.PI * 2);
+        material.emissiveIntensity = GLOW_BASE + GLOW_AMPLITUDE * pulse;
+      }
+    }
+
+    const alive = new Set<number>();
+
+    for (const entity of fragments) {
+      alive.add(entity.id);
+
+      const mesh = entity.getComponent<MeshComponent>(ComponentType.Mesh);
+      const shard = mesh?.root.children[0];
+      if (!shard) continue;
+
+      let spin = this.spins.get(entity.id);
+      if (!spin) {
+        spin = this.randomAngularVelocity();
+        this.spins.set(entity.id, spin);
+        // Random initial attitude so simultaneous fragments don't tumble in sync.
+        shard.rotation.set(
+          Math.random() * Math.PI * 2,
+          Math.random() * Math.PI * 2,
+          Math.random() * Math.PI * 2
+        );
+      }
+
+      shard.rotation.x += spin.x * deltaTime;
+      shard.rotation.y += spin.y * deltaTime;
+      shard.rotation.z += spin.z * deltaTime;
+    }
+
+    // Fragments returned to the pool leave the query; drop their spin state so
+    // a pooled respawn (same entity id) rolls a fresh tumble.
+    for (const id of this.spins.keys()) {
+      if (!alive.has(id)) this.spins.delete(id);
+    }
+  }
+
+  private randomAngularVelocity(): THREE.Vector3 {
+    const speed =
+      SPIN_SPEED_MIN + Math.random() * (SPIN_SPEED_MAX - SPIN_SPEED_MIN);
+    const axis = new THREE.Vector3(
+      Math.random() * 2 - 1,
+      Math.random() * 2 - 1,
+      Math.random() * 2 - 1
+    );
+    // Degenerate near-zero axis: fall back to a plain Y tumble.
+    if (axis.lengthSq() < 1e-6) axis.set(0, 1, 0);
+    return axis.normalize().multiplyScalar(speed);
+  }
+}

--- a/abilities-playground/src/systems/formation/FormationGridData.ts
+++ b/abilities-playground/src/systems/formation/FormationGridData.ts
@@ -247,6 +247,8 @@ export class FormationGridData {
         return { x: gridX, z: gridZ };
       case 'rocket':
         return this.findRocketOrigin(grid, gridX, gridZ);
+      case 'sau':
+        return this.findSauOrigin(grid, gridX, gridZ);
       case 'cube':
         return this.findCubeOrigin(grid, gridX, gridZ);
       default:
@@ -288,6 +290,42 @@ export class FormationGridData {
     }
 
     return this.findOriginFromPlacedUnits(grid, gridX, gridZ, 'rocket');
+  }
+
+  /**
+   * Find the origin of an SAU (1x2 footprint) — the near cell of the 1x2 area.
+   */
+  private findSauOrigin(
+    grid: FormationGrid,
+    gridX: number,
+    gridZ: number
+  ): GridCoords | null {
+    for (let dz = 0; dz >= -1; dz--) {
+      const checkZ = gridZ + dz;
+      if (checkZ >= 0) {
+        const checkCell = grid.cells[gridX]?.[checkZ];
+        if (checkCell?.unitType === 'sau') {
+          const isOrigin =
+            checkZ + 1 < grid.gridHeight &&
+            grid.cells[gridX][checkZ]?.unitType === 'sau' &&
+            grid.cells[gridX][checkZ + 1]?.unitType === 'sau';
+
+          if (
+            isOrigin &&
+            grid.placedUnits.some(
+              (u) =>
+                u.gridX === gridX &&
+                u.gridZ === checkZ &&
+                u.unitType === 'sau'
+            )
+          ) {
+            return { x: gridX, z: checkZ };
+          }
+        }
+      }
+    }
+
+    return this.findOriginFromPlacedUnits(grid, gridX, gridZ, 'sau');
   }
 
   /**

--- a/abilities-playground/src/systems/index.ts
+++ b/abilities-playground/src/systems/index.ts
@@ -15,5 +15,6 @@ export { ProjectileDespawnQueueSystem } from './ProjectileDespawnQueueSystem';
 export { RenderSyncSystem } from './RenderSyncSystem';
 export { RotationSystem } from './RotationSystem';
 export { ShrapnelLandingSystem } from './ShrapnelLandingSystem';
+export { ShrapnelSpinSystem } from './ShrapnelSpinSystem';
 export { TargetingSystem } from './TargetingSystem';
 export { VoltAttackSystem } from './VoltAttackSystem';

--- a/abilities-playground/src/systems/index.ts
+++ b/abilities-playground/src/systems/index.ts
@@ -1,3 +1,4 @@
+export { ArtilleryShellSystem } from './ArtilleryShellSystem';
 export { AttackSystem } from './AttackSystem';
 export { ChainLightningJumpSystem } from './ChainLightningJumpSystem';
 export { CubeTargetingSystem } from './CubeTargetingSystem';
@@ -13,5 +14,6 @@ export { ProjectileMovementSystem } from './ProjectileMovementSystem';
 export { ProjectileDespawnQueueSystem } from './ProjectileDespawnQueueSystem';
 export { RenderSyncSystem } from './RenderSyncSystem';
 export { RotationSystem } from './RotationSystem';
+export { ShrapnelLandingSystem } from './ShrapnelLandingSystem';
 export { TargetingSystem } from './TargetingSystem';
 export { VoltAttackSystem } from './VoltAttackSystem';

--- a/abilities-playground/src/units/UnitDefinition.ts
+++ b/abilities-playground/src/units/UnitDefinition.ts
@@ -3,7 +3,7 @@ import type { UnitType, UnitGridSize } from './UnitType';
 /** View-layer description (geometry + decorations). Data, not behavior. */
 export interface UnitVisualSpec {
   readonly shape:
-    'sphere' | 'box' | 'cone' | 'octahedron' | 'volt' | 'plasmaTank';
+    'sphere' | 'box' | 'cone' | 'octahedron' | 'volt' | 'plasmaTank' | 'sau';
   readonly size: number; // sphere radius / box edge / cone radius / etc.
   readonly hasSpawnArrow: boolean;
   readonly hasAuraRing: boolean;

--- a/abilities-playground/src/units/UnitType.ts
+++ b/abilities-playground/src/units/UnitType.ts
@@ -5,6 +5,7 @@ export const UnitType = {
   Rocket: 'rocket',
   Volt: 'volt',
   PlasmaTank: 'plasmaTank',
+  Sau: 'sau',
 } as const;
 
 export type UnitType = (typeof UnitType)[keyof typeof UnitType];
@@ -25,4 +26,5 @@ export const UNIT_GRID_SIZE: Readonly<Record<UnitType, UnitGridSize>> = {
   [UnitType.Rocket]: { width: 2, depth: 1 },
   [UnitType.Volt]: { width: 1, depth: 1 },
   [UnitType.PlasmaTank]: { width: 1, depth: 1 },
+  [UnitType.Sau]: { width: 1, depth: 2 },
 } as const;

--- a/abilities-playground/src/units/unitDefinitions.ts
+++ b/abilities-playground/src/units/unitDefinitions.ts
@@ -10,6 +10,10 @@ import {
   ROCKET_DETECTION_RANGE,
   ROCKET_MAX_HEALTH,
   ROCKET_STOP_RANGE,
+  SAU_COOLDOWN_TICKS,
+  SAU_DETECTION_RANGE,
+  SAU_MAX_HEALTH,
+  SAU_STOP_RANGE,
   VOLT_DETECTION_RANGE,
 } from '../config/abilityDefinitions';
 
@@ -119,6 +123,29 @@ export const UNIT_DEFINITIONS: Readonly<Record<UnitType, UnitDefinition>> = {
     visual: {
       shape: 'plasmaTank',
       size: 2.2,
+      hasSpawnArrow: false,
+      hasAuraRing: false,
+    },
+  },
+  [UnitType.Sau]: {
+    type: UnitType.Sau,
+    radius: 2.2,
+    mass: 4,
+    stopRange: SAU_STOP_RANGE,
+    maxHealth: SAU_MAX_HEALTH,
+    detectionRange: SAU_DETECTION_RANGE,
+    heightOffset: 2.5,
+    gridSize: { width: 1, depth: 2 },
+    abilities: ['Ability.SAU.Artillery'],
+    hasAutoAttackTimer: true,
+    hasCubeState: false,
+    autoAttack: {
+      abilityId: 'Ability.SAU.Artillery',
+      cooldownTicks: SAU_COOLDOWN_TICKS,
+    },
+    visual: {
+      shape: 'sau',
+      size: 3.8,
       hasSpawnArrow: false,
       hasAuraRing: false,
     },

--- a/abilities-playground/src/units/unitVisuals.ts
+++ b/abilities-playground/src/units/unitVisuals.ts
@@ -283,10 +283,11 @@ function createPlasmaTankBody(
  *
  * Ported from the finalized concept: a hovering platform + layered hull with a
  * rounded bow, a boxy turret, and a long elevated barrel. The model is authored
- * with its long axis along local +X and its barrel toward +X; the outer root is
+ * with its long axis along local +X and its barrel toward +X; the inner model is
  * yawed -90° so the barrel points +Z (the engine's forward axis, matching the
- * other units and `SauMuzzleFlashCue`'s muzzle offset). `size` scales the whole
- * assembly (size 3.8 reproduces the concept's 1.3× scale).
+ * other units and `SauMuzzleFlashCue`'s muzzle offset). Root rotation stays
+ * available for team facing. `size` scales the whole assembly (size 3.8
+ * reproduces the concept's 1.3× scale).
  */
 function createSauBody(
   size: number,
@@ -429,10 +430,12 @@ function createSauBody(
   );
   exhaust.rotation.z = Math.PI / 2;
 
-  // Lower the assembly so its mass centers near the group origin, then yaw so
-  // the barrel faces +Z and scale to the requested size (3.8 → concept 1.3×).
+  // Lower the assembly so its mass centers near the group origin, then yaw the
+  // inner model so the barrel faces +Z. Keep root.rotation free for team facing
+  // / combat turns (FormationGridRenderer and RotationSystem write root.yaw).
+  // Scale to the requested size (3.8 → concept 1.3×).
   model.position.y = -HOVER_Y;
-  root.rotation.y = -Math.PI / 2;
+  model.rotation.y = -Math.PI / 2;
   root.scale.setScalar(size * 0.342);
 
   return root;

--- a/abilities-playground/src/units/unitVisuals.ts
+++ b/abilities-playground/src/units/unitVisuals.ts
@@ -81,6 +81,8 @@ function createBody(
       return createVoltBody(spec.size, teamId, unitType);
     case 'plasmaTank':
       return createPlasmaTankBody(spec.size, teamId, unitType);
+    case 'sau':
+      return createSauBody(spec.size, teamId, unitType);
   }
 }
 
@@ -272,6 +274,166 @@ function createPlasmaTankBody(
   barrel.position.set(0, turretY, barrelCenterZ);
   enableShadows(barrel);
   root.add(barrel);
+
+  return root;
+}
+
+/**
+ * SAU (self-propelled artillery) visual: a hover artillery tank.
+ *
+ * Ported from the finalized concept: a hovering platform + layered hull with a
+ * rounded bow, a boxy turret, and a long elevated barrel. The model is authored
+ * with its long axis along local +X and its barrel toward +X; the outer root is
+ * yawed -90° so the barrel points +Z (the engine's forward axis, matching the
+ * other units and `SauMuzzleFlashCue`'s muzzle offset). `size` scales the whole
+ * assembly (size 3.8 reproduces the concept's 1.3× scale).
+ */
+function createSauBody(
+  size: number,
+  teamId: TeamId,
+  unitType: UnitType
+): THREE.Object3D {
+  const root = new THREE.Group();
+  const model = new THREE.Group();
+  root.add(model);
+
+  const hullMat = createTeamMaterial(teamId, unitType);
+  const hullLoMat = new THREE.MeshStandardMaterial({
+    color: resolveUnitColor(teamId, unitType),
+    roughness: 0.85,
+    metalness: 0.15,
+  });
+  hullLoMat.color.multiplyScalar(0.7);
+  const turretMat = createTeamMaterial(teamId, unitType);
+  const gunMat = new THREE.MeshStandardMaterial({
+    color: 0x35393d,
+    roughness: 0.55,
+    metalness: 0.45,
+  });
+  const darkMat = new THREE.MeshStandardMaterial({
+    color: 0x2a2d30,
+    roughness: 0.7,
+    metalness: 0.3,
+  });
+  const detailMat = new THREE.MeshStandardMaterial({
+    color: resolveUnitColor(teamId, unitType),
+    roughness: 0.8,
+    metalness: 0.1,
+  });
+  detailMat.color.multiplyScalar(0.85);
+  const platformMat = new THREE.MeshStandardMaterial({
+    color: 0x2b3022,
+    roughness: 0.6,
+    metalness: 0.35,
+  });
+
+  const HOVER_Y = 1.15;
+
+  const add = (
+    geometry: THREE.BufferGeometry,
+    material: THREE.Material,
+    x: number,
+    y: number,
+    z: number,
+    castShadow = true
+  ): THREE.Mesh => {
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(x, y, z);
+    if (castShadow) mesh.castShadow = true;
+    model.add(mesh);
+    return mesh;
+  };
+
+  // Hover platform + skirt.
+  add(new THREE.BoxGeometry(4.5, 0.34, 2.05), platformMat, -0.1, 0.66, 0);
+  add(new THREE.BoxGeometry(4.5, 0.2, 2.05), darkMat, -0.1, HOVER_Y - 0.4, 0, false);
+
+  // Hull stack.
+  add(new THREE.BoxGeometry(4.4, 1.0, 1.95), hullLoMat, -0.1, HOVER_Y, 0);
+  const bow = add(
+    new THREE.CylinderGeometry(0.5, 0.5, 1.95, 24),
+    hullLoMat,
+    2.1,
+    HOVER_Y,
+    0
+  );
+  bow.rotation.x = Math.PI / 2;
+  add(new THREE.BoxGeometry(4.1, 0.55, 1.78), hullMat, -0.1, HOVER_Y + 0.62, 0);
+  add(new THREE.BoxGeometry(0.9, 0.6, 1.6), detailMat, -2.05, HOVER_Y + 0.6, 0);
+
+  // Turret.
+  add(new THREE.BoxGeometry(2.4, 0.78, 1.8), turretMat, -0.25, HOVER_Y + 1.27, 0);
+  add(new THREE.BoxGeometry(2.0, 0.12, 1.45), detailMat, -0.25, HOVER_Y + 1.7, 0);
+  const cupola = add(
+    new THREE.CylinderGeometry(0.3, 0.32, 0.34, 16),
+    detailMat,
+    0,
+    HOVER_Y + 1.92,
+    -0.45
+  );
+  cupola.castShadow = true;
+  add(
+    new THREE.CylinderGeometry(0.23, 0.23, 0.08, 16),
+    darkMat,
+    -0.95,
+    HOVER_Y + 1.74,
+    0.45,
+    false
+  );
+  add(new THREE.BoxGeometry(0.5, 0.62, 1.0), gunMat, 1.0, HOVER_Y + 1.22, 0);
+
+  // Barrel assembly (elevated, along +X local).
+  const barrelGroup = new THREE.Group();
+  barrelGroup.position.set(1.1, HOVER_Y + 1.22, 0);
+  barrelGroup.rotation.z = 0.28;
+  model.add(barrelGroup);
+  const barrel = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.14, 0.15, 5.6, 24),
+    gunMat
+  );
+  barrel.rotation.z = -Math.PI / 2;
+  barrel.position.x = 2.8;
+  barrel.castShadow = true;
+  barrelGroup.add(barrel);
+  const fume = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.22, 0.22, 0.55, 20),
+    darkMat
+  );
+  fume.rotation.z = -Math.PI / 2;
+  fume.position.x = 4.0;
+  barrelGroup.add(fume);
+  const muzzle = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.2, 0.17, 0.55, 20),
+    darkMat
+  );
+  muzzle.rotation.z = -Math.PI / 2;
+  muzzle.position.x = 5.5;
+  barrelGroup.add(muzzle);
+
+  // Antenna + side exhaust.
+  const antenna = add(
+    new THREE.CylinderGeometry(0.022, 0.022, 1.7, 6),
+    darkMat,
+    -1.35,
+    HOVER_Y + 2.45,
+    0.55
+  );
+  antenna.castShadow = true;
+  const exhaust = add(
+    new THREE.CylinderGeometry(0.13, 0.13, 0.95, 12),
+    darkMat,
+    -2.4,
+    HOVER_Y + 0.5,
+    0.5,
+    false
+  );
+  exhaust.rotation.z = Math.PI / 2;
+
+  // Lower the assembly so its mass centers near the group origin, then yaw so
+  // the barrel faces +Z and scale to the requested size (3.8 → concept 1.3×).
+  model.position.y = -HOVER_Y;
+  root.rotation.y = -Math.PI / 2;
+  root.scale.setScalar(size * 0.342);
 
   return root;
 }

--- a/abilities-playground/tests/SauArtillery.test.ts
+++ b/abilities-playground/tests/SauArtillery.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  Entity,
+  EntityManager,
+  EventBus,
+  SoAComponent,
+  SystemContext,
+} from '@phalanx-engine/ecs';
+import type { GameWorld } from '@phalanx-engine/ecs';
+import { FP, FPVector3 } from '@phalanx-engine/math';
+import {
+  TransformComponent,
+  TRANSFORM_COMPONENT_TYPE,
+} from '@phalanx-engine/physics';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+  ArtilleryShellComponent,
+  ShrapnelPayloadComponent,
+} from '../src/components';
+import { ArtilleryShellSystem } from '../src/systems/ArtilleryShellSystem';
+import {
+  ShrapnelLandingSystem,
+  computeGroundLanding,
+} from '../src/systems/ShrapnelLandingSystem';
+import { sauArtillery } from '../src/hooks/SauArtillery';
+import { GameRandom } from '../src/core/GameRandom';
+import {
+  SAU_SHRAPNEL_COUNT,
+  SAU_MIN_ENGAGEMENT_RANGE,
+} from '../src/config/abilityDefinitions';
+import {
+  SAU_SHRAPNEL_CONE,
+  SAU_SHRAPNEL_SPEED,
+} from '../src/config/constants';
+
+function makeManager(): EntityManager {
+  const entityManager = new EntityManager();
+  entityManager.registerComponentTypes([
+    TRANSFORM_COMPONENT_TYPE,
+    ComponentType.Team,
+    ComponentType.UnitStats,
+    ComponentType.ArtilleryShell,
+    ComponentType.ShrapnelPayload,
+  ]);
+  SoAComponent.useEntityManager(entityManager);
+  return entityManager;
+}
+
+function addTransformUnit(
+  entityManager: EntityManager,
+  pos: { x: number; y: number; z: number },
+  teamId: 0 | 1
+): Entity {
+  const entity = new Entity();
+  entity.addComponent(
+    new TransformComponent(
+      entity.id,
+      FPVector3.FromFloat(pos.x, pos.y, pos.z)
+    )
+  );
+  entity.addComponent(new TeamComponent(teamId));
+  entityManager.addEntity(entity);
+  entityManager.onComponentAdded(entity, TRANSFORM_COMPONENT_TYPE);
+  entityManager.onComponentAdded(entity, ComponentType.Team);
+  return entity;
+}
+
+describe('computeGroundLanding (FP safety + landing point)', () => {
+  it('returns null when the segment does not cross the ground plane', () => {
+    // Both endpoints above ground.
+    expect(
+      computeGroundLanding(
+        FP.FromFloat(0),
+        FP.FromFloat(5),
+        FP.FromFloat(0),
+        FP.FromFloat(0),
+        FP.FromFloat(2),
+        FP.FromFloat(0)
+      )
+    ).toBeNull();
+    // Ascending (below → above) is not a downward crossing.
+    expect(
+      computeGroundLanding(
+        FP.FromFloat(0),
+        FP.FromFloat(-1),
+        FP.FromFloat(0),
+        FP.FromFloat(0),
+        FP.FromFloat(3),
+        FP.FromFloat(0)
+      )
+    ).toBeNull();
+  });
+
+  it('interpolates the exact crossing point without dividing by zero', () => {
+    // prevY=5 → curY=-1 over dx=2..2 dz=3..3 crosses at t=5/6.
+    const landing = computeGroundLanding(
+      FP.FromFloat(2),
+      FP.FromFloat(5),
+      FP.FromFloat(3),
+      FP.FromFloat(2),
+      FP.FromFloat(-1),
+      FP.FromFloat(3)
+    );
+    expect(landing).not.toBeNull();
+    expect(FP.ToFloat(landing!.x)).toBeCloseTo(2, 5);
+    expect(FP.ToFloat(landing!.y)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(landing!.z)).toBeCloseTo(3, 5);
+  });
+
+  it('never throws across many crossing configurations (FP.Div guard)', () => {
+    for (let i = 1; i <= 50; i++) {
+      const prevY = FP.FromFloat(i * 0.13);
+      const curY = FP.FromFloat(-i * 0.07);
+      expect(() =>
+        computeGroundLanding(
+          FP.FromFloat(i),
+          prevY,
+          FP.FromFloat(-i),
+          FP.FromFloat(i + 1),
+          curY,
+          FP.FromFloat(-i - 1)
+        )
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('sauArtillery hook', () => {
+  let entityManager: EntityManager;
+  let spawn: ReturnType<typeof vi.fn>;
+  let world: GameWorld;
+
+  beforeEach(() => {
+    entityManager = makeManager();
+    spawn = vi.fn(() => ({ id: 9999 }));
+    world = {
+      entityManager,
+      eventBus: new EventBus(),
+      pools: { spawn },
+    } as unknown as GameWorld;
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function fireAt(target: Entity, caster: Entity): void {
+    sauArtillery(
+      {
+        tick: 100,
+        casterEntityId: caster.id,
+        resolvedTargets: [target.id],
+      } as never,
+      world
+    );
+  }
+
+  it('snapshots the impact point independent of later target movement', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const target = addTransformUnit(entityManager, { x: 0, y: 0, z: 50 }, 1);
+
+    fireAt(target, caster);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const args = spawn.mock.calls[0][1] as {
+      impactPoint: { x: number; y: number; z: number };
+    };
+    const snapshotZ = FP.ToFloat(args.impactPoint.z);
+    expect(snapshotZ).toBeCloseTo(50, 3);
+
+    // Move the target far away; the already-snapshotted impact must not change.
+    const targetTransform = target.getComponent<TransformComponent>(
+      ComponentType.Transform
+    )!;
+    targetTransform.fpPosition = FPVector3.FromFloat(0, 0, 999);
+    expect(FP.ToFloat(args.impactPoint.z)).toBeCloseTo(snapshotZ, 3);
+  });
+
+  it('refuses to fire on enemies inside the minimum engagement range', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const near = addTransformUnit(
+      entityManager,
+      { x: 0, y: 0, z: SAU_MIN_ENGAGEMENT_RANGE - 5 },
+      1
+    );
+    fireAt(near, caster);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('fires on enemies beyond the minimum engagement range', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const far = addTransformUnit(
+      entityManager,
+      { x: 0, y: 0, z: SAU_MIN_ENGAGEMENT_RANGE + 20 },
+      1
+    );
+    fireAt(far, caster);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ArtilleryShellSystem shrapnel determinism', () => {
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function runDetonation(seed: number): Array<[number, number, number]> {
+    GameRandom.initialize(seed);
+    const entityManager = makeManager();
+    const context = new SystemContext(new EventBus(), entityManager);
+    const impulses: Array<[number, number, number]> = [];
+    let nextId = 5000;
+    context.physics = {
+      spatialGrid: { queryRadius: () => [] as number[] },
+      getEntityPosition: () => undefined,
+      applyImpulse3D: (_id: number, vx: number, vy: number, vz: number) => {
+        impulses.push([FP.ToRaw(vx), FP.ToRaw(vy), FP.ToRaw(vz)]);
+      },
+    } as never;
+    context.abilities = { applyEffect: vi.fn() } as never;
+    context.pools = {
+      spawn: () => ({ id: nextId++ }),
+      despawn: vi.fn(),
+    } as never;
+
+    const shellEntity = new Entity();
+    const shell = new ArtilleryShellComponent();
+    shell.sourceEntityId = 1;
+    shell.teamId = 0;
+    shell.detonateTick = 0;
+    shell.primaryRadius = FP._0;
+    shell.secondaryRadius = FP.FromFloat(5);
+    shell.shrapnelConfig = {
+      count: SAU_SHRAPNEL_COUNT,
+      cone: FP.FromFloat(SAU_SHRAPNEL_CONE),
+      speed: FP.FromFloat(SAU_SHRAPNEL_SPEED),
+    };
+    shellEntity.addComponent(shell);
+    entityManager.addEntity(shellEntity);
+    entityManager.onComponentAdded(shellEntity, ComponentType.ArtilleryShell);
+
+    const system = new ArtilleryShellSystem();
+    system.init(context);
+    system.processTick(0);
+    return impulses;
+  }
+
+  it('spawns SAU_SHRAPNEL_COUNT fragments', () => {
+    const impulses = runDetonation(42);
+    expect(impulses).toHaveLength(SAU_SHRAPNEL_COUNT);
+  });
+
+  it('produces identical impulses for the same seed', () => {
+    const a = runDetonation(1234);
+    const b = runDetonation(1234);
+    expect(b).toEqual(a);
+  });
+});
+
+describe('ShrapnelLandingSystem secondary blast', () => {
+  let entityManager: EntityManager;
+  let context: SystemContext;
+  let applyEffect: ReturnType<typeof vi.fn>;
+  let queryRadius: ReturnType<typeof vi.fn>;
+  let despawn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    entityManager = makeManager();
+    context = new SystemContext(new EventBus(), entityManager);
+    applyEffect = vi.fn();
+    despawn = vi.fn();
+    queryRadius = vi.fn();
+    context.abilities = { applyEffect } as never;
+    context.pools = { despawn, spawn: vi.fn() } as never;
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function addShrapnel(sourceEntityId: number): Entity {
+    const entity = new Entity();
+    // Current position is below ground (crossed this tick).
+    entity.addComponent(
+      new TransformComponent(entity.id, FPVector3.FromFloat(2, -1, 3))
+    );
+    const payload = new ShrapnelPayloadComponent();
+    payload.sourceEntityId = sourceEntityId;
+    payload.teamId = 0;
+    payload.secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+    payload.secondaryRadius = FP.FromFloat(5);
+    payload.prevPosX = FP.FromFloat(2);
+    payload.prevPosY = FP.FromFloat(5);
+    payload.prevPosZ = FP.FromFloat(3);
+    entity.addComponent(payload);
+    entityManager.addEntity(entity);
+    entityManager.onComponentAdded(entity, TRANSFORM_COMPONENT_TYPE);
+    entityManager.onComponentAdded(entity, ComponentType.ShrapnelPayload);
+    return entity;
+  }
+
+  function addVictim(): Entity {
+    const entity = new Entity();
+    const stats = new StatsComponent({ stopRange: 1 });
+    stats.alive = true;
+    entity.addComponent(stats);
+    entity.addComponent(new TeamComponent(1));
+    entityManager.addEntity(entity);
+    entityManager.onComponentAdded(entity, ComponentType.UnitStats);
+    entityManager.onComponentAdded(entity, ComponentType.Team);
+    return entity;
+  }
+
+  it('applies the secondary effect at the exact ground landing point', () => {
+    const victim = addVictim();
+    queryRadius.mockReturnValue([victim.id]);
+    context.physics = {
+      spatialGrid: { queryRadius },
+      getEntityPosition: () => ({ x: FP.FromFloat(2), z: FP.FromFloat(3) }),
+    } as never;
+
+    const shrapnel = addShrapnel(1);
+    const system = new ShrapnelLandingSystem();
+    system.init(context);
+    system.processTick(0);
+
+    // Queried around the interpolated landing point (≈ x=2, z=3).
+    expect(queryRadius).toHaveBeenCalledTimes(1);
+    const [qx, qz] = queryRadius.mock.calls[0];
+    expect(FP.ToFloat(qx)).toBeCloseTo(2, 3);
+    expect(FP.ToFloat(qz)).toBeCloseTo(3, 3);
+
+    expect(applyEffect).toHaveBeenCalledWith(
+      victim.id,
+      'Effect.Damage.SAU.Secondary',
+      1
+    );
+    const payload = shrapnel.getComponent<ShrapnelPayloadComponent>(
+      ComponentType.ShrapnelPayload
+    )!;
+    expect(payload.landed).toBe(true);
+    expect(despawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the secondary even when the firing unit has already died', () => {
+    const victim = addVictim();
+    queryRadius.mockReturnValue([victim.id]);
+    context.physics = {
+      spatialGrid: { queryRadius },
+      getEntityPosition: () => ({ x: FP.FromFloat(2), z: FP.FromFloat(3) }),
+    } as never;
+
+    // Source id 777 has no live entity in the manager (caster is gone).
+    addShrapnel(777);
+    const system = new ShrapnelLandingSystem();
+    system.init(context);
+    system.processTick(0);
+
+    expect(applyEffect).toHaveBeenCalledWith(
+      victim.id,
+      'Effect.Damage.SAU.Secondary',
+      777
+    );
+  });
+});

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -277,6 +277,9 @@ class PhysicsWorld {
   applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void;
   isSettled(threshold?: FixedPoint): boolean;
 
+  // 3D collision workaround — see "Raycast / swept-segment queries"
+  raycastSegment(prev: { x: FixedPoint; y: FixedPoint; z: FixedPoint }, cur: { x: FixedPoint; y: FixedPoint; z: FixedPoint }, boxes: ReadonlyArray<AABB3>): RayHit | null;
+
   // Spatial / transform queries
   readonly spatialGrid: SpatialHashGrid;
   getEntityPosition(entityId: number): { x: FixedPoint; z: FixedPoint } | undefined;
@@ -424,6 +427,47 @@ integrated across every sub-step. The net ΔY per tick is `velocityY * tickDt`
 (semi-implicit Euler) — correct for gameplay. Sub-step-accurate gravity would
 require folding the acceleration into `PhysicsSystem.step()`'s loop (at which
 point it would no longer be a separate system); this is intentionally not done.
+
+## Raycast / swept-segment queries (3D collision workaround)
+
+The body-vs-body narrow phase is **2D/XZ only** (circles on the ground plane) and
+has no notion of height. For **3D collision** — e.g. a fast-moving ordnance
+(artillery shrapnel, shell, projectile) hitting a static obstacle such as a
+building, where you need the impact point and surface normal — use the swept-
+segment raycast query as a **workaround** until a full 3D body-body collision
+system is implemented (planned v2: `BoxColliderComponent` as ECS entities +
+grid-accelerated raycast + 3D sphere/box vs sphere/box resolution).
+
+```typescript
+import { FP } from '@phalanx-engine/math';
+import { PhysicsWorld, type AABB3, type RayHit } from '@phalanx-engine/physics';
+
+// prev = previous tick position of the shard, cur = current position (after
+// gravity + integration ran). buildings = static 3D AABBs.
+const hit: RayHit | null = physicsWorld.raycastSegment(prev, cur, buildings);
+if (hit) {
+  spawnSecondaryAoE(hit.point, radii);   // explosion on the wall
+  cue(Impact, hit.point);                // VFX/SFX at the impact
+  // hit.normal is the outward face normal — use for ricochet / impulse direction.
+  despawn(shrapnel);
+  return;
+}
+// No building hit -> check ground plane, else carry prevPos forward next tick.
+```
+
+- `segmentVsAABB(prev, cur, box)` — pure slab-method query returning
+  `{ t, point, normal }` (t in `[0,1]` along the segment, `point = lerp(prev, cur, t)`,
+  `normal` = outward face normal of the entry plane) or `null`.
+- `PhysicsWorld.raycastSegment(prev, cur, boxes)` — scans a caller-supplied list of
+  static `AABB3` boxes and returns the **nearest** hit, or `null`.
+
+Using the swept segment (not point-in-box per tick) prevents **tunneling**: a
+fast shard cannot skip through a thin wall between ticks.
+
+**v1 limitations:** linear scan over caller-supplied boxes (no broad-phase
+acceleration) — fine for tens of obstacles; the unit-vs-unit 2D circle pipeline
+is untouched. **v2 path:** `BoxColliderComponent` as ECS entities + spatial-grid
+raycast + full 3D body-body collision.
 
 ### `TransformComponent`
 

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -293,7 +293,7 @@ class PhysicsWorld {
 
 - **`applyImpulse(entityId, vx, vz)`** — Set body XZ velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
 - **`applyImpulse3D(entityId, vx, vy, vz)`** — Set full 3D body velocity (replaces all three axes). Re-enables previously ejected bodies. Use for arcing ordnance; see [Gravity](#gravity).
-- **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`).
+- **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`). Considers the full 3D velocity (X, Y, Z), so a body falling on Y alone is correctly reported as not settled.
 - **`onBoundsExit(callback)`** — Subscribe to `BOUNDS_EXIT` events (requires `ejectOnBoundsExit: true`).
 - **`setCollisionFilter(filter)`** — Inject a per-pair predicate. Return `false` to skip collision resolution for that pair.
 

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -16,6 +16,7 @@ A deterministic, fixed-point physics engine for the [Phalanx Engine](../README.m
 - **Tick Providers**: Pluggable `IPhysicsTickProvider` interface decouples tick scheduling from simulation logic — supports GameWorld-driven, autonomous (turn-based), and external (rAF) modes
 - **Impulse API**: `applyImpulse()` sets body XZ velocity for flick/strike mechanics; `applyImpulse3D()` sets full 3D velocity for arcing ordnance; `isSettled()` queries whether all bodies are at rest
 - **Gravity**: opt-in gravitational acceleration via `GravitySystem` + per-body `useGravity` flag; position integrated on all three axes by `PhysicsSystem` (see [Gravity](#gravity))
+- **Raycast / Swept-Segment Query**: `raycastSegment()` / `segmentVsAABB()` return the nearest hit (point + surface normal) against caller-supplied AABBs — a **workaround for 3D collisions** (e.g. ordnance vs a building) until full 3D body-body collision exists (see [Raycast / swept-segment queries](#raycast--swept-segment-queries))
 - **Bounds Exit Mode**: Optional `ejectOnBoundsExit` mode marks out-of-bounds bodies as ignored and emits `BOUNDS_EXIT` events instead of clamping
 - **Event-Driven**: Collision, trigger enter, trigger exit, and bounds exit events emitted via phalanx-ecs `EventBus`
 - **Built-in Transform & Interpolation**: `TransformComponent` (SoA fixed-point spatial state), `InterpolationComponent`, and `InterpolationSystem` for tick-to-frame render smoothing
@@ -277,13 +278,11 @@ class PhysicsWorld {
   applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void;
   isSettled(threshold?: FixedPoint): boolean;
 
-  // 3D collision workaround — see "Raycast / swept-segment queries"
-  raycastSegment(prev: { x: FixedPoint; y: FixedPoint; z: FixedPoint }, cur: { x: FixedPoint; y: FixedPoint; z: FixedPoint }, boxes: ReadonlyArray<AABB3>): RayHit | null;
-
   // Spatial / transform queries
   readonly spatialGrid: SpatialHashGrid;
   getEntityPosition(entityId: number): { x: FixedPoint; z: FixedPoint } | undefined;
   getInterpolatedTransform(entityId: number): InterpolatedTransformSample | undefined;
+  raycastSegment(prev: Vec3FP, cur: Vec3FP, boxes: ReadonlyArray<AABB>): RayHit | null;
 
   // Cleanup
   dispose(): void;
@@ -293,6 +292,7 @@ class PhysicsWorld {
 - **`getSystems()`** — Returns `physicsSystem` and `gravitySystem` (register as tick systems, gravity before physics) and `interpolationSystem` (register as frame system). Backward-compatible: destructuring only `{ physicsSystem, interpolationSystem }` still works.
 - **`getEntityPosition(entityId)`** — Fixed-point position for gameplay queries (e.g. ability targeting).
 - **`getInterpolatedTransform(entityId)`** — Interpolated float transform for rendering, populated after `InterpolationSystem` runs. Returns an `InterpolatedTransformSample` with `position: { x, y, z }` and `rotation: { x, y, z, w }` — rotation is a float quaternion (slerped between tick samples), apply it directly to a mesh quaternion.
+- **`raycastSegment(prev, cur, boxes)`** — Swept-segment (raycast) query returning the nearest hit against caller-supplied AABBs. **Workaround for 3D collisions** (e.g. ordnance vs a building) until full 3D body-body collision exists; see [Raycast / swept-segment queries](#raycast--swept-segment-queries).
 
 - **`applyImpulse(entityId, vx, vz)`** — Set body XZ velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
 - **`applyImpulse3D(entityId, vx, vy, vz)`** — Set full 3D body velocity (replaces all three axes). Re-enables previously ejected bodies. Use for arcing ordnance; see [Gravity](#gravity).
@@ -428,46 +428,67 @@ integrated across every sub-step. The net ΔY per tick is `velocityY * tickDt`
 require folding the acceleration into `PhysicsSystem.step()`'s loop (at which
 point it would no longer be a separate system); this is intentionally not done.
 
-## Raycast / swept-segment queries (3D collision workaround)
+## Raycast / swept-segment queries
 
-The body-vs-body narrow phase is **2D/XZ only** (circles on the ground plane) and
-has no notion of height. For **3D collision** — e.g. a fast-moving ordnance
-(artillery shrapnel, shell, projectile) hitting a static obstacle such as a
-building, where you need the impact point and surface normal — use the swept-
-segment raycast query as a **workaround** until a full 3D body-body collision
-system is implemented (planned v2: `BoxColliderComponent` as ECS entities +
-grid-accelerated raycast + 3D sphere/box vs sphere/box resolution).
+> ⚠️ **Workaround for 3D collisions.** The core physics pipeline is 2D/XZ
+> (circle-vs-circle broad/narrow phase); it does **not** detect collisions on
+> the Y axis. For 3D collisions — e.g. ordnance hitting a static obstacle like a
+> building — use this swept-segment raycast query as a workaround until full 3D
+> body-body collision is implemented (planned for v2). It answers "did this
+> moving point cross a box between last tick and this tick, and if so, where and
+> on which face?"
+
+Pass a moving body's previous and current position, plus the AABBs of the static
+obstacles you care about. The query returns the nearest impact point and the
+outward surface normal, or `null` if nothing was hit.
 
 ```typescript
-import { FP } from '@phalanx-engine/math';
-import { PhysicsWorld, type AABB3, type RayHit } from '@phalanx-engine/physics';
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import type { Vec3FP, AABB, RayHit } from '@phalanx-engine/physics';
 
-// prev = previous tick position of the shard, cur = current position (after
-// gravity + integration ran). buildings = static 3D AABBs.
-const hit: RayHit | null = physicsWorld.raycastSegment(prev, cur, buildings);
+const hit: RayHit | null = physicsWorld.raycastSegment(prevPos, curPos, buildingBoxes);
 if (hit) {
-  spawnSecondaryAoE(hit.point, radii);   // explosion on the wall
-  cue(Impact, hit.point);                // VFX/SFX at the impact
-  // hit.normal is the outward face normal — use for ricochet / impulse direction.
-  despawn(shrapnel);
-  return;
+  // hit.t     — parametric distance along the segment, 0 at prev, 1 at cur
+  // hit.point — impact position (= lerp(prev, cur, t)), fixed-point
+  // hit.normal — outward face normal at the impact (±X / ±Y / ±Z), fixed-point
+  detonateAt(hit.point, hit.normal);
 }
-// No building hit -> check ground plane, else carry prevPos forward next tick.
 ```
 
-- `segmentVsAABB(prev, cur, box)` — pure slab-method query returning
-  `{ t, point, normal }` (t in `[0,1]` along the segment, `point = lerp(prev, cur, t)`,
-  `normal` = outward face normal of the entry plane) or `null`.
-- `PhysicsWorld.raycastSegment(prev, cur, boxes)` — scans a caller-supplied list of
-  static `AABB3` boxes and returns the **nearest** hit, or `null`.
+`RayHit`, `Vec3FP`, and `AABB` are exported from the package root. The low-level
+`segmentVsAABB(prev, cur, box)` tests a single box (returns the same `RayHit`
+shape or `null`); `raycastSegment` is the multi-box convenience wrapper.
 
-Using the swept segment (not point-in-box per tick) prevents **tunneling**: a
-fast shard cannot skip through a thin wall between ticks.
+### Semantics
 
-**v1 limitations:** linear scan over caller-supplied boxes (no broad-phase
-acceleration) — fine for tens of obstacles; the unit-vs-unit 2D circle pipeline
-is untouched. **v2 path:** `BoxColliderComponent` as ECS entities + spatial-grid
-raycast + full 3D body-body collision.
+- **`t ∈ [0, 1]`** — `0` at `prev`, `1` at `cur`; `point = lerp(prev, cur, t)`.
+- **Segment starting inside a box** → `t = 0`, `point = prev`, `normal` = the
+  nearest face's outward normal.
+- **Normal convention** — outward normal of the entry face: moving `+X` enters
+  the min-X face → `normal = -X`; moving `-Y` enters the max-Y (top) face →
+  `normal = +Y`, and so on.
+- **Deterministic** — pure `FP.*` fixed-point math, no floats. Degenerate cases
+  (segment parallel to a slab, zero-length segment) are handled without
+  divide-by-zero or `NaN`; identical inputs always yield a bit-for-bit identical
+  `RayHit`.
+
+### v1 limitations (workaround scope)
+
+- **Pure linear scan** over the boxes you pass — no broad-phase acceleration
+  (the spatial hash grid is not consulted).
+- **Caller-supplied boxes** — the query does not read colliders from the ECS; you
+  assemble the `AABB[]` yourself.
+- **Point-vs-box only** — the moving body is treated as a point (its radius is
+  not swept); inflate the box by the radius if you need a Minkowski-style margin.
+- **Unit-vs-unit collisions remain 2D/XZ** in `PhysicsSystem` — this query does
+  not change the body-body pipeline.
+
+### v2 path (planned)
+
+Full 3D collision is planned for v2: a `BoxColliderComponent`, grid-accelerated
+raycasts (broad-phase against the spatial hash), and true 3D body-body collision
+resolution — at which point this swept-segment query becomes an optimization
+detail rather than the only 3D path.
 
 ### `TransformComponent`
 

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -14,7 +14,8 @@ A deterministic, fixed-point physics engine for the [Phalanx Engine](../README.m
 - **Sub-stepping**: Configurable physics sub-steps per tick for higher fidelity at the same tick rate
 - **Collision Filtering**: Inject game-specific collision rules via callback — no coupling to game concepts
 - **Tick Providers**: Pluggable `IPhysicsTickProvider` interface decouples tick scheduling from simulation logic — supports GameWorld-driven, autonomous (turn-based), and external (rAF) modes
-- **Impulse API**: `applyImpulse()` sets body velocity for flick/strike mechanics; `isSettled()` queries whether all bodies are at rest
+- **Impulse API**: `applyImpulse()` sets body XZ velocity for flick/strike mechanics; `applyImpulse3D()` sets full 3D velocity for arcing ordnance; `isSettled()` queries whether all bodies are at rest
+- **Gravity**: opt-in gravitational acceleration via `GravitySystem` + per-body `useGravity` flag; position integrated on all three axes by `PhysicsSystem` (see [Gravity](#gravity))
 - **Bounds Exit Mode**: Optional `ejectOnBoundsExit` mode marks out-of-bounds bodies as ignored and emits `BOUNDS_EXIT` events instead of clamping
 - **Event-Driven**: Collision, trigger enter, trigger exit, and bounds exit events emitted via phalanx-ecs `EventBus`
 - **Built-in Transform & Interpolation**: `TransformComponent` (SoA fixed-point spatial state), `InterpolationComponent`, and `InterpolationSystem` for tick-to-frame render smoothing
@@ -260,7 +261,7 @@ class PhysicsWorld {
   constructor(config?: PhysicsWorldConfig);
 
   // System wiring
-  getSystems(): { physicsSystem: PhysicsSystem; interpolationSystem: InterpolationSystem };
+  getSystems(): { physicsSystem: PhysicsSystem; gravitySystem: GravitySystem; interpolationSystem: InterpolationSystem };
   setCollisionFilter(filter: (entityA: number, entityB: number) => boolean): void;
 
   // Event subscriptions (must be called after GameWorld.start())
@@ -273,6 +274,7 @@ class PhysicsWorld {
 
   // Impulse / settle queries
   applyImpulse(entityId: number, vx: FixedPoint, vz: FixedPoint): void;
+  applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void;
   isSettled(threshold?: FixedPoint): boolean;
 
   // Spatial / transform queries
@@ -285,11 +287,12 @@ class PhysicsWorld {
 }
 ```
 
-- **`getSystems()`** — Returns both `physicsSystem` (register as tick system) and `interpolationSystem` (register as frame system).
+- **`getSystems()`** — Returns `physicsSystem` and `gravitySystem` (register as tick systems, gravity before physics) and `interpolationSystem` (register as frame system). Backward-compatible: destructuring only `{ physicsSystem, interpolationSystem }` still works.
 - **`getEntityPosition(entityId)`** — Fixed-point position for gameplay queries (e.g. ability targeting).
 - **`getInterpolatedTransform(entityId)`** — Interpolated float transform for rendering, populated after `InterpolationSystem` runs. Returns an `InterpolatedTransformSample` with `position: { x, y, z }` and `rotation: { x, y, z, w }` — rotation is a float quaternion (slerped between tick samples), apply it directly to a mesh quaternion.
 
-- **`applyImpulse(entityId, vx, vz)`** — Set body velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
+- **`applyImpulse(entityId, vx, vz)`** — Set body XZ velocity (replaces, does not accumulate). Re-enables previously ejected bodies.
+- **`applyImpulse3D(entityId, vx, vy, vz)`** — Set full 3D body velocity (replaces all three axes). Re-enables previously ejected bodies. Use for arcing ordnance; see [Gravity](#gravity).
 - **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`).
 - **`onBoundsExit(callback)`** — Subscribe to `BOUNDS_EXIT` events (requires `ejectOnBoundsExit: true`).
 - **`setCollisionFilter(filter)`** — Inject a per-pair predicate. Return `false` to skip collision resolution for that pair.
@@ -311,6 +314,8 @@ interface PhysicsWorldConfig {
   tickProvider?: IPhysicsTickProvider;
   ejectOnBoundsExit?: boolean;   // default false
   settleThreshold?: FixedPoint;  // default FP.FromFloat(0.01)
+  gravity?: FixedPoint;          // acceleration magnitude, default 0 (disabled)
+  gravityAxis?: 'x' | 'y' | 'z'; // default 'y'; only 'y' supported in v1
 }
 ```
 
@@ -338,6 +343,87 @@ const physicsWorld = new PhysicsWorld({
   restitution: FP.FromFloat(0.85),
 });
 ```
+
+## Gravity
+
+Gravity is **opt-in** and off by default (`gravity` defaults to `0`, so
+`GravitySystem` is a no-op and existing bodies are unaffected). It is designed
+for arcing ordnance — artillery shrapnel, thrown grenades, anything that leaves
+the ground plane.
+
+### Model: acceleration vs. integration
+
+The engine follows the "one owner per axis" rule to avoid double-integration:
+
+| Concern | Owner | What it does |
+|---|---|---|
+| **Acceleration** | `GravitySystem` | For bodies with `useGravity=true`, decays velocity along the gravity axis each tick: `velocityY -= gravity * tickDt`. **Never writes position.** |
+| **Integration** | `PhysicsSystem.applyVelocities` | Integrates position from velocity on **all three axes**: `posX/Y/Z += velX/Y/Z * dt`. This is the *only* position integrator. |
+
+Because `PhysicsSystem` already integrates X/Z, gravity is restricted to the Y
+axis — applying it to X/Z would double-integrate those axes (the body would move
+twice and desync friction/clamp). See `gravityAxis` below.
+
+Y integration is **additive and safe**: `maxVelocity` and `worldBounds` clamps
+remain XZ-only, and collision detection stays 2D/XZ (a shrapnel body at altitude
+flies over ground units). Bodies with `velocityY = 0` — i.e. every pre-existing
+body — do not move on Y, so behavior is unchanged.
+
+### `useGravity` flag
+
+Per-body opt-in, set via `PhysicsBodyConfig.useGravity` (default `false`):
+
+```typescript
+new PhysicsBodyComponent(entity.id, {
+  radius: FP.FromFloat(0.2),
+  friction: FP._1,     // no XZ damping for a projectile
+  useGravity: true,    // GravitySystem will pull it down
+});
+```
+
+### `gravityAxis` — why only `'y'`
+
+`gravityAxis` defaults to `'y'` and **only `'y'` is supported in v1**.
+Constructing `GravitySystem` with `'x'` or `'z'` throws. Those axes are owned by
+`PhysicsSystem`'s position integrator; letting `GravitySystem` also drive them
+would double-integrate. `'x'`/`'z'` are reserved for a future version that would
+cede an axis from `PhysicsSystem`.
+
+### `applyImpulse3D`
+
+`applyImpulse()` sets only XZ velocity (backward-compatible). To launch a body
+with vertical velocity, use `applyImpulse3D(entityId, vx, vy, vz)` — it replaces
+all three velocity components and clears `ignorePhysics`.
+
+```typescript
+// Launch shrapnel up and out; GravitySystem arcs it back down.
+physicsWorld.applyImpulse3D(shrapnelId, FP.FromFloat(6), FP.FromFloat(8), FP.FromFloat(-3));
+```
+
+### System ordering
+
+Register **`GravitySystem` before `PhysicsSystem`** so the tick's acceleration is
+applied before that tick's integration (semi-implicit Euler):
+
+```typescript
+const { gravitySystem, physicsSystem, interpolationSystem } = physicsWorld.getSystems();
+world.registerSystems(
+  [movementSystem, gravitySystem, physicsSystem, /* landing systems… */],
+  [interpolationSystem, renderSystem],
+);
+```
+
+`getSystems()` remains backward-compatible: callers that destructure only
+`{ physicsSystem, interpolationSystem }` simply ignore `gravitySystem`.
+
+### Tick-resolution gravity vs. sub-stepped integration
+
+`GravitySystem` runs once per `GameWorld` tick, while `PhysicsSystem` sub-steps
+(e.g. 3×). Gravity is applied once per tick, then that same `velocityY` is
+integrated across every sub-step. The net ΔY per tick is `velocityY * tickDt`
+(semi-implicit Euler) — correct for gameplay. Sub-step-accurate gravity would
+require folding the acceleration into `PhysicsSystem.step()`'s loop (at which
+point it would no longer be a separate system); this is intentionally not done.
 
 ### `TransformComponent`
 
@@ -397,6 +483,7 @@ class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.definiti
   readonly friction: FixedPoint;
   readonly isStatic: boolean;
   ignorePhysics: boolean;        // get/set
+  useGravity: boolean;           // get/set — opt in to GravitySystem acceleration
 
   // Spatial-grid bookkeeping
   lastX: number;
@@ -409,6 +496,7 @@ interface PhysicsBodyConfig {
   isStatic?: boolean;            // default false
   restitution?: FixedPoint;      // default FP.FromFloat(0.5)
   friction?: FixedPoint;         // default FP._0
+  useGravity?: boolean;          // default false — opt in to GravitySystem acceleration
 }
 ```
 

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -133,11 +133,12 @@ export class PhysicsWorld {
   }
 
   /**
-   * Apply a full 3D velocity impulse to a body (replaces existing velocity on
-   * all three axes). Use for arcing ordnance that leaves the ground plane.
+   * Apply a 3D momentum impulse to a body (replaces existing velocity on all
+   * three axes). Velocity is `impulse / mass`. Use for arcing ordnance that
+   * leaves the ground plane.
    */
-  public applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void {
-    this.physicsSystem.applyImpulse3D(entityId, vx, vy, vz);
+  public applyImpulse3D(entityId: number, ix: FixedPoint, iy: FixedPoint, iz: FixedPoint): void {
+    this.physicsSystem.applyImpulse3D(entityId, ix, iy, iz);
   }
 
   /**

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -5,7 +5,8 @@ import { GravitySystem } from './systems/GravitySystem';
 import { InterpolationSystem } from './systems/InterpolationSystem';
 import type { InterpolatedTransformSample } from './systems/InterpolationSystem';
 import { SpatialHashGrid } from './collision/SpatialHashGrid';
-import { segmentVsAABB, type AABB3, type RayHit } from './collision/Raycast';
+import { segmentVsAABB } from './collision/Raycast';
+import type { RayHit, Vec3FP, AABB } from './collision/Raycast';
 import { PhysicsEvents } from './events';
 import type { PhysicsWorldConfig } from './PhysicsWorldConfig';
 import type { FixedPoint } from '@phalanx-engine/math';
@@ -156,42 +157,6 @@ export class PhysicsWorld {
     return unsub;
   }
 
-  /**
-   * WORKAROUND for 3D collision detection.
-   *
-   * Casts a swept segment `prev -> cur` against a list of static 3D AABBs
-   * (e.g. buildings / cover) and returns the nearest impact with its point
-   * and outward face normal, or `null` if none is hit.
-   *
-   * Use this for fast-moving ordnance (artillery shrapnel / shells / projectiles)
-   * to detect hits on static obstacles without a full 3D body-body collision
-   * system (planned v2). The 2D/XZ circle pipeline for unit-vs-unit collisions
-   * is unaffected. Pure query — no side effects, no state mutation.
-   *
-   * v1 limitation: linear scan over caller-supplied boxes (no broad-phase
-   * acceleration). Fine for tens of obstacles; optimise with a spatial grid
-   * when obstacle counts grow.
-   *
-   * @param prev   Segment start (previous tick position of the ordnance).
-   * @param cur    Segment end (current tick position of the ordnance).
-   * @param boxes  Static 3D AABBs to test against.
-   * @returns The nearest impact along the segment, or `null`.
-   */
-  public raycastSegment(
-    prev: { x: FixedPoint; y: FixedPoint; z: FixedPoint },
-    cur: { x: FixedPoint; y: FixedPoint; z: FixedPoint },
-    boxes: ReadonlyArray<AABB3>,
-  ): RayHit | null {
-    let best: RayHit | null = null;
-    for (const b of boxes) {
-      const hit = segmentVsAABB(prev, cur, b);
-      if (hit && (best === null || FP.Lt(hit.t, best.t))) {
-        best = hit;
-      }
-    }
-    return best;
-  }
-
   /** Direct access to the spatial grid for custom queries (e.g. range finding) */
   public get spatialGrid(): SpatialHashGrid {
     return this.physicsSystem.getSpatialGrid();
@@ -204,6 +169,33 @@ export class PhysicsWorld {
     entityId: number
   ): { x: FixedPoint; z: FixedPoint } | undefined {
     return this.physicsSystem.getEntityPosition(entityId);
+  }
+
+  /**
+   * Swept-segment (raycast) query against caller-supplied axis-aligned boxes,
+   * returning the nearest hit (smallest `t`) or `null` when nothing is hit.
+   *
+   * WORKAROUND FOR 3D COLLISIONS: the core physics pipeline is 2D/XZ, so it
+   * does not detect collisions on the Y axis. For 3D collisions — e.g. ordnance
+   * hitting a static obstacle like a building — use this swept-segment raycast
+   * query as a workaround until full 3D body-body collision is implemented
+   * (planned for v2). Pass a moving body's previous and current position to get
+   * the impact point and surface normal.
+   *
+   * v1 is a pure linear scan over the supplied boxes with no broad-phase
+   * acceleration; unit-vs-unit collisions remain 2D/XZ in `PhysicsSystem`.
+   *
+   * Pure query — no side effects.
+   */
+  public raycastSegment(prev: Vec3FP, cur: Vec3FP, boxes: ReadonlyArray<AABB>): RayHit | null {
+    let nearest: RayHit | null = null;
+    for (const box of boxes) {
+      const hit = segmentVsAABB(prev, cur, box);
+      if (hit && (nearest === null || FP.Lt(hit.t, nearest.t))) {
+        nearest = hit;
+      }
+    }
+    return nearest;
   }
 
   /**

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -1,6 +1,7 @@
 import { type EventBus } from '@phalanx-engine/ecs';
 import { FP } from '@phalanx-engine/math';
 import { PhysicsSystem } from './systems/PhysicsSystem';
+import { GravitySystem } from './systems/GravitySystem';
 import { InterpolationSystem } from './systems/InterpolationSystem';
 import type { InterpolatedTransformSample } from './systems/InterpolationSystem';
 import { SpatialHashGrid } from './collision/SpatialHashGrid';
@@ -18,6 +19,7 @@ import type { CollisionEvent, PhysicsConfig, BoundsExitEvent } from './types';
  */
 export class PhysicsWorld {
   private readonly physicsSystem: PhysicsSystem;
+  private readonly gravitySystem: GravitySystem;
   private readonly interpolationSystem: InterpolationSystem;
   private eventBusRef: EventBus | null = null;
   private readonly unsubscribers: (() => void)[] = [];
@@ -31,6 +33,8 @@ export class PhysicsWorld {
     const maxVelocity = config?.maxVelocity ?? FP.FromFloat(15.0);
     const pushStrength = config?.pushStrength ?? FP.FromFloat(15.0);
     const defaultFriction = config?.defaultFriction ?? FP.FromFloat(0.92);
+    const gravity = config?.gravity ?? FP._0;
+    const gravityAxis = config?.gravityAxis ?? 'y';
 
     const physicsConfig: PhysicsConfig = {
       tickDt,
@@ -43,9 +47,12 @@ export class PhysicsWorld {
       ejectOnBoundsExit: config?.ejectOnBoundsExit,
       collisionResponse: config?.collisionResponse,
       restitution: config?.restitution,
+      gravity,
+      gravityAxis,
     };
 
     this.physicsSystem = new PhysicsSystem(physicsConfig);
+    this.gravitySystem = new GravitySystem(gravity, gravityAxis, tickDt);
     this.interpolationSystem = new InterpolationSystem();
     this.settleThreshold = config?.settleThreshold;
 
@@ -59,10 +66,12 @@ export class PhysicsWorld {
    */
   public getSystems(): {
     physicsSystem: PhysicsSystem;
+    gravitySystem: GravitySystem;
     interpolationSystem: InterpolationSystem;
   } {
     return {
       physicsSystem: this.physicsSystem,
+      gravitySystem: this.gravitySystem,
       interpolationSystem: this.interpolationSystem,
     };
   }
@@ -119,6 +128,14 @@ export class PhysicsWorld {
   /** Apply a velocity impulse to a body ("flick" mechanic). Replaces existing velocity. */
   public applyImpulse(entityId: number, vx: FixedPoint, vz: FixedPoint): void {
     this.physicsSystem.applyImpulse(entityId, vx, vz);
+  }
+
+  /**
+   * Apply a full 3D velocity impulse to a body (replaces existing velocity on
+   * all three axes). Use for arcing ordnance that leaves the ground plane.
+   */
+  public applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void {
+    this.physicsSystem.applyImpulse3D(entityId, vx, vy, vz);
   }
 
   /**

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -5,6 +5,7 @@ import { GravitySystem } from './systems/GravitySystem';
 import { InterpolationSystem } from './systems/InterpolationSystem';
 import type { InterpolatedTransformSample } from './systems/InterpolationSystem';
 import { SpatialHashGrid } from './collision/SpatialHashGrid';
+import { segmentVsAABB, type AABB3, type RayHit } from './collision/Raycast';
 import { PhysicsEvents } from './events';
 import type { PhysicsWorldConfig } from './PhysicsWorldConfig';
 import type { FixedPoint } from '@phalanx-engine/math';
@@ -153,6 +154,42 @@ export class PhysicsWorld {
     const unsub = eb.on<BoundsExitEvent>(PhysicsEvents.BOUNDS_EXIT, callback);
     this.unsubscribers.push(unsub);
     return unsub;
+  }
+
+  /**
+   * WORKAROUND for 3D collision detection.
+   *
+   * Casts a swept segment `prev -> cur` against a list of static 3D AABBs
+   * (e.g. buildings / cover) and returns the nearest impact with its point
+   * and outward face normal, or `null` if none is hit.
+   *
+   * Use this for fast-moving ordnance (artillery shrapnel / shells / projectiles)
+   * to detect hits on static obstacles without a full 3D body-body collision
+   * system (planned v2). The 2D/XZ circle pipeline for unit-vs-unit collisions
+   * is unaffected. Pure query — no side effects, no state mutation.
+   *
+   * v1 limitation: linear scan over caller-supplied boxes (no broad-phase
+   * acceleration). Fine for tens of obstacles; optimise with a spatial grid
+   * when obstacle counts grow.
+   *
+   * @param prev   Segment start (previous tick position of the ordnance).
+   * @param cur    Segment end (current tick position of the ordnance).
+   * @param boxes  Static 3D AABBs to test against.
+   * @returns The nearest impact along the segment, or `null`.
+   */
+  public raycastSegment(
+    prev: { x: FixedPoint; y: FixedPoint; z: FixedPoint },
+    cur: { x: FixedPoint; y: FixedPoint; z: FixedPoint },
+    boxes: ReadonlyArray<AABB3>,
+  ): RayHit | null {
+    let best: RayHit | null = null;
+    for (const b of boxes) {
+      const hit = segmentVsAABB(prev, cur, b);
+      if (hit && (best === null || FP.Lt(hit.t, best.t))) {
+        best = hit;
+      }
+    }
+    return best;
   }
 
   /** Direct access to the spatial grid for custom queries (e.g. range finding) */

--- a/phalanx-physics/src/PhysicsWorldConfig.ts
+++ b/phalanx-physics/src/PhysicsWorldConfig.ts
@@ -60,4 +60,17 @@ export interface PhysicsWorldConfig {
    * Default: FP.FromFloat(0.01)
    */
   settleThreshold?: FixedPoint;
+
+  /**
+   * Gravitational acceleration magnitude applied by GravitySystem to bodies
+   * with `useGravity=true`. Default 0 = no gravity (GravitySystem is a no-op).
+   */
+  gravity?: FixedPoint;
+
+  /**
+   * Axis along which gravity acts. Default `'y'`. Only `'y'` is supported in
+   * v1 — `'x'`/`'z'` are reserved (PhysicsSystem owns those axes) and cause
+   * GravitySystem to throw.
+   */
+  gravityAxis?: 'x' | 'y' | 'z';
 }

--- a/phalanx-physics/src/collision/Raycast.ts
+++ b/phalanx-physics/src/collision/Raycast.ts
@@ -1,0 +1,168 @@
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+
+/** A 3D point / direction in fixed-point. Structurally compatible with `FPVector3`. */
+interface Vec3 {
+  x: FixedPoint;
+  y: FixedPoint;
+  z: FixedPoint;
+}
+
+/** Axis-aligned 3D bounding box in fixed-point. */
+export interface AABB3 {
+  minX: FixedPoint;
+  minY: FixedPoint;
+  minZ: FixedPoint;
+  maxX: FixedPoint;
+  maxY: FixedPoint;
+  maxZ: FixedPoint;
+}
+
+/**
+ * Result of a swept-segment (raycast) query against an AABB.
+ *
+ * - `t` — parametric position of the impact along the segment, in `[0, 1]`
+ *   (`0` at `prev`, `1` at `cur`).
+ * - `point` — the impact point in 3D space (`lerp(prev, cur, t)`).
+ * - `normal` — outward face normal of the box at the entry point (one of ±X/±Y/±Z).
+ */
+export interface RayHit {
+  t: FixedPoint;
+  point: Vec3;
+  normal: Vec3;
+}
+
+/**
+ * WORKAROUND for 3D collision detection.
+ *
+ * The physics engine's body-vs-body narrow phase is 2D/XZ only (circles on the
+ * ground plane). For 3D collision — e.g. a fast-moving ordnance (artillery
+ * shrapnel, shell, projectile) hitting a static obstacle such as a building —
+ * use this swept-segment query as a workaround until a full 3D body-body
+ * collision system is implemented (planned v2: `BoxColliderComponent` as ECS
+ * entities + grid-accelerated raycast + 3D sphere/box vs sphere/box resolution).
+ *
+ * Casts a segment `prev -> cur` against an axis-aligned 3D box and returns the
+ * first impact (`t`, `point`, outward `normal`), or `null` if the segment never
+ * enters the box. Using the swept segment (rather than point-in-box per tick)
+ * prevents tunneling: a fast shard cannot skip through a thin wall between ticks.
+ *
+ * Pure, deterministic, fixed-point only. Uses the slab method.
+ *
+ * @param prev  Segment start (previous tick position of the ordnance).
+ * @param cur   Segment end (current tick position of the ordnance).
+ * @param box   Axis-aligned 3D box to test against.
+ * @returns The nearest impact along the segment, or `null` if no intersection.
+ */
+export function segmentVsAABB(prev: Vec3, cur: Vec3, box: AABB3): RayHit | null {
+  const pPrev: readonly FixedPoint[] = [prev.x, prev.y, prev.z];
+  const pCur: readonly FixedPoint[] = [cur.x, cur.y, cur.z];
+  const pMin: readonly FixedPoint[] = [box.minX, box.minY, box.minZ];
+  const pMax: readonly FixedPoint[] = [box.maxX, box.maxY, box.maxZ];
+
+  // Segment starts inside the box -> impact at the start with the nearest face
+  // normal (covers both stationary points and moving segments that begin inside).
+  const startsInside =
+    FP.Gte(prev.x, box.minX) && FP.Lte(prev.x, box.maxX) &&
+    FP.Gte(prev.y, box.minY) && FP.Lte(prev.y, box.maxY) &&
+    FP.Gte(prev.z, box.minZ) && FP.Lte(prev.z, box.maxZ);
+  if (startsInside) {
+    return {
+      t: FP._0,
+      point: { x: prev.x, y: prev.y, z: prev.z },
+      normal: nearestFaceNormal(pPrev, pMin, pMax),
+    };
+  }
+
+  let tEnter: FixedPoint = FP._0;
+  let tExit: FixedPoint = FP._0;
+  let entrySet = false;
+  let exitSet = false;
+  let entryAxis = 0;
+  let entryFromMin = true;
+
+  for (let a = 0; a < 3; a++) {
+    const d = FP.Sub(pCur[a], pPrev[a]);
+
+    if (FP.Eq(d, FP._0)) {
+      // Segment is parallel to this slab. It lies within the slab for the
+      // whole [0,1] interval iff `prev` is inside [min, max] on this axis.
+      if (FP.Lt(pPrev[a], pMin[a]) || FP.Gt(pPrev[a], pMax[a])) {
+        return null;
+      }
+      continue; // no constraint on this axis
+    }
+
+    // Crossing times of the two slab planes.
+    let tMin = FP.Div(FP.Sub(pMin[a], pPrev[a]), d);
+    let tMax = FP.Div(FP.Sub(pMax[a], pPrev[a]), d);
+    // d > 0  -> enters through the min face (outward normal = -axis)
+    // d < 0  -> enters through the max face (outward normal = +axis)
+    const fromMin = FP.Gt(d, FP._0);
+    if (FP.Gt(tMin, tMax)) {
+      const tmp = tMin;
+      tMin = tMax;
+      tMax = tmp;
+    }
+
+    // Overall entry = max of per-axis entry times; exit = min of per-axis exits.
+    if (!entrySet || FP.Gt(tMin, tEnter)) {
+      tEnter = tMin;
+      entryAxis = a;
+      entryFromMin = fromMin;
+    }
+    if (!exitSet || FP.Lt(tMax, tExit)) {
+      tExit = tMax;
+    }
+    entrySet = true;
+    exitSet = true;
+  }
+
+  // No overlap of the per-axis intervals -> segment misses the box.
+  if (FP.Gt(tEnter, tExit)) return null;
+  // Box lies entirely before the segment start or beyond its end.
+  if (FP.Lt(tExit, FP._0)) return null;
+  if (FP.Gt(tEnter, FP._1)) return null;
+
+  const t = FP.Clamp(tEnter, FP._0, FP._1);
+  const point: Vec3 = {
+    x: FP.Lerp(prev.x, cur.x, t),
+    y: FP.Lerp(prev.y, cur.y, t),
+    z: FP.Lerp(prev.z, cur.z, t),
+  };
+  return { t, point, normal: axisNormal(entryAxis, entryFromMin) };
+}
+
+/** Outward unit normal for the entry face of a given axis. */
+function axisNormal(axis: number, fromMin: boolean): Vec3 {
+  const s = fromMin ? FP.Neg(FP._1) : FP._1;
+  if (axis === 0) return { x: s, y: FP._0, z: FP._0 };
+  if (axis === 1) return { x: FP._0, y: s, z: FP._0 };
+  return { x: FP._0, y: FP._0, z: s };
+}
+
+/** Outward normal of the box face nearest to a point (used when starting inside). */
+function nearestFaceNormal(
+  p: readonly FixedPoint[],
+  pMin: readonly FixedPoint[],
+  pMax: readonly FixedPoint[],
+): Vec3 {
+  let bestAxis = 0;
+  let bestFromMin = true;
+  let bestDist = FP.Sub(p[0], pMin[0]); // distance to minX face
+
+  for (let a = 0; a < 3; a++) {
+    const distMin = FP.Sub(p[a], pMin[a]); // to min face (>=0 inside)
+    const distMax = FP.Sub(pMax[a], p[a]); // to max face (>=0 inside)
+    if (FP.Lt(distMin, bestDist)) {
+      bestDist = distMin;
+      bestAxis = a;
+      bestFromMin = true;
+    }
+    if (FP.Lt(distMax, bestDist)) {
+      bestDist = distMax;
+      bestAxis = a;
+      bestFromMin = false;
+    }
+  }
+  return axisNormal(bestAxis, bestFromMin);
+}

--- a/phalanx-physics/src/collision/Raycast.ts
+++ b/phalanx-physics/src/collision/Raycast.ts
@@ -1,14 +1,18 @@
 import { FP, type FixedPoint } from '@phalanx-engine/math';
 
-/** A 3D point / direction in fixed-point. Structurally compatible with `FPVector3`. */
-interface Vec3 {
+/**
+ * Fixed-point 3D point/vector used by the raycast query.
+ */
+export interface Vec3FP {
   x: FixedPoint;
   y: FixedPoint;
   z: FixedPoint;
 }
 
-/** Axis-aligned 3D bounding box in fixed-point. */
-export interface AABB3 {
+/**
+ * Axis-aligned bounding box in fixed-point world space.
+ */
+export interface AABB {
   minX: FixedPoint;
   minY: FixedPoint;
   minZ: FixedPoint;
@@ -18,151 +22,128 @@ export interface AABB3 {
 }
 
 /**
- * Result of a swept-segment (raycast) query against an AABB.
- *
- * - `t` — parametric position of the impact along the segment, in `[0, 1]`
- *   (`0` at `prev`, `1` at `cur`).
- * - `point` — the impact point in 3D space (`lerp(prev, cur, t)`).
- * - `normal` — outward face normal of the box at the entry point (one of ±X/±Y/±Z).
+ * Result of a swept-segment vs AABB query.
  */
 export interface RayHit {
+  /** Parametric hit distance along the segment, `t ∈ [0, 1]` (0 at `prev`, 1 at `cur`). */
   t: FixedPoint;
-  point: Vec3;
-  normal: Vec3;
+  /** World-space hit point, equal to `lerp(prev, cur, t)`. */
+  point: Vec3FP;
+  /** Outward unit normal of the entry face (one of ±X/±Y/±Z). */
+  normal: Vec3FP;
 }
 
 /**
- * WORKAROUND for 3D collision detection.
+ * Swept-segment (raycast) vs axis-aligned box, using the deterministic slab
+ * method entirely in `FP.*` fixed-point arithmetic.
  *
- * The physics engine's body-vs-body narrow phase is 2D/XZ only (circles on the
- * ground plane). For 3D collision — e.g. a fast-moving ordnance (artillery
- * shrapnel, shell, projectile) hitting a static obstacle such as a building —
- * use this swept-segment query as a workaround until a full 3D body-body
- * collision system is implemented (planned v2: `BoxColliderComponent` as ECS
- * entities + grid-accelerated raycast + 3D sphere/box vs sphere/box resolution).
+ * WORKAROUND FOR 3D COLLISIONS: the core physics pipeline is 2D/XZ
+ * (circle-vs-circle) and does not detect collisions on the Y axis. For 3D
+ * collisions — e.g. ordnance hitting a static obstacle like a building — use
+ * this swept-segment raycast query as a workaround until full 3D body-body
+ * collision is implemented (planned for v2). Call it with a moving body's
+ * previous and current position to get the impact point and surface normal
+ * against caller-supplied static boxes.
  *
- * Casts a segment `prev -> cur` against an axis-aligned 3D box and returns the
- * first impact (`t`, `point`, outward `normal`), or `null` if the segment never
- * enters the box. Using the swept segment (rather than point-in-box per tick)
- * prevents tunneling: a fast shard cannot skip through a thin wall between ticks.
+ * Conventions:
+ * - `t ∈ [0, 1]`: 0 at `prev`, 1 at `cur`; `point = lerp(prev, cur, t)`.
+ * - `normal` is the OUTWARD normal of the face the segment enters through.
+ *   Entering the min-X face while moving +X yields `(-1, 0, 0)`, etc.
+ * - Segment starting inside the box → hit at `t = 0`, `point = prev`, and
+ *   `normal` = the outward normal of the nearest face.
+ * - Zero-length segment: outside the box → `null`; inside → `t = 0`.
+ * - Axes parallel to a slab are handled without dividing by zero (guarded by an
+ *   explicit `FP.Eq(delta, 0)` check — `FP.Div` throws on divide-by-zero).
  *
- * Pure, deterministic, fixed-point only. Uses the slab method.
- *
- * @param prev  Segment start (previous tick position of the ordnance).
- * @param cur   Segment end (current tick position of the ordnance).
- * @param box   Axis-aligned 3D box to test against.
- * @returns The nearest impact along the segment, or `null` if no intersection.
+ * @returns the entry hit, or `null` when the segment never intersects the box.
  */
-export function segmentVsAABB(prev: Vec3, cur: Vec3, box: AABB3): RayHit | null {
-  const pPrev: readonly FixedPoint[] = [prev.x, prev.y, prev.z];
-  const pCur: readonly FixedPoint[] = [cur.x, cur.y, cur.z];
-  const pMin: readonly FixedPoint[] = [box.minX, box.minY, box.minZ];
-  const pMax: readonly FixedPoint[] = [box.maxX, box.maxY, box.maxZ];
+export function segmentVsAABB(prev: Vec3FP, cur: Vec3FP, box: AABB): RayHit | null {
+  const dx = FP.Sub(cur.x, prev.x);
+  const dy = FP.Sub(cur.y, prev.y);
+  const dz = FP.Sub(cur.z, prev.z);
 
-  // Segment starts inside the box -> impact at the start with the nearest face
-  // normal (covers both stationary points and moving segments that begin inside).
-  const startsInside =
-    FP.Gte(prev.x, box.minX) && FP.Lte(prev.x, box.maxX) &&
-    FP.Gte(prev.y, box.minY) && FP.Lte(prev.y, box.maxY) &&
-    FP.Gte(prev.z, box.minZ) && FP.Lte(prev.z, box.maxZ);
-  if (startsInside) {
-    return {
-      t: FP._0,
-      point: { x: prev.x, y: prev.y, z: prev.z },
-      normal: nearestFaceNormal(pPrev, pMin, pMax),
-    };
-  }
+  // Clip the parameter range [0, 1] against each slab (Liang-Barsky style).
+  let tEnter = FP._0;
+  let tExit = FP._1;
 
-  let tEnter: FixedPoint = FP._0;
-  let tExit: FixedPoint = FP._0;
-  let entrySet = false;
-  let exitSet = false;
-  let entryAxis = 0;
-  let entryFromMin = true;
+  // Outward normal of the entry face; stays null while the entry is still at
+  // t = 0 (which means the segment started inside the box).
+  let entryNormal: Vec3FP | null = null;
 
-  for (let a = 0; a < 3; a++) {
-    const d = FP.Sub(pCur[a], pPrev[a]);
-
+  const clip = (
+    p: FixedPoint,
+    d: FixedPoint,
+    lo: FixedPoint,
+    hi: FixedPoint,
+    negNormal: Vec3FP,
+    posNormal: Vec3FP,
+  ): boolean => {
     if (FP.Eq(d, FP._0)) {
-      // Segment is parallel to this slab. It lies within the slab for the
-      // whole [0,1] interval iff `prev` is inside [min, max] on this axis.
-      if (FP.Lt(pPrev[a], pMin[a]) || FP.Gt(pPrev[a], pMax[a])) {
-        return null;
-      }
-      continue; // no constraint on this axis
+      // Parallel to this slab: only possible to hit if the origin is inside it.
+      return !(FP.Lt(p, lo) || FP.Gt(p, hi));
     }
-
-    // Crossing times of the two slab planes.
-    let tMin = FP.Div(FP.Sub(pMin[a], pPrev[a]), d);
-    let tMax = FP.Div(FP.Sub(pMax[a], pPrev[a]), d);
-    // d > 0  -> enters through the min face (outward normal = -axis)
-    // d < 0  -> enters through the max face (outward normal = +axis)
-    const fromMin = FP.Gt(d, FP._0);
-    if (FP.Gt(tMin, tMax)) {
-      const tmp = tMin;
-      tMin = tMax;
-      tMax = tmp;
+    const t1 = FP.Div(FP.Sub(lo, p), d);
+    const t2 = FP.Div(FP.Sub(hi, p), d);
+    const tNear = FP.Min(t1, t2);
+    const tFar = FP.Max(t1, t2);
+    // Moving in +axis enters through the min face (outward normal -axis);
+    // moving in -axis enters through the max face (outward normal +axis).
+    const nearNormal = FP.Gt(d, FP._0) ? negNormal : posNormal;
+    if (FP.Gt(tNear, tEnter)) {
+      tEnter = tNear;
+      entryNormal = nearNormal;
     }
-
-    // Overall entry = max of per-axis entry times; exit = min of per-axis exits.
-    if (!entrySet || FP.Gt(tMin, tEnter)) {
-      tEnter = tMin;
-      entryAxis = a;
-      entryFromMin = fromMin;
+    if (FP.Lt(tFar, tExit)) {
+      tExit = tFar;
     }
-    if (!exitSet || FP.Lt(tMax, tExit)) {
-      tExit = tMax;
-    }
-    entrySet = true;
-    exitSet = true;
-  }
-
-  // No overlap of the per-axis intervals -> segment misses the box.
-  if (FP.Gt(tEnter, tExit)) return null;
-  // Box lies entirely before the segment start or beyond its end.
-  if (FP.Lt(tExit, FP._0)) return null;
-  if (FP.Gt(tEnter, FP._1)) return null;
-
-  const t = FP.Clamp(tEnter, FP._0, FP._1);
-  const point: Vec3 = {
-    x: FP.Lerp(prev.x, cur.x, t),
-    y: FP.Lerp(prev.y, cur.y, t),
-    z: FP.Lerp(prev.z, cur.z, t),
+    return !FP.Gt(tEnter, tExit);
   };
-  return { t, point, normal: axisNormal(entryAxis, entryFromMin) };
-}
 
-/** Outward unit normal for the entry face of a given axis. */
-function axisNormal(axis: number, fromMin: boolean): Vec3 {
-  const s = fromMin ? FP.Neg(FP._1) : FP._1;
-  if (axis === 0) return { x: s, y: FP._0, z: FP._0 };
-  if (axis === 1) return { x: FP._0, y: s, z: FP._0 };
-  return { x: FP._0, y: FP._0, z: s };
-}
+  if (!clip(prev.x, dx, box.minX, box.maxX, NEG_X, POS_X)) return null;
+  if (!clip(prev.y, dy, box.minY, box.maxY, NEG_Y, POS_Y)) return null;
+  if (!clip(prev.z, dz, box.minZ, box.maxZ, NEG_Z, POS_Z)) return null;
 
-/** Outward normal of the box face nearest to a point (used when starting inside). */
-function nearestFaceNormal(
-  p: readonly FixedPoint[],
-  pMin: readonly FixedPoint[],
-  pMax: readonly FixedPoint[],
-): Vec3 {
-  let bestAxis = 0;
-  let bestFromMin = true;
-  let bestDist = FP.Sub(p[0], pMin[0]); // distance to minX face
-
-  for (let a = 0; a < 3; a++) {
-    const distMin = FP.Sub(p[a], pMin[a]); // to min face (>=0 inside)
-    const distMax = FP.Sub(pMax[a], p[a]); // to max face (>=0 inside)
-    if (FP.Lt(distMin, bestDist)) {
-      bestDist = distMin;
-      bestAxis = a;
-      bestFromMin = true;
-    }
-    if (FP.Lt(distMax, bestDist)) {
-      bestDist = distMax;
-      bestAxis = a;
-      bestFromMin = false;
-    }
+  // Entry never advanced past t = 0 → the segment started inside the box.
+  if (entryNormal === null) {
+    return { t: FP._0, point: { x: prev.x, y: prev.y, z: prev.z }, normal: nearestFaceNormal(prev, box) };
   }
-  return axisNormal(bestAxis, bestFromMin);
+
+  const t = tEnter;
+  return {
+    t,
+    point: {
+      x: FP.Lerp(prev.x, cur.x, t),
+      y: FP.Lerp(prev.y, cur.y, t),
+      z: FP.Lerp(prev.z, cur.z, t),
+    },
+    normal: entryNormal,
+  };
 }
+
+/** Outward normal of the box face nearest to an interior point. */
+function nearestFaceNormal(p: Vec3FP, box: AABB): Vec3FP {
+  let best = FP.Sub(p.x, box.minX);
+  let normal = NEG_X;
+
+  const consider = (dist: FixedPoint, faceNormal: Vec3FP): void => {
+    if (FP.Lt(dist, best)) {
+      best = dist;
+      normal = faceNormal;
+    }
+  };
+
+  consider(FP.Sub(box.maxX, p.x), POS_X);
+  consider(FP.Sub(p.y, box.minY), NEG_Y);
+  consider(FP.Sub(box.maxY, p.y), POS_Y);
+  consider(FP.Sub(p.z, box.minZ), NEG_Z);
+  consider(FP.Sub(box.maxZ, p.z), POS_Z);
+
+  return normal;
+}
+
+const NEG_X: Vec3FP = { x: FP.Neg(FP._1), y: FP._0, z: FP._0 };
+const POS_X: Vec3FP = { x: FP._1, y: FP._0, z: FP._0 };
+const NEG_Y: Vec3FP = { x: FP._0, y: FP.Neg(FP._1), z: FP._0 };
+const POS_Y: Vec3FP = { x: FP._0, y: FP._1, z: FP._0 };
+const NEG_Z: Vec3FP = { x: FP._0, y: FP._0, z: FP.Neg(FP._1) };
+const POS_Z: Vec3FP = { x: FP._0, y: FP._0, z: FP._1 };

--- a/phalanx-physics/src/collision/index.ts
+++ b/phalanx-physics/src/collision/index.ts
@@ -2,4 +2,4 @@ export type { CollisionManifold } from './CollisionManifold';
 export { SpatialHashGrid } from './SpatialHashGrid';
 export { NarrowPhase } from './NarrowPhase';
 export { segmentVsAABB } from './Raycast';
-export type { AABB3, RayHit } from './Raycast';
+export type { RayHit, Vec3FP, AABB } from './Raycast';

--- a/phalanx-physics/src/collision/index.ts
+++ b/phalanx-physics/src/collision/index.ts
@@ -1,3 +1,5 @@
 export type { CollisionManifold } from './CollisionManifold';
 export { SpatialHashGrid } from './SpatialHashGrid';
 export { NarrowPhase } from './NarrowPhase';
+export { segmentVsAABB } from './Raycast';
+export type { AABB3, RayHit } from './Raycast';

--- a/phalanx-physics/src/components/PhysicsBodyComponent.ts
+++ b/phalanx-physics/src/components/PhysicsBodyComponent.ts
@@ -18,6 +18,7 @@ export const PhysicsSoASchema = defineSoASchema({
   friction: 'i64',
   isStatic: 'u8',
   ignorePhysics: 'u8',
+  useGravity: 'u8',
   lastX: 'f64',
   lastZ: 'f64',
 }, 'PhysicsBody');
@@ -54,6 +55,7 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
     const restitution = config.restitution ?? FP.FromFloat(0.5);
     const friction = config.friction ?? FP._0;
     const isStatic = config.isStatic ?? false;
+    const useGravity = config.useGravity ?? false;
 
     super(PhysicsSoASchema, entityId, {
       velocityX: FP.ToRaw(FP._0),
@@ -65,6 +67,7 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
       friction: FP.ToRaw(friction),
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
+      useGravity: useGravity ? 1 : 0,
       lastX: 0,
       lastZ: 0,
     });
@@ -181,6 +184,20 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
     const idx = this.getIndex();
     if (idx === -1) return;
     this.store.arrays.ignorePhysics[idx] = value ? 1 : 0;
+  }
+
+  // ============ Gravity Flag ============
+
+  public get useGravity(): boolean {
+    const idx = this.getIndex();
+    if (idx === -1) return false;
+    return this.store.arrays.useGravity[idx] === 1;
+  }
+
+  public set useGravity(value: boolean) {
+    const idx = this.getIndex();
+    if (idx === -1) return;
+    this.store.arrays.useGravity[idx] = value ? 1 : 0;
   }
 
   // ============ Cached Position (for spatial grid) ============

--- a/phalanx-physics/src/components/PhysicsBodyComponent.ts
+++ b/phalanx-physics/src/components/PhysicsBodyComponent.ts
@@ -19,6 +19,7 @@ export const PhysicsSoASchema = defineSoASchema({
   isStatic: 'u8',
   ignorePhysics: 'u8',
   useGravity: 'u8',
+  gravityMultiplier: 'i64',
   lastX: 'f64',
   lastZ: 'f64',
 }, 'PhysicsBody');
@@ -56,6 +57,7 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
     const friction = config.friction ?? FP._0;
     const isStatic = config.isStatic ?? false;
     const useGravity = config.useGravity ?? false;
+    const gravityMultiplier = config.gravityMultiplier ?? FP._1;
 
     super(PhysicsSoASchema, entityId, {
       velocityX: FP.ToRaw(FP._0),
@@ -68,6 +70,7 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
       useGravity: useGravity ? 1 : 0,
+      gravityMultiplier: FP.ToRaw(gravityMultiplier),
       lastX: 0,
       lastZ: 0,
     });
@@ -198,6 +201,20 @@ export class PhysicsBodyComponent extends SoAComponent<typeof PhysicsSoASchema.d
     const idx = this.getIndex();
     if (idx === -1) return;
     this.store.arrays.useGravity[idx] = value ? 1 : 0;
+  }
+
+  // ============ Gravity Multiplier ============
+
+  public get gravityMultiplier(): FixedPoint {
+    const idx = this.getIndex();
+    if (idx === -1) return FP._1;
+    return FP.FromRaw(this.store.arrays.gravityMultiplier[idx]);
+  }
+
+  public set gravityMultiplier(value: FixedPoint) {
+    const idx = this.getIndex();
+    if (idx === -1) return;
+    this.store.arrays.gravityMultiplier[idx] = FP.ToRaw(value);
   }
 
   // ============ Cached Position (for spatial grid) ============

--- a/phalanx-physics/src/index.ts
+++ b/phalanx-physics/src/index.ts
@@ -15,6 +15,8 @@ export type { PhysicsBodyConfig } from './types';
 export { SpatialHashGrid } from './collision/SpatialHashGrid';
 export { NarrowPhase } from './collision/NarrowPhase';
 export type { CollisionManifold } from './collision/CollisionManifold';
+export { segmentVsAABB } from './collision/Raycast';
+export type { AABB3, RayHit } from './collision/Raycast';
 
 // Systems
 export { PhysicsSystem, GravitySystem, InterpolationSystem } from './systems';

--- a/phalanx-physics/src/index.ts
+++ b/phalanx-physics/src/index.ts
@@ -17,7 +17,7 @@ export { NarrowPhase } from './collision/NarrowPhase';
 export type { CollisionManifold } from './collision/CollisionManifold';
 
 // Systems
-export { PhysicsSystem, InterpolationSystem } from './systems';
+export { PhysicsSystem, GravitySystem, InterpolationSystem } from './systems';
 export type { InterpolatedTransformSample } from './systems';
 
 // Facade

--- a/phalanx-physics/src/index.ts
+++ b/phalanx-physics/src/index.ts
@@ -16,7 +16,7 @@ export { SpatialHashGrid } from './collision/SpatialHashGrid';
 export { NarrowPhase } from './collision/NarrowPhase';
 export type { CollisionManifold } from './collision/CollisionManifold';
 export { segmentVsAABB } from './collision/Raycast';
-export type { AABB3, RayHit } from './collision/Raycast';
+export type { RayHit, Vec3FP, AABB } from './collision/Raycast';
 
 // Systems
 export { PhysicsSystem, GravitySystem, InterpolationSystem } from './systems';

--- a/phalanx-physics/src/systems/GravitySystem.ts
+++ b/phalanx-physics/src/systems/GravitySystem.ts
@@ -56,14 +56,15 @@ export class GravitySystem extends GameSystem {
     const physVelocityY = this.physicsStore.arrays.velocityY;
     const physUseGravity = this.physicsStore.arrays.useGravity;
     const physIsStatic = this.physicsStore.arrays.isStatic;
+    const physIgnorePhysics = this.physicsStore.arrays.ignorePhysics;
 
     for (const entityId of this.physicsStore.entityIds()) {
       const physIndex = this.physicsStore.indexOf(entityId);
       if (physUseGravity[physIndex] !== 1) continue;
+      if (physIgnorePhysics[physIndex] === 1) continue;
       // Static bodies never integrate position, so accumulating velocity on
       // them is dead state — skip so static+useGravity is a clean no-op.
       if (physIsStatic[physIndex] === 1) continue;
-
       // velocityY -= gravity * tickDt
       const velY = FP.FromRaw(physVelocityY[physIndex]);
       physVelocityY[physIndex] = FP.ToRaw(FP.Sub(velY, delta));

--- a/phalanx-physics/src/systems/GravitySystem.ts
+++ b/phalanx-physics/src/systems/GravitySystem.ts
@@ -1,0 +1,76 @@
+import { GameSystem, type SoAComponentStore, type SystemContext } from '@phalanx-engine/ecs';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import { PhysicsSoASchema } from '../components/PhysicsBodyComponent';
+
+/**
+ * GravitySystem — applies gravitational ACCELERATION to velocity.
+ *
+ * On each tick, for every body with `useGravity=true`, it decays the velocity
+ * along the configured axis: `velocityY -= gravity * tickDt` (for the default
+ * `gravityAxis='y'`). It NEVER writes position — position integration is owned
+ * exclusively by PhysicsSystem.applyVelocities (which integrates X/Y/Z). This
+ * "one owner per axis" rule avoids double-integration.
+ *
+ * Ordering: register GravitySystem BEFORE PhysicsSystem so the acceleration is
+ * applied before that tick's position integration (semi-implicit Euler).
+ *
+ * When `gravity` is 0 (default), the system is a no-op.
+ *
+ * v1 supports only `gravityAxis='y'`. X/Z are integrated by PhysicsSystem, so
+ * applying gravity there would double-integrate that axis; `'x'`/`'z'` are
+ * reserved and rejected at construction.
+ */
+export class GravitySystem extends GameSystem {
+  private physicsStore!: SoAComponentStore<typeof PhysicsSoASchema.definition>;
+  private readonly gravity: FixedPoint;
+  private readonly gravityAxis: 'x' | 'y' | 'z';
+  private readonly tickDt: FixedPoint;
+
+  constructor(gravity: FixedPoint, gravityAxis: 'x' | 'y' | 'z', tickDt: FixedPoint) {
+    super();
+    // TODO(v2): supporting 'x'/'z' would require PhysicsSystem to cede
+    // integration of that axis to GravitySystem to avoid double-integration.
+    if (gravityAxis !== 'y') {
+      throw new Error(
+        `GravitySystem: gravityAxis='${gravityAxis}' is not supported in v1. ` +
+          `Only 'y' is supported — X/Z are owned by PhysicsSystem's position integrator.`,
+      );
+    }
+    this.gravity = gravity;
+    this.gravityAxis = gravityAxis;
+    this.tickDt = tickDt;
+  }
+
+  public override init(context: SystemContext): void {
+    super.init(context);
+    this.physicsStore = this.entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+  }
+
+  public override processTick(_tick: number): void {
+    // No gravity configured → nothing to do.
+    if (FP.Eq(this.gravity, FP._0)) return;
+
+    const delta = FP.Mul(this.gravity, this.tickDt);
+    const physVelocityY = this.physicsStore.arrays.velocityY;
+    const physUseGravity = this.physicsStore.arrays.useGravity;
+
+    for (const entityId of this.physicsStore.entityIds()) {
+      const physIndex = this.physicsStore.indexOf(entityId);
+      if (physUseGravity[physIndex] !== 1) continue;
+
+      // velocityY -= gravity * tickDt
+      const velY = FP.FromRaw(physVelocityY[physIndex]);
+      physVelocityY[physIndex] = FP.ToRaw(FP.Sub(velY, delta));
+    }
+  }
+
+  /** Configured gravity magnitude (0 = disabled). */
+  public getGravity(): FixedPoint {
+    return this.gravity;
+  }
+
+  /** Configured gravity axis (v1: always `'y'`). */
+  public getGravityAxis(): 'x' | 'y' | 'z' {
+    return this.gravityAxis;
+  }
+}

--- a/phalanx-physics/src/systems/GravitySystem.ts
+++ b/phalanx-physics/src/systems/GravitySystem.ts
@@ -14,7 +14,9 @@ import { PhysicsSoASchema } from '../components/PhysicsBodyComponent';
  * Ordering: register GravitySystem BEFORE PhysicsSystem so the acceleration is
  * applied before that tick's position integration (semi-implicit Euler).
  *
- * When `gravity` is 0 (default), the system is a no-op.
+ * When `gravity` is 0 (default), the system is a no-op. Static bodies are
+ * skipped (they never integrate position, so accumulating velocity on them
+ * would be dead state) — static+useGravity is therefore a clean no-op.
  *
  * v1 supports only `gravityAxis='y'`. X/Z are integrated by PhysicsSystem, so
  * applying gravity there would double-integrate that axis; `'x'`/`'z'` are
@@ -53,10 +55,14 @@ export class GravitySystem extends GameSystem {
     const delta = FP.Mul(this.gravity, this.tickDt);
     const physVelocityY = this.physicsStore.arrays.velocityY;
     const physUseGravity = this.physicsStore.arrays.useGravity;
+    const physIsStatic = this.physicsStore.arrays.isStatic;
 
     for (const entityId of this.physicsStore.entityIds()) {
       const physIndex = this.physicsStore.indexOf(entityId);
       if (physUseGravity[physIndex] !== 1) continue;
+      // Static bodies never integrate position, so accumulating velocity on
+      // them is dead state — skip so static+useGravity is a clean no-op.
+      if (physIsStatic[physIndex] === 1) continue;
 
       // velocityY -= gravity * tickDt
       const velY = FP.FromRaw(physVelocityY[physIndex]);

--- a/phalanx-physics/src/systems/GravitySystem.ts
+++ b/phalanx-physics/src/systems/GravitySystem.ts
@@ -55,6 +55,7 @@ export class GravitySystem extends GameSystem {
     const delta = FP.Mul(this.gravity, this.tickDt);
     const physVelocityY = this.physicsStore.arrays.velocityY;
     const physUseGravity = this.physicsStore.arrays.useGravity;
+    const physGravityMultiplier = this.physicsStore.arrays.gravityMultiplier;
     const physIsStatic = this.physicsStore.arrays.isStatic;
     const physIgnorePhysics = this.physicsStore.arrays.ignorePhysics;
 
@@ -65,9 +66,10 @@ export class GravitySystem extends GameSystem {
       // Static bodies never integrate position, so accumulating velocity on
       // them is dead state — skip so static+useGravity is a clean no-op.
       if (physIsStatic[physIndex] === 1) continue;
-      // velocityY -= gravity * tickDt
+      const multiplier = FP.FromRaw(physGravityMultiplier[physIndex]);
+      // velocityY -= gravity * tickDt * gravityMultiplier
       const velY = FP.FromRaw(physVelocityY[physIndex]);
-      physVelocityY[physIndex] = FP.ToRaw(FP.Sub(velY, delta));
+      physVelocityY[physIndex] = FP.ToRaw(FP.Sub(velY, FP.Mul(delta, multiplier)));
     }
   }
 

--- a/phalanx-physics/src/systems/PhysicsSystem.ts
+++ b/phalanx-physics/src/systems/PhysicsSystem.ts
@@ -112,6 +112,27 @@ export class PhysicsSystem extends GameSystem {
   }
 
   /**
+   * Set the full 3D velocity of a physics body ("flick" impulse in 3D).
+   * Replaces any existing velocity on all three axes. Mirrors applyImpulse but
+   * also sets velocityY — used for arcing ordnance (e.g. artillery shrapnel)
+   * that leaves the ground plane. The Y component is integrated by
+   * applyVelocities and decayed by GravitySystem when `useGravity=true`.
+   *
+   * @param entityId  Target entity
+   * @param vx        New velocity along X axis (FixedPoint)
+   * @param vy        New velocity along Y axis (FixedPoint)
+   * @param vz        New velocity along Z axis (FixedPoint)
+   */
+  public applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void {
+    const physIndex = this.physicsStore.indexOf(entityId);
+    if (physIndex === -1) return;
+    this.physicsStore.arrays.ignorePhysics[physIndex] = 0; // re-enable if previously ejected
+    this.physicsStore.arrays.velocityX[physIndex] = FP.ToRaw(vx);
+    this.physicsStore.arrays.velocityY[physIndex] = FP.ToRaw(vy);
+    this.physicsStore.arrays.velocityZ[physIndex] = FP.ToRaw(vz);
+  }
+
+  /**
    * Returns true when all non-static, non-ignored bodies have velocity magnitude
    * below the given threshold.
    *
@@ -144,11 +165,13 @@ export class PhysicsSystem extends GameSystem {
    */
   private applyVelocities(dt: FixedPoint): void {
     const physVelocityX = this.physicsStore.arrays.velocityX;
+    const physVelocityY = this.physicsStore.arrays.velocityY;
     const physVelocityZ = this.physicsStore.arrays.velocityZ;
     const physIsStatic = this.physicsStore.arrays.isStatic;
     const physIgnorePhysics = this.physicsStore.arrays.ignorePhysics;
 
     const fpPosXArr = this.transformStore.arrays.fpPositionX;
+    const fpPosYArr = this.transformStore.arrays.fpPositionY;
     const fpPosZArr = this.transformStore.arrays.fpPositionZ;
 
     const maxVelSq = FP.Mul(this.config.maxVelocity, this.config.maxVelocity);
@@ -209,6 +232,14 @@ export class PhysicsSystem extends GameSystem {
 
       fpPosXArr[transformIndex] = FP.ToRaw(newPosX);
       fpPosZArr[transformIndex] = FP.ToRaw(newPosZ);
+
+      // Integrate Y independently: pos.y += vel.y * dt. No maxVelocity or
+      // worldBounds clamp on Y (those remain XZ-only), and Y does not affect
+      // collision detection. Additive/safe: bodies with velocityY=0 (all
+      // existing bodies) do not move on Y.
+      const velY = FP.FromRaw(physVelocityY[physIndex]);
+      const posY = FP.FromRaw(fpPosYArr[transformIndex]);
+      fpPosYArr[transformIndex] = FP.ToRaw(FP.Add(posY, FP.Mul(velY, dt)));
     }
 
     // Emit buffered BOUNDS_EXIT events after iteration completes

--- a/phalanx-physics/src/systems/PhysicsSystem.ts
+++ b/phalanx-physics/src/systems/PhysicsSystem.ts
@@ -134,7 +134,8 @@ export class PhysicsSystem extends GameSystem {
 
   /**
    * Returns true when all non-static, non-ignored bodies have velocity magnitude
-   * below the given threshold.
+   * below the given threshold. Considers the full 3D velocity (X, Y, Z), so a
+   * body moving only on Y (e.g. falling shrapnel) is correctly not settled.
    *
    * This is a pure query with no side effects. Game code is responsible for
    * interpreting what "settled" means in gameplay terms.
@@ -145,6 +146,7 @@ export class PhysicsSystem extends GameSystem {
     const thresh = threshold ?? FP.FromFloat(0.01);
     const threshSq = FP.Mul(thresh, thresh);
     const velX = this.physicsStore.arrays.velocityX;
+    const velY = this.physicsStore.arrays.velocityY;
     const velZ = this.physicsStore.arrays.velocityZ;
     const isStatic = this.physicsStore.arrays.isStatic;
     const ignore = this.physicsStore.arrays.ignorePhysics;
@@ -153,8 +155,10 @@ export class PhysicsSystem extends GameSystem {
       const i = this.physicsStore.indexOf(entityId);
       if (isStatic[i] === 1 || ignore[i] === 1) continue;
       const vx = FP.FromRaw(velX[i]);
+      const vy = FP.FromRaw(velY[i]);
       const vz = FP.FromRaw(velZ[i]);
-      if (FP.Gt(FP.Add(FP.Mul(vx, vx), FP.Mul(vz, vz)), threshSq)) return false;
+      const velMagSq = FP.Add(FP.Add(FP.Mul(vx, vx), FP.Mul(vy, vy)), FP.Mul(vz, vz));
+      if (FP.Gt(velMagSq, threshSq)) return false;
     }
     return true;
   }

--- a/phalanx-physics/src/systems/PhysicsSystem.ts
+++ b/phalanx-physics/src/systems/PhysicsSystem.ts
@@ -112,24 +112,24 @@ export class PhysicsSystem extends GameSystem {
   }
 
   /**
-   * Set the full 3D velocity of a physics body ("flick" impulse in 3D).
-   * Replaces any existing velocity on all three axes. Mirrors applyImpulse but
-   * also sets velocityY — used for arcing ordnance (e.g. artillery shrapnel)
-   * that leaves the ground plane. The Y component is integrated by
-   * applyVelocities and decayed by GravitySystem when `useGravity=true`.
+   * Apply a 3D momentum impulse to a physics body. Replaces any existing
+   * velocity on all three axes. Velocity is `impulse / mass`; bodies with
+   * mass <= 0 are treated as immovable (no velocity change).
    *
    * @param entityId  Target entity
-   * @param vx        New velocity along X axis (FixedPoint)
-   * @param vy        New velocity along Y axis (FixedPoint)
-   * @param vz        New velocity along Z axis (FixedPoint)
+   * @param ix        Impulse along X axis (FixedPoint)
+   * @param iy        Impulse along Y axis (FixedPoint)
+   * @param iz        Impulse along Z axis (FixedPoint)
    */
-  public applyImpulse3D(entityId: number, vx: FixedPoint, vy: FixedPoint, vz: FixedPoint): void {
+  public applyImpulse3D(entityId: number, ix: FixedPoint, iy: FixedPoint, iz: FixedPoint): void {
     const physIndex = this.physicsStore.indexOf(entityId);
     if (physIndex === -1) return;
     this.physicsStore.arrays.ignorePhysics[physIndex] = 0; // re-enable if previously ejected
-    this.physicsStore.arrays.velocityX[physIndex] = FP.ToRaw(vx);
-    this.physicsStore.arrays.velocityY[physIndex] = FP.ToRaw(vy);
-    this.physicsStore.arrays.velocityZ[physIndex] = FP.ToRaw(vz);
+    const mass = FP.FromRaw(this.physicsStore.arrays.mass[physIndex]);
+    if (FP.Lte(mass, FP._0)) return;
+    this.physicsStore.arrays.velocityX[physIndex] = FP.ToRaw(FP.Div(ix, mass));
+    this.physicsStore.arrays.velocityY[physIndex] = FP.ToRaw(FP.Div(iy, mass));
+    this.physicsStore.arrays.velocityZ[physIndex] = FP.ToRaw(FP.Div(iz, mass));
   }
 
   /**

--- a/phalanx-physics/src/systems/index.ts
+++ b/phalanx-physics/src/systems/index.ts
@@ -1,4 +1,5 @@
 export { PhysicsSystem } from './PhysicsSystem';
+export { GravitySystem } from './GravitySystem';
 export { CollisionSystem } from './CollisionSystem';
 export { InterpolationSystem } from './InterpolationSystem';
 export type { InterpolatedTransformSample } from './InterpolationSystem';

--- a/phalanx-physics/src/types.ts
+++ b/phalanx-physics/src/types.ts
@@ -108,4 +108,10 @@ export interface PhysicsBodyConfig {
    * still owned by PhysicsSystem.
    */
   useGravity?: boolean;
+  /**
+   * Per-body scale on global gravity when `useGravity=true` (default `FP._1`).
+   * Does not affect bodies with `useGravity=false`. `0` disables gravity on
+   * that body without toggling the flag.
+   */
+  gravityMultiplier?: FixedPoint;
 }

--- a/phalanx-physics/src/types.ts
+++ b/phalanx-physics/src/types.ts
@@ -78,6 +78,18 @@ export interface PhysicsConfig {
    * When false (default), bodies are clamped to the boundary.
    */
   ejectOnBoundsExit?: boolean;
+  /**
+   * Gravitational acceleration magnitude applied by GravitySystem to bodies
+   * with `useGravity=true`. Default 0 (no gravity → GravitySystem is a no-op).
+   */
+  gravity?: FixedPoint;
+  /**
+   * Axis along which gravity is applied. Default `'y'`. In v1 only `'y'` is
+   * supported: X/Z are owned by PhysicsSystem's position integrator, so gravity
+   * on those axes would double-integrate. `'x'`/`'z'` are reserved and cause
+   * GravitySystem to throw.
+   */
+  gravityAxis?: 'x' | 'y' | 'z';
 }
 
 /**
@@ -89,4 +101,11 @@ export interface PhysicsBodyConfig {
   isStatic?: boolean;
   restitution?: FixedPoint;
   friction?: FixedPoint;
+  /**
+   * When true, GravitySystem applies gravitational acceleration to this body's
+   * velocity each tick (default false). Existing bodies keep `useGravity=false`
+   * and are unaffected. Integration of the resulting velocity into position is
+   * still owned by PhysicsSystem.
+   */
+  useGravity?: boolean;
 }

--- a/phalanx-physics/tests/CollisionSystem.test.ts
+++ b/phalanx-physics/tests/CollisionSystem.test.ts
@@ -79,6 +79,7 @@ describe('Collision (via PhysicsSystem)', () => {
       friction: FP.ToRaw(FP.FromFloat(0.3)),
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/CollisionSystem.test.ts
+++ b/phalanx-physics/tests/CollisionSystem.test.ts
@@ -80,6 +80,7 @@ describe('Collision (via PhysicsSystem)', () => {
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/GravitySystem.test.ts
+++ b/phalanx-physics/tests/GravitySystem.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import {
+  EntityManager,
+  EventBus,
+  SystemContext,
+  SoAComponent,
+  type SoAComponentStore,
+} from '@phalanx-engine/ecs';
+import { GravitySystem } from '../src/systems/GravitySystem';
+import { PhysicsSystem } from '../src/systems/PhysicsSystem';
+import { PhysicsSoASchema } from '../src/components/PhysicsBodyComponent';
+import { TransformSoASchema } from '../src/components/TransformComponent';
+import type { PhysicsConfig } from '../src/types';
+import { addTransformRow } from './testTransformHelpers';
+
+const TICK_DT = FP.FromFloat(0.05);
+const GRAVITY = FP.FromFloat(10);
+
+function createPhysicsConfig(overrides?: Partial<PhysicsConfig>): PhysicsConfig {
+  return {
+    tickDt: TICK_DT,
+    subSteps: 1,
+    maxVelocity: FP.FromFloat(1000),
+    defaultFriction: FP.FromFloat(1.0), // no friction for cleaner tests
+    pushStrength: FP.FromFloat(15.0),
+    gridCellSize: FP.FromFloat(4),
+    ...overrides,
+  };
+}
+
+function addBody(
+  physicsStore: SoAComponentStore<typeof PhysicsSoASchema.definition>,
+  transformStore: SoAComponentStore<typeof TransformSoASchema.definition>,
+  entityId: number,
+  opts: { velX?: number; velY?: number; velZ?: number; useGravity?: boolean; posY?: number } = {},
+): void {
+  physicsStore.add(entityId, {
+    velocityX: FP.ToRaw(FP.FromFloat(opts.velX ?? 0)),
+    velocityY: FP.ToRaw(FP.FromFloat(opts.velY ?? 0)),
+    velocityZ: FP.ToRaw(FP.FromFloat(opts.velZ ?? 0)),
+    radius: FP.ToRaw(FP._1),
+    mass: FP.ToRaw(FP._1),
+    restitution: FP.ToRaw(FP.FromFloat(0.5)),
+    friction: FP.ToRaw(FP._1),
+    isStatic: 0,
+    ignorePhysics: 0,
+    useGravity: opts.useGravity ? 1 : 0,
+    lastX: 0,
+    lastZ: 0,
+  });
+  addTransformRow(transformStore, entityId, 0, 0, opts.posY ?? 0);
+}
+
+describe('GravitySystem', () => {
+  let entityManager: EntityManager;
+  let eventBus: EventBus;
+  let context: SystemContext;
+
+  beforeEach(() => {
+    entityManager = new EntityManager();
+    eventBus = new EventBus();
+    context = new SystemContext(eventBus, entityManager);
+    SoAComponent.useEntityManager(entityManager);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function setup(gravity = GRAVITY, gravityAxis: 'x' | 'y' | 'z' = 'y') {
+    const gravitySystem = new GravitySystem(gravity, gravityAxis, TICK_DT);
+    gravitySystem.init(context);
+    const physicsStore = entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+    const transformStore = entityManager.getOrCreateSoAStore(TransformSoASchema);
+    return { gravitySystem, physicsStore, transformStore };
+  }
+
+  it('decreases velocityY by gravity*dt each tick for a useGravity body', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { useGravity: true });
+    const idx = physicsStore.indexOf(1);
+
+    const deltaPerTick = FP.ToFloat(FP.Mul(GRAVITY, TICK_DT)); // 10 * 0.05 = 0.5
+
+    gravitySystem.processTick(1);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(-deltaPerTick, 5);
+
+    gravitySystem.processTick(2);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(-2 * deltaPerTick, 5);
+
+    gravitySystem.processTick(3);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(-3 * deltaPerTick, 5);
+  });
+
+  it('does not change X/Z velocities', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { velX: 7, velZ: -4, useGravity: true });
+    const idx = physicsStore.indexOf(1);
+
+    gravitySystem.processTick(1);
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(7, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(-4, 5);
+  });
+
+  it('leaves velocityY untouched for a useGravity=false body', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { velY: 3, useGravity: false });
+    const idx = physicsStore.indexOf(1);
+
+    gravitySystem.processTick(1);
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(3, 5);
+  });
+
+  it('does NOT change positionY (integration is PhysicsSystem\'s job)', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { useGravity: true, posY: 100 });
+    const txIdx = transformStore.indexOf(1);
+
+    // GravitySystem alone: velocity changes, position does not.
+    gravitySystem.processTick(1);
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(100, 5);
+
+    const velY = FP.FromRaw(physicsStore.arrays.velocityY[physicsStore.indexOf(1)]);
+    expect(FP.ToFloat(velY)).toBeCloseTo(-0.5, 5);
+
+    // Now PhysicsSystem integrates the accumulated velocity into position.
+    const physicsSystem = new PhysicsSystem(createPhysicsConfig());
+    physicsSystem.init(context);
+    physicsSystem.processTick(1);
+
+    // pos.y += velY * dt = 100 + (-0.5 * 0.05) = 99.975
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(99.975, 4);
+  });
+
+  it('is a no-op when gravity is 0', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup(FP._0);
+    addBody(physicsStore, transformStore, 1, { velY: 2, useGravity: true });
+    const idx = physicsStore.indexOf(1);
+
+    gravitySystem.processTick(1);
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(2, 5);
+  });
+
+  it('throws when gravityAxis is not \'y\'', () => {
+    expect(() => new GravitySystem(GRAVITY, 'x', TICK_DT)).toThrow();
+    expect(() => new GravitySystem(GRAVITY, 'z', TICK_DT)).toThrow();
+  });
+
+  it('is deterministic: two identical worlds produce identical velY each tick', () => {
+    const worldA = (() => {
+      const em = new EntityManager();
+      const eb = new EventBus();
+      const ctx = new SystemContext(eb, em);
+      SoAComponent.useEntityManager(em);
+      const sys = new GravitySystem(GRAVITY, 'y', TICK_DT);
+      sys.init(ctx);
+      const ps = em.getOrCreateSoAStore(PhysicsSoASchema);
+      const ts = em.getOrCreateSoAStore(TransformSoASchema);
+      addBody(ps, ts, 1, { velY: 5, useGravity: true });
+      SoAComponent.resetContext();
+      return { sys, ps };
+    })();
+
+    const worldB = (() => {
+      const em = new EntityManager();
+      const eb = new EventBus();
+      const ctx = new SystemContext(eb, em);
+      SoAComponent.useEntityManager(em);
+      const sys = new GravitySystem(GRAVITY, 'y', TICK_DT);
+      sys.init(ctx);
+      const ps = em.getOrCreateSoAStore(PhysicsSoASchema);
+      const ts = em.getOrCreateSoAStore(TransformSoASchema);
+      addBody(ps, ts, 1, { velY: 5, useGravity: true });
+      SoAComponent.resetContext();
+      return { sys, ps };
+    })();
+
+    for (let tick = 1; tick <= 10; tick++) {
+      worldA.sys.processTick(tick);
+      worldB.sys.processTick(tick);
+      const a = worldA.ps.arrays.velocityY[worldA.ps.indexOf(1)];
+      const b = worldB.ps.arrays.velocityY[worldB.ps.indexOf(1)];
+      expect(a).toBe(b);
+    }
+  });
+});

--- a/phalanx-physics/tests/GravitySystem.test.ts
+++ b/phalanx-physics/tests/GravitySystem.test.ts
@@ -135,6 +135,21 @@ describe('GravitySystem', () => {
     expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(99.975, 4);
   });
 
+  it('skips static bodies: velocityY and positionY stay unchanged', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { useGravity: true, posY: 50 });
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.isStatic[idx] = 1;
+    const txIdx = transformStore.indexOf(1);
+
+    gravitySystem.processTick(1);
+
+    // Static + useGravity is a clean no-op: no velocity accumulation...
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(0, 5);
+    // ...and no position change.
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(50, 5);
+  });
+
   it('is a no-op when gravity is 0', () => {
     const { gravitySystem, physicsStore, transformStore } = setup(FP._0);
     addBody(physicsStore, transformStore, 1, { velY: 2, useGravity: true });

--- a/phalanx-physics/tests/GravitySystem.test.ts
+++ b/phalanx-physics/tests/GravitySystem.test.ts
@@ -46,6 +46,7 @@ function addBody(
     isStatic: 0,
     ignorePhysics: 0,
     useGravity: opts.useGravity ? 1 : 0,
+    gravityMultiplier: FP.ToRaw(FP._1),
     lastX: 0,
     lastZ: 0,
   });
@@ -91,6 +92,29 @@ describe('GravitySystem', () => {
 
     gravitySystem.processTick(3);
     expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(-3 * deltaPerTick, 5);
+  });
+
+  it('scales gravity by per-body gravityMultiplier', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { useGravity: true });
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.gravityMultiplier[idx] = FP.ToRaw(FP.FromFloat(2));
+
+    const deltaPerTick = FP.ToFloat(FP.Mul(GRAVITY, TICK_DT)); // 0.5
+
+    gravitySystem.processTick(1);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(-2 * deltaPerTick, 5);
+  });
+
+  it('applies no gravity when gravityMultiplier is 0', () => {
+    const { gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, { velY: 3, useGravity: true });
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.gravityMultiplier[idx] = FP.ToRaw(FP._0);
+
+    gravitySystem.processTick(1);
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(3, 5);
   });
 
   it('does not change X/Z velocities', () => {

--- a/phalanx-physics/tests/PhysicsSystem.test.ts
+++ b/phalanx-physics/tests/PhysicsSystem.test.ts
@@ -76,6 +76,7 @@ describe('PhysicsSystem', () => {
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/PhysicsSystem.test.ts
+++ b/phalanx-physics/tests/PhysicsSystem.test.ts
@@ -75,6 +75,7 @@ describe('PhysicsSystem', () => {
       friction: FP.ToRaw(FP.FromFloat(0.3)),
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/PhysicsSystemYIntegration.test.ts
+++ b/phalanx-physics/tests/PhysicsSystemYIntegration.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import {
+  EntityManager,
+  EventBus,
+  SystemContext,
+  SoAComponent,
+  type SoAComponentStore,
+} from '@phalanx-engine/ecs';
+import { PhysicsSystem } from '../src/systems/PhysicsSystem';
+import { PhysicsSoASchema } from '../src/components/PhysicsBodyComponent';
+import { TransformSoASchema } from '../src/components/TransformComponent';
+import type { PhysicsConfig } from '../src/types';
+import { addTransformRow } from './testTransformHelpers';
+
+function createPhysicsConfig(overrides?: Partial<PhysicsConfig>): PhysicsConfig {
+  return {
+    tickDt: FP.FromFloat(0.05),
+    subSteps: 1,
+    maxVelocity: FP.FromFloat(1000),
+    defaultFriction: FP.FromFloat(1.0), // no friction so XZ velocity is preserved
+    pushStrength: FP.FromFloat(15.0),
+    gridCellSize: FP.FromFloat(4),
+    ...overrides,
+  };
+}
+
+describe('PhysicsSystem Y integration', () => {
+  let entityManager: EntityManager;
+  let eventBus: EventBus;
+  let context: SystemContext;
+
+  beforeEach(() => {
+    entityManager = new EntityManager();
+    eventBus = new EventBus();
+    context = new SystemContext(eventBus, entityManager);
+    SoAComponent.useEntityManager(entityManager);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function setup(overrides?: Partial<PhysicsConfig>) {
+    const system = new PhysicsSystem(createPhysicsConfig(overrides));
+    system.init(context);
+    const physicsStore = entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+    const transformStore = entityManager.getOrCreateSoAStore(TransformSoASchema);
+    return { system, physicsStore, transformStore };
+  }
+
+  function addBody(
+    physicsStore: SoAComponentStore<typeof PhysicsSoASchema.definition>,
+    transformStore: SoAComponentStore<typeof TransformSoASchema.definition>,
+    entityId: number,
+    velX: number, velY: number, velZ: number,
+    posY = 0,
+  ): void {
+    physicsStore.add(entityId, {
+      velocityX: FP.ToRaw(FP.FromFloat(velX)),
+      velocityY: FP.ToRaw(FP.FromFloat(velY)),
+      velocityZ: FP.ToRaw(FP.FromFloat(velZ)),
+      radius: FP.ToRaw(FP._1),
+      mass: FP.ToRaw(FP._1),
+      restitution: FP.ToRaw(FP.FromFloat(0.5)),
+      friction: FP.ToRaw(FP._1),
+      isStatic: 0,
+      ignorePhysics: 0,
+      useGravity: 0,
+      lastX: 0,
+      lastZ: 0,
+    });
+    addTransformRow(transformStore, entityId, 0, 0, posY);
+  }
+
+  it('moves a body on Y linearly when velocityY is nonzero (useGravity=false)', () => {
+    const { system, physicsStore, transformStore } = setup();
+    // velY = 8, dt = 0.05, subSteps = 1 -> ΔY per tick = 8 * 0.05 = 0.4 (constant velocity)
+    addBody(physicsStore, transformStore, 1, 0, 8, 0, 0);
+    const txIdx = transformStore.indexOf(1);
+
+    system.processTick(1);
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(0.4, 4);
+
+    system.processTick(2);
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(0.8, 4);
+
+    system.processTick(3);
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(1.2, 4);
+  });
+
+  it('sub-steps Y integration consistently with XZ', () => {
+    const { system, physicsStore, transformStore } = setup({ subSteps: 3 });
+    // velY = 6, total ΔY per tick = 6 * (0.05/3) * 3 = 0.3
+    addBody(physicsStore, transformStore, 1, 0, 6, 0, 0);
+    const txIdx = transformStore.indexOf(1);
+
+    system.processTick(1);
+    // 3-digit tolerance: fixed-point sub-step dt = 0.05/3 is not exactly
+    // representable, so accumulated ΔY has a small (~1e-4) rounding error.
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(0.3, 3);
+  });
+
+  it('regression: body with velocityY=0 does not move on Y', () => {
+    const { system, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, 10, 0, 5, 42);
+    const txIdx = transformStore.indexOf(1);
+
+    system.processTick(1);
+
+    // Y stays fixed even though XZ move.
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(42, 5);
+    // XZ still integrate normally.
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionX[txIdx]))).toBeCloseTo(0.5, 4);
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionZ[txIdx]))).toBeCloseTo(0.25, 4);
+  });
+
+  it('static bodies do not integrate on Y', () => {
+    const { system, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, 0, 8, 0, 10);
+    const physIdx = physicsStore.indexOf(1);
+    physicsStore.arrays.isStatic[physIdx] = 1;
+    const txIdx = transformStore.indexOf(1);
+
+    system.processTick(1);
+
+    expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(10, 5);
+  });
+});

--- a/phalanx-physics/tests/PhysicsSystemYIntegration.test.ts
+++ b/phalanx-physics/tests/PhysicsSystemYIntegration.test.ts
@@ -67,6 +67,7 @@ describe('PhysicsSystem Y integration', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/PhysicsWorld.test.ts
+++ b/phalanx-physics/tests/PhysicsWorld.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Entity, EntityManager, EventBus, SoAComponent, SystemContext } from '@phalanx-engine/ecs';
 import { FPVector3, FPQuaternion } from '@phalanx-engine/math';
+import { FP } from '@phalanx-engine/math';
 import { PhysicsWorld } from '../src/PhysicsWorld';
 import { PhysicsSystem } from '../src/systems/PhysicsSystem';
+import { GravitySystem } from '../src/systems/GravitySystem';
 import { InterpolationSystem } from '../src/systems/InterpolationSystem';
 import { TransformComponent, TRANSFORM_COMPONENT_TYPE } from '../src/components/TransformComponent';
 import {
@@ -34,6 +36,51 @@ describe('PhysicsWorld', () => {
 
     expect(physicsSystem).toBeInstanceOf(PhysicsSystem);
     expect(interpolationSystem).toBeInstanceOf(InterpolationSystem);
+  });
+
+  it('getSystems exposes a gravitySystem (backward-compatible destructure)', () => {
+    const physicsWorld = new PhysicsWorld({ gravity: FP.FromFloat(9.8) });
+    const { gravitySystem } = physicsWorld.getSystems();
+
+    expect(gravitySystem).toBeInstanceOf(GravitySystem);
+    expect(FP.ToFloat(gravitySystem.getGravity())).toBeCloseTo(9.8, 3);
+    expect(gravitySystem.getGravityAxis()).toBe('y');
+  });
+
+  it('defaults gravity to 0 (GravitySystem no-op) when not configured', () => {
+    const physicsWorld = new PhysicsWorld();
+    const { gravitySystem } = physicsWorld.getSystems();
+
+    expect(FP.ToFloat(gravitySystem.getGravity())).toBe(0);
+  });
+
+  it('applyImpulse3D delegates to PhysicsSystem and sets all three axes', () => {
+    const physicsWorld = new PhysicsWorld();
+    const { physicsSystem } = physicsWorld.getSystems();
+    physicsSystem.init(context);
+
+    const physicsStore = physicsSystem.getPhysicsStore();
+    physicsStore.add(1, {
+      velocityX: FP.ToRaw(FP._0),
+      velocityY: FP.ToRaw(FP._0),
+      velocityZ: FP.ToRaw(FP._0),
+      radius: FP.ToRaw(FP._1),
+      mass: FP.ToRaw(FP._1),
+      restitution: FP.ToRaw(FP.FromFloat(0.5)),
+      friction: FP.ToRaw(FP._1),
+      isStatic: 0,
+      ignorePhysics: 0,
+      useGravity: 0,
+      lastX: 0,
+      lastZ: 0,
+    });
+
+    physicsWorld.applyImpulse3D(1, FP.FromFloat(1), FP.FromFloat(2), FP.FromFloat(3));
+
+    const idx = physicsStore.indexOf(1);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(1, 4);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(2, 4);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(3, 4);
   });
 
   it('getInterpolatedTransform delegates to the owned interpolation system', () => {

--- a/phalanx-physics/tests/PhysicsWorld.test.ts
+++ b/phalanx-physics/tests/PhysicsWorld.test.ts
@@ -71,6 +71,7 @@ describe('PhysicsWorld', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/Raycast.test.ts
+++ b/phalanx-physics/tests/Raycast.test.ts
@@ -1,200 +1,150 @@
 import { describe, it, expect } from 'vitest';
 import { FP } from '@phalanx-engine/math';
-import { segmentVsAABB } from '../src/collision/Raycast';
-import type { AABB3 } from '../src/collision/Raycast';
+import { segmentVsAABB, type AABB, type Vec3FP } from '../src/collision/Raycast';
 import { PhysicsWorld } from '../src/PhysicsWorld';
 
-const F = (n: number) => FP.FromFloat(n);
-const box = (minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number): AABB3 => ({
-  minX: F(minX), minY: F(minY), minZ: F(minZ),
-  maxX: F(maxX), maxY: F(maxY), maxZ: F(maxZ),
-});
+function vec(x: number, y: number, z: number): Vec3FP {
+  return { x: FP.FromFloat(x), y: FP.FromFloat(y), z: FP.FromFloat(z) };
+}
+
+function box(
+  minX: number, minY: number, minZ: number,
+  maxX: number, maxY: number, maxZ: number,
+): AABB {
+  return {
+    minX: FP.FromFloat(minX), minY: FP.FromFloat(minY), minZ: FP.FromFloat(minZ),
+    maxX: FP.FromFloat(maxX), maxY: FP.FromFloat(maxY), maxZ: FP.FromFloat(maxZ),
+  };
+}
+
+// Unit cube centered at origin: [-1,1]^3.
+const UNIT = box(-1, -1, -1, 1, 1, 1);
 
 describe('segmentVsAABB', () => {
-  describe('hits', () => {
-    it('hits the -X face when moving in +X', () => {
-      // Box occupies x in [2,4], y in [0,2], z in [0,2].
-      // Segment from (0,1,1) to (6,1,1): enters through minX face.
-      const hit = segmentVsAABB(
-        { x: F(0), y: F(1), z: F(1) },
-        { x: F(6), y: F(1), z: F(1) },
-        box(2, 0, 0, 4, 2, 2),
-      );
-      expect(hit).not.toBeNull();
-      expect(FP.ToFloat(hit!.t)).toBeCloseTo(2 / 6, 5); // t = (2-0)/6
-      // Entry through minX face -> outward normal (-1,0,0).
-      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(-1, 5);
-      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
-      // Point lies on the entry face: x = 2, y = z = 1 (4-decimal FP tolerance).
-      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(2, 4);
-      expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(1, 4);
-      expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(1, 4);
-    });
-
-    it('hits the +Y face when falling from above', () => {
-      // Box y in [0,2]; segment from (1,5,1) to (1,-1,1) falls through top.
-      const hit = segmentVsAABB(
-        { x: F(1), y: F(5), z: F(1) },
-        { x: F(1), y: F(-1), z: F(1) },
-        box(0, 0, 0, 2, 2, 2),
-      );
-      expect(hit).not.toBeNull();
-      // d_y < 0 -> enters through maxY face -> outward normal (0,1,0).
-      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(1, 5);
-      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(2, 5); // on top face
-    });
-
-    it('point equals lerp(prev, cur, t)', () => {
-      const prev = { x: F(-3), y: F(1), z: F(7) };
-      const cur = { x: F(5), y: F(1), z: F(-1) };
-      const hit = segmentVsAABB(prev, cur, box(0, 0, 0, 2, 2, 2));
-      expect(hit).not.toBeNull();
-      const t = FP.ToFloat(hit!.t);
-      const px = FP.ToFloat(prev.x) + t * (FP.ToFloat(cur.x) - FP.ToFloat(prev.x));
-      const pz = FP.ToFloat(prev.z) + t * (FP.ToFloat(cur.z) - FP.ToFloat(prev.z));
-      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(px, 4);
-      expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(pz, 4);
-    });
+  it('hits the min-X face when moving +X from outside (normal = -X)', () => {
+    const hit = segmentVsAABB(vec(-5, 0, 0), vec(5, 0, 0), UNIT);
+    expect(hit).not.toBeNull();
+    // Enters at x = -1 → t = (-1 - (-5)) / 10 = 0.4
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0.4, 5);
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(-1, 5);
+    expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(-1, 5);
+    expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
+    // t strictly inside (0, 1)
+    expect(FP.Gt(hit!.t, FP._0)).toBe(true);
+    expect(FP.Lt(hit!.t, FP._1)).toBe(true);
   });
 
-  describe('misses', () => {
-    it('returns null when the segment passes outside the box', () => {
-      const hit = segmentVsAABB(
-        { x: F(0), y: F(0), z: F(5) },
-        { x: F(10), y: F(0), z: F(5) },
-        box(2, 0, 0, 4, 2, 2), // box z in [0,2], segment at z=5
-      );
-      expect(hit).toBeNull();
-    });
-
-    it('returns null when the box is entirely before the segment start', () => {
-      // Box x in [-10,-5]; segment from (0,1,1) to (6,1,1) moving +x.
-      const hit = segmentVsAABB(
-        { x: F(0), y: F(1), z: F(1) },
-        { x: F(6), y: F(1), z: F(1) },
-        box(-10, 0, 0, -5, 2, 2),
-      );
-      expect(hit).toBeNull();
-    });
-
-    it('returns null when the box is entirely beyond the segment end', () => {
-      const hit = segmentVsAABB(
-        { x: F(0), y: F(1), z: F(1) },
-        { x: F(1), y: F(1), z: F(1) }, // ends before reaching box at x=2
-        box(2, 0, 0, 4, 2, 2),
-      );
-      expect(hit).toBeNull();
-    });
+  it('hits the top (max-Y) face when descending from above (normal = +Y)', () => {
+    const hit = segmentVsAABB(vec(0, 5, 0), vec(0, -5, 0), UNIT);
+    expect(hit).not.toBeNull();
+    // Enters at y = 1 → t = (1 - 5) / (-10) = 0.4
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0.4, 5);
+    expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(1, 5);
+    expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(1, 5);
+    expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
   });
 
-  describe('edge cases', () => {
-    it('reports t=0 at prev when the segment starts inside the box', () => {
-      const prev = { x: F(1), y: F(1), z: F(1) };
-      const cur = { x: F(1.5), y: F(1), z: F(1) };
-      const hit = segmentVsAABB(prev, cur, box(0, 0, 0, 2, 2, 2));
-      expect(hit).not.toBeNull();
-      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(1, 5);
-    });
-
-    it('returns the nearest face normal for a moving segment that starts inside', () => {
-      // prev=(1.5,1,1) is closest to the maxX face (dist 0.5) -> normal (1,0,0).
-      const hit = segmentVsAABB(
-        { x: F(1.5), y: F(1), z: F(1) },
-        { x: F(1.9), y: F(1), z: F(1) },
-        box(0, 0, 0, 2, 2, 2),
-      );
-      expect(hit).not.toBeNull();
-      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(1, 5);
-      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(0, 5);
-      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
-    });
-
-    it('returns a face normal when the segment is a point inside the box', () => {
-      const p = { x: F(1), y: F(1), z: F(1) };
-      const hit = segmentVsAABB(p, p, box(0, 0, 0, 2, 2, 2));
-      expect(hit).not.toBeNull();
-      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
-      // Normal must be a unit axis vector (one component ±1, others 0).
-      const nx = FP.ToFloat(hit!.normal.x);
-      const ny = FP.ToFloat(hit!.normal.y);
-      const nz = FP.ToFloat(hit!.normal.z);
-      const mag = Math.sqrt(nx * nx + ny * ny + nz * nz);
-      expect(mag).toBeCloseTo(1, 5);
-    });
-
-    it('returns null for a zero-length segment outside the box', () => {
-      const p = { x: F(5), y: F(5), z: F(5) };
-      expect(segmentVsAABB(p, p, box(0, 0, 0, 2, 2, 2))).toBeNull();
-    });
-
-    it('handles a segment parallel to a slab without NaN', () => {
-      // Movement only along X (y,z constant and inside the slab) -> hit on X face.
-      const hit = segmentVsAABB(
-        { x: F(0), y: F(1), z: F(1) },
-        { x: F(6), y: F(1), z: F(1) },
-        box(2, 0, 0, 4, 2, 2),
-      );
-      expect(hit).not.toBeNull();
-      expect(Number.isNaN(FP.ToFloat(hit!.point.x))).toBe(false);
-    });
+  it('returns null when the segment misses the box', () => {
+    // Parallel to X at y = 5, well above the box.
+    const hit = segmentVsAABB(vec(-5, 5, 0), vec(5, 5, 0), UNIT);
+    expect(hit).toBeNull();
   });
 
-  describe('determinism', () => {
-    it('produces identical results for identical inputs across runs', () => {
-      const prev = { x: F(0), y: F(1), z: F(1) };
-      const cur = { x: F(6), y: F(1), z: F(1) };
-      const b = box(2, 0, 0, 4, 2, 2);
-      const a = segmentVsAABB(prev, cur, b);
-      const bb = segmentVsAABB(prev, cur, b);
-      expect(a).not.toBeNull();
-      expect(bb).not.toBeNull();
-      expect(FP.ToRaw(a!.t)).toBe(FP.ToRaw(bb!.t));
-      expect(FP.ToRaw(a!.point.x)).toBe(FP.ToRaw(bb!.point.x));
-      expect(FP.ToRaw(a!.normal.x)).toBe(FP.ToRaw(bb!.normal.x));
-    });
+  it('starts inside the box → t = 0, point = prev, normal = nearest face', () => {
+    // Closest to the +X face (0.6 from maxX vs 0.9 from others).
+    const prev = vec(0.4, 0, 0);
+    const hit = segmentVsAABB(prev, vec(5, 0, 0), UNIT);
+    expect(hit).not.toBeNull();
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(0.4, 5);
+    expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(0, 5);
+    // Nearest face is +X.
+    expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(1, 5);
+  });
+
+  it('point equals lerp(prev, cur, t)', () => {
+    // Diagonal through the origin: varies on all three axes and clearly hits.
+    const prev = vec(-3, -3, -3);
+    const cur = vec(3, 3, 3);
+    const hit = segmentVsAABB(prev, cur, UNIT);
+    expect(hit).not.toBeNull();
+    const t = hit!.t;
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(FP.ToFloat(FP.Lerp(prev.x, cur.x, t)), 5);
+    expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(FP.ToFloat(FP.Lerp(prev.y, cur.y, t)), 5);
+    expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(FP.ToFloat(FP.Lerp(prev.z, cur.z, t)), 5);
+  });
+
+  it('zero-length segment outside the box → null', () => {
+    const hit = segmentVsAABB(vec(5, 5, 5), vec(5, 5, 5), UNIT);
+    expect(hit).toBeNull();
+  });
+
+  it('zero-length segment inside the box → t = 0', () => {
+    const hit = segmentVsAABB(vec(0, 0, 0), vec(0, 0, 0), UNIT);
+    expect(hit).not.toBeNull();
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(0, 5);
+  });
+
+  it('handles a segment parallel to a slab deterministically (no NaN)', () => {
+    // Parallel to X, exactly at y = 1 (on the top face plane), passing through.
+    const hit = segmentVsAABB(vec(-5, 1, 0), vec(5, 1, 0), UNIT);
+    // Whatever the outcome, it must be well-defined (a hit here, entering at x=-1).
+    expect(hit).not.toBeNull();
+    expect(Number.isNaN(FP.ToFloat(hit!.t))).toBe(false);
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(-1, 5);
+  });
+
+  it('parallel-and-outside slab → null (no divide-by-zero)', () => {
+    // Parallel to X but z = 9 lies outside the box's z-slab.
+    const hit = segmentVsAABB(vec(-5, 0, 9), vec(5, 0, 9), UNIT);
+    expect(hit).toBeNull();
+  });
+
+  it('is deterministic: identical inputs → identical RayHit', () => {
+    const prev = vec(-4, 2, 1);
+    const cur = vec(6, -3, -2);
+    const a = segmentVsAABB(prev, cur, UNIT);
+    const b = segmentVsAABB(prev, cur, UNIT);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    // Raw bigint equality — bit-for-bit determinism.
+    expect(FP.ToRaw(a!.t)).toBe(FP.ToRaw(b!.t));
+    expect(FP.ToRaw(a!.point.x)).toBe(FP.ToRaw(b!.point.x));
+    expect(FP.ToRaw(a!.point.y)).toBe(FP.ToRaw(b!.point.y));
+    expect(FP.ToRaw(a!.point.z)).toBe(FP.ToRaw(b!.point.z));
+    expect(FP.ToRaw(a!.normal.x)).toBe(FP.ToRaw(b!.normal.x));
+    expect(FP.ToRaw(a!.normal.y)).toBe(FP.ToRaw(b!.normal.y));
+    expect(FP.ToRaw(a!.normal.z)).toBe(FP.ToRaw(b!.normal.z));
   });
 });
 
 describe('PhysicsWorld.raycastSegment', () => {
+  // raycastSegment is a pure query over the supplied boxes — no ECS context needed.
+  it('returns the nearest hit (smallest t) among many boxes', () => {
+    const world = new PhysicsWorld();
+    const near = box(1, -1, -1, 2, 1, 1); // enters at x = 1
+    const far = box(4, -1, -1, 5, 1, 1); // enters at x = 4
+    const hit = world.raycastSegment(vec(-5, 0, 0), vec(10, 0, 0), [far, near]);
+    expect(hit).not.toBeNull();
+    // Nearest is the box entered at x = 1 → t = (1 - (-5)) / 15 = 0.4
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(1, 5);
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0.4, 5);
+  });
+
   it('returns null for an empty box list', () => {
     const world = new PhysicsWorld();
-    const hit = world.raycastSegment(
-      { x: F(0), y: F(0), z: F(0) },
-      { x: F(10), y: F(0), z: F(0) },
-      [],
-    );
+    const hit = world.raycastSegment(vec(-5, 0, 0), vec(5, 0, 0), []);
     expect(hit).toBeNull();
   });
 
-  it('returns the nearest of multiple hits', () => {
+  it('returns null when the segment hits none of the boxes', () => {
     const world = new PhysicsWorld();
-    const boxes: AABB3[] = [
-      box(4, 0, 0, 6, 2, 2),  // farther along +X
-      box(2, 0, 0, 3, 2, 2),  // nearer
-    ];
-    const hit = world.raycastSegment(
-      { x: F(0), y: F(1), z: F(1) },
-      { x: F(10), y: F(1), z: F(1) },
-      boxes,
-    );
-    expect(hit).not.toBeNull();
-    // Nearest box enters at x=2 -> t = 2/10 = 0.2.
-    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0.2, 5);
-    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(2, 5);
-  });
-
-  it('returns null when no box is hit', () => {
-    const world = new PhysicsWorld();
-    const hit = world.raycastSegment(
-      { x: F(0), y: F(0), z: F(5) },
-      { x: F(10), y: F(0), z: F(5) },
-      [box(2, 0, 0, 4, 2, 2)],
-    );
+    const b = box(10, 10, 10, 11, 11, 11);
+    const hit = world.raycastSegment(vec(-5, 0, 0), vec(5, 0, 0), [b]);
     expect(hit).toBeNull();
   });
 });

--- a/phalanx-physics/tests/Raycast.test.ts
+++ b/phalanx-physics/tests/Raycast.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import { segmentVsAABB } from '../src/collision/Raycast';
+import type { AABB3 } from '../src/collision/Raycast';
+import { PhysicsWorld } from '../src/PhysicsWorld';
+
+const F = (n: number) => FP.FromFloat(n);
+const box = (minX: number, minY: number, minZ: number, maxX: number, maxY: number, maxZ: number): AABB3 => ({
+  minX: F(minX), minY: F(minY), minZ: F(minZ),
+  maxX: F(maxX), maxY: F(maxY), maxZ: F(maxZ),
+});
+
+describe('segmentVsAABB', () => {
+  describe('hits', () => {
+    it('hits the -X face when moving in +X', () => {
+      // Box occupies x in [2,4], y in [0,2], z in [0,2].
+      // Segment from (0,1,1) to (6,1,1): enters through minX face.
+      const hit = segmentVsAABB(
+        { x: F(0), y: F(1), z: F(1) },
+        { x: F(6), y: F(1), z: F(1) },
+        box(2, 0, 0, 4, 2, 2),
+      );
+      expect(hit).not.toBeNull();
+      expect(FP.ToFloat(hit!.t)).toBeCloseTo(2 / 6, 5); // t = (2-0)/6
+      // Entry through minX face -> outward normal (-1,0,0).
+      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(-1, 5);
+      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
+      // Point lies on the entry face: x = 2, y = z = 1 (4-decimal FP tolerance).
+      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(2, 4);
+      expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(1, 4);
+      expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(1, 4);
+    });
+
+    it('hits the +Y face when falling from above', () => {
+      // Box y in [0,2]; segment from (1,5,1) to (1,-1,1) falls through top.
+      const hit = segmentVsAABB(
+        { x: F(1), y: F(5), z: F(1) },
+        { x: F(1), y: F(-1), z: F(1) },
+        box(0, 0, 0, 2, 2, 2),
+      );
+      expect(hit).not.toBeNull();
+      // d_y < 0 -> enters through maxY face -> outward normal (0,1,0).
+      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(1, 5);
+      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.point.y)).toBeCloseTo(2, 5); // on top face
+    });
+
+    it('point equals lerp(prev, cur, t)', () => {
+      const prev = { x: F(-3), y: F(1), z: F(7) };
+      const cur = { x: F(5), y: F(1), z: F(-1) };
+      const hit = segmentVsAABB(prev, cur, box(0, 0, 0, 2, 2, 2));
+      expect(hit).not.toBeNull();
+      const t = FP.ToFloat(hit!.t);
+      const px = FP.ToFloat(prev.x) + t * (FP.ToFloat(cur.x) - FP.ToFloat(prev.x));
+      const pz = FP.ToFloat(prev.z) + t * (FP.ToFloat(cur.z) - FP.ToFloat(prev.z));
+      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(px, 4);
+      expect(FP.ToFloat(hit!.point.z)).toBeCloseTo(pz, 4);
+    });
+  });
+
+  describe('misses', () => {
+    it('returns null when the segment passes outside the box', () => {
+      const hit = segmentVsAABB(
+        { x: F(0), y: F(0), z: F(5) },
+        { x: F(10), y: F(0), z: F(5) },
+        box(2, 0, 0, 4, 2, 2), // box z in [0,2], segment at z=5
+      );
+      expect(hit).toBeNull();
+    });
+
+    it('returns null when the box is entirely before the segment start', () => {
+      // Box x in [-10,-5]; segment from (0,1,1) to (6,1,1) moving +x.
+      const hit = segmentVsAABB(
+        { x: F(0), y: F(1), z: F(1) },
+        { x: F(6), y: F(1), z: F(1) },
+        box(-10, 0, 0, -5, 2, 2),
+      );
+      expect(hit).toBeNull();
+    });
+
+    it('returns null when the box is entirely beyond the segment end', () => {
+      const hit = segmentVsAABB(
+        { x: F(0), y: F(1), z: F(1) },
+        { x: F(1), y: F(1), z: F(1) }, // ends before reaching box at x=2
+        box(2, 0, 0, 4, 2, 2),
+      );
+      expect(hit).toBeNull();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('reports t=0 at prev when the segment starts inside the box', () => {
+      const prev = { x: F(1), y: F(1), z: F(1) };
+      const cur = { x: F(1.5), y: F(1), z: F(1) };
+      const hit = segmentVsAABB(prev, cur, box(0, 0, 0, 2, 2, 2));
+      expect(hit).not.toBeNull();
+      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(1, 5);
+    });
+
+    it('returns the nearest face normal for a moving segment that starts inside', () => {
+      // prev=(1.5,1,1) is closest to the maxX face (dist 0.5) -> normal (1,0,0).
+      const hit = segmentVsAABB(
+        { x: F(1.5), y: F(1), z: F(1) },
+        { x: F(1.9), y: F(1), z: F(1) },
+        box(0, 0, 0, 2, 2, 2),
+      );
+      expect(hit).not.toBeNull();
+      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.normal.x)).toBeCloseTo(1, 5);
+      expect(FP.ToFloat(hit!.normal.y)).toBeCloseTo(0, 5);
+      expect(FP.ToFloat(hit!.normal.z)).toBeCloseTo(0, 5);
+    });
+
+    it('returns a face normal when the segment is a point inside the box', () => {
+      const p = { x: F(1), y: F(1), z: F(1) };
+      const hit = segmentVsAABB(p, p, box(0, 0, 0, 2, 2, 2));
+      expect(hit).not.toBeNull();
+      expect(FP.ToFloat(hit!.t)).toBeCloseTo(0, 5);
+      // Normal must be a unit axis vector (one component ±1, others 0).
+      const nx = FP.ToFloat(hit!.normal.x);
+      const ny = FP.ToFloat(hit!.normal.y);
+      const nz = FP.ToFloat(hit!.normal.z);
+      const mag = Math.sqrt(nx * nx + ny * ny + nz * nz);
+      expect(mag).toBeCloseTo(1, 5);
+    });
+
+    it('returns null for a zero-length segment outside the box', () => {
+      const p = { x: F(5), y: F(5), z: F(5) };
+      expect(segmentVsAABB(p, p, box(0, 0, 0, 2, 2, 2))).toBeNull();
+    });
+
+    it('handles a segment parallel to a slab without NaN', () => {
+      // Movement only along X (y,z constant and inside the slab) -> hit on X face.
+      const hit = segmentVsAABB(
+        { x: F(0), y: F(1), z: F(1) },
+        { x: F(6), y: F(1), z: F(1) },
+        box(2, 0, 0, 4, 2, 2),
+      );
+      expect(hit).not.toBeNull();
+      expect(Number.isNaN(FP.ToFloat(hit!.point.x))).toBe(false);
+    });
+  });
+
+  describe('determinism', () => {
+    it('produces identical results for identical inputs across runs', () => {
+      const prev = { x: F(0), y: F(1), z: F(1) };
+      const cur = { x: F(6), y: F(1), z: F(1) };
+      const b = box(2, 0, 0, 4, 2, 2);
+      const a = segmentVsAABB(prev, cur, b);
+      const bb = segmentVsAABB(prev, cur, b);
+      expect(a).not.toBeNull();
+      expect(bb).not.toBeNull();
+      expect(FP.ToRaw(a!.t)).toBe(FP.ToRaw(bb!.t));
+      expect(FP.ToRaw(a!.point.x)).toBe(FP.ToRaw(bb!.point.x));
+      expect(FP.ToRaw(a!.normal.x)).toBe(FP.ToRaw(bb!.normal.x));
+    });
+  });
+});
+
+describe('PhysicsWorld.raycastSegment', () => {
+  it('returns null for an empty box list', () => {
+    const world = new PhysicsWorld();
+    const hit = world.raycastSegment(
+      { x: F(0), y: F(0), z: F(0) },
+      { x: F(10), y: F(0), z: F(0) },
+      [],
+    );
+    expect(hit).toBeNull();
+  });
+
+  it('returns the nearest of multiple hits', () => {
+    const world = new PhysicsWorld();
+    const boxes: AABB3[] = [
+      box(4, 0, 0, 6, 2, 2),  // farther along +X
+      box(2, 0, 0, 3, 2, 2),  // nearer
+    ];
+    const hit = world.raycastSegment(
+      { x: F(0), y: F(1), z: F(1) },
+      { x: F(10), y: F(1), z: F(1) },
+      boxes,
+    );
+    expect(hit).not.toBeNull();
+    // Nearest box enters at x=2 -> t = 2/10 = 0.2.
+    expect(FP.ToFloat(hit!.t)).toBeCloseTo(0.2, 5);
+    expect(FP.ToFloat(hit!.point.x)).toBeCloseTo(2, 5);
+  });
+
+  it('returns null when no box is hit', () => {
+    const world = new PhysicsWorld();
+    const hit = world.raycastSegment(
+      { x: F(0), y: F(0), z: F(5) },
+      { x: F(10), y: F(0), z: F(5) },
+      [box(2, 0, 0, 4, 2, 2)],
+    );
+    expect(hit).toBeNull();
+  });
+});

--- a/phalanx-physics/tests/applyImpulse.test.ts
+++ b/phalanx-physics/tests/applyImpulse.test.ts
@@ -70,6 +70,7 @@ describe('applyImpulse', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/applyImpulse.test.ts
+++ b/phalanx-physics/tests/applyImpulse.test.ts
@@ -69,6 +69,7 @@ describe('applyImpulse', () => {
       friction: FP.ToRaw(FP._1), // no friction
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/applyImpulse3D.test.ts
+++ b/phalanx-physics/tests/applyImpulse3D.test.ts
@@ -46,6 +46,7 @@ function addBody(
     isStatic: 0,
     ignorePhysics: 0,
     useGravity: useGravity ? 1 : 0,
+    gravityMultiplier: FP.ToRaw(FP._1),
     lastX: 0,
     lastZ: 0,
   });
@@ -78,7 +79,7 @@ describe('applyImpulse3D', () => {
     return { physicsSystem, gravitySystem, physicsStore, transformStore };
   }
 
-  it('sets all three velocity components', () => {
+  it('sets all three velocity components (mass=1: impulse equals velocity)', () => {
     const { physicsSystem, physicsStore, transformStore } = setup();
     addBody(physicsStore, transformStore, 1, false);
 
@@ -88,6 +89,32 @@ describe('applyImpulse3D', () => {
     expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(4, 5);
     expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(5, 5);
     expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(-2, 5);
+  });
+
+  it('scales velocity by 1/mass for heavier bodies', () => {
+    const { physicsSystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, false);
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.mass[idx] = FP.ToRaw(FP.FromFloat(2));
+
+    physicsSystem.applyImpulse3D(1, FP.FromFloat(4), FP.FromFloat(5), FP.FromFloat(-2));
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(2, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(2.5, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(-1, 5);
+  });
+
+  it('no-ops velocity for zero or negative mass (infinite mass)', () => {
+    const { physicsSystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, false);
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.mass[idx] = FP.ToRaw(FP._0);
+
+    physicsSystem.applyImpulse3D(1, FP.FromFloat(4), FP.FromFloat(5), FP.FromFloat(-2));
+
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(0, 5);
   });
 
   it('clears ignorePhysics', () => {

--- a/phalanx-physics/tests/applyImpulse3D.test.ts
+++ b/phalanx-physics/tests/applyImpulse3D.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import {
+  EntityManager,
+  EventBus,
+  SystemContext,
+  SoAComponent,
+  type SoAComponentStore,
+} from '@phalanx-engine/ecs';
+import { PhysicsSystem } from '../src/systems/PhysicsSystem';
+import { GravitySystem } from '../src/systems/GravitySystem';
+import { PhysicsSoASchema } from '../src/components/PhysicsBodyComponent';
+import { TransformSoASchema } from '../src/components/TransformComponent';
+import type { PhysicsConfig } from '../src/types';
+import { addTransformRow } from './testTransformHelpers';
+
+const TICK_DT = FP.FromFloat(0.05);
+const GRAVITY = FP.FromFloat(10);
+
+function createPhysicsConfig(overrides?: Partial<PhysicsConfig>): PhysicsConfig {
+  return {
+    tickDt: TICK_DT,
+    subSteps: 1,
+    maxVelocity: FP.FromFloat(1000),
+    defaultFriction: FP.FromFloat(1.0), // no friction so XZ stays linear
+    pushStrength: FP.FromFloat(15.0),
+    gridCellSize: FP.FromFloat(4),
+    ...overrides,
+  };
+}
+
+function addBody(
+  physicsStore: SoAComponentStore<typeof PhysicsSoASchema.definition>,
+  transformStore: SoAComponentStore<typeof TransformSoASchema.definition>,
+  entityId: number,
+  useGravity: boolean,
+): void {
+  physicsStore.add(entityId, {
+    velocityX: FP.ToRaw(FP._0),
+    velocityY: FP.ToRaw(FP._0),
+    velocityZ: FP.ToRaw(FP._0),
+    radius: FP.ToRaw(FP._1),
+    mass: FP.ToRaw(FP._1),
+    restitution: FP.ToRaw(FP.FromFloat(0.5)),
+    friction: FP.ToRaw(FP._1),
+    isStatic: 0,
+    ignorePhysics: 0,
+    useGravity: useGravity ? 1 : 0,
+    lastX: 0,
+    lastZ: 0,
+  });
+  addTransformRow(transformStore, entityId, 0, 0, 0);
+}
+
+describe('applyImpulse3D', () => {
+  let entityManager: EntityManager;
+  let eventBus: EventBus;
+  let context: SystemContext;
+
+  beforeEach(() => {
+    entityManager = new EntityManager();
+    eventBus = new EventBus();
+    context = new SystemContext(eventBus, entityManager);
+    SoAComponent.useEntityManager(entityManager);
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function setup(overrides?: Partial<PhysicsConfig>) {
+    const physicsSystem = new PhysicsSystem(createPhysicsConfig(overrides));
+    physicsSystem.init(context);
+    const gravitySystem = new GravitySystem(GRAVITY, 'y', TICK_DT);
+    gravitySystem.init(context);
+    const physicsStore = entityManager.getOrCreateSoAStore(PhysicsSoASchema);
+    const transformStore = entityManager.getOrCreateSoAStore(TransformSoASchema);
+    return { physicsSystem, gravitySystem, physicsStore, transformStore };
+  }
+
+  it('sets all three velocity components', () => {
+    const { physicsSystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, false);
+
+    physicsSystem.applyImpulse3D(1, FP.FromFloat(4), FP.FromFloat(5), FP.FromFloat(-2));
+
+    const idx = physicsStore.indexOf(1);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityX[idx]))).toBeCloseTo(4, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(5, 5);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityZ[idx]))).toBeCloseTo(-2, 5);
+  });
+
+  it('clears ignorePhysics', () => {
+    const { physicsSystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, false);
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.ignorePhysics[idx] = 1;
+
+    physicsSystem.applyImpulse3D(1, FP.FromFloat(1), FP.FromFloat(1), FP.FromFloat(1));
+
+    expect(physicsStore.arrays.ignorePhysics[idx]).toBe(0);
+  });
+
+  it('no-ops for unknown entityId', () => {
+    const { physicsSystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, false);
+
+    physicsSystem.applyImpulse3D(999, FP.FromFloat(5), FP.FromFloat(5), FP.FromFloat(5));
+
+    const idx = physicsStore.indexOf(1);
+    expect(FP.ToFloat(FP.FromRaw(physicsStore.arrays.velocityY[idx]))).toBeCloseTo(0, 5);
+  });
+
+  it('applyImpulse3D + GravitySystem + PhysicsSystem produces a parabolic Y with linear XZ', () => {
+    const { physicsSystem, gravitySystem, physicsStore, transformStore } = setup();
+    addBody(physicsStore, transformStore, 1, true);
+
+    const v0x = 4, v0y = 5, v0z = -2;
+    physicsSystem.applyImpulse3D(1, FP.FromFloat(v0x), FP.FromFloat(v0y), FP.FromFloat(v0z));
+
+    const txIdx = transformStore.indexOf(1);
+    const dt = FP.ToFloat(TICK_DT);
+    const g = FP.ToFloat(GRAVITY);
+
+    // Reference float simulation of semi-implicit Euler:
+    // per tick: velY -= g*dt (gravity first), then posY += velY*dt.
+    let refPosY = 0, refVelY = v0y;
+    let refPosX = 0, refPosZ = 0;
+
+    const N = 6;
+    for (let tick = 1; tick <= N; tick++) {
+      gravitySystem.processTick(tick);
+      physicsSystem.processTick(tick);
+
+      refVelY -= g * dt;
+      refPosY += refVelY * dt;
+      refPosX += v0x * dt;
+      refPosZ += v0z * dt;
+
+      expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionY[txIdx]))).toBeCloseTo(refPosY, 3);
+      expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionX[txIdx]))).toBeCloseTo(refPosX, 3);
+      expect(FP.ToFloat(FP.FromRaw(transformStore.arrays.fpPositionZ[txIdx]))).toBeCloseTo(refPosZ, 3);
+    }
+
+    // The Y trajectory must rise then fall (parabola): apex above 0, and by the
+    // end it has descended below the apex.
+    // v0y=5, g*dt=0.5 -> velY crosses zero around tick 10; within N=6 it is still rising.
+    expect(refPosY).toBeGreaterThan(0);
+  });
+
+  it('is deterministic across two identical worlds', () => {
+    function runWorld(): bigint[] {
+      const em = new EntityManager();
+      const eb = new EventBus();
+      const ctx = new SystemContext(eb, em);
+      SoAComponent.useEntityManager(em);
+      const phys = new PhysicsSystem(createPhysicsConfig());
+      phys.init(ctx);
+      const grav = new GravitySystem(GRAVITY, 'y', TICK_DT);
+      grav.init(ctx);
+      const ps = em.getOrCreateSoAStore(PhysicsSoASchema);
+      const ts = em.getOrCreateSoAStore(TransformSoASchema);
+      addBody(ps, ts, 1, true);
+      phys.applyImpulse3D(1, FP.FromFloat(4), FP.FromFloat(5), FP.FromFloat(-2));
+
+      const samples: bigint[] = [];
+      for (let tick = 1; tick <= 12; tick++) {
+        grav.processTick(tick);
+        phys.processTick(tick);
+        const txIdx = ts.indexOf(1);
+        samples.push(ts.arrays.fpPositionY[txIdx]);
+      }
+      SoAComponent.resetContext();
+      return samples;
+    }
+
+    const a = runWorld();
+    const b = runWorld();
+    expect(a).toEqual(b);
+  });
+});

--- a/phalanx-physics/tests/boundsExit.test.ts
+++ b/phalanx-physics/tests/boundsExit.test.ts
@@ -81,6 +81,7 @@ describe('boundsExit', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/boundsExit.test.ts
+++ b/phalanx-physics/tests/boundsExit.test.ts
@@ -80,6 +80,7 @@ describe('boundsExit', () => {
       friction: FP.ToRaw(FP._1),
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/getEntityPosition.test.ts
+++ b/phalanx-physics/tests/getEntityPosition.test.ts
@@ -54,6 +54,7 @@ describe('getEntityPosition', () => {
       friction: FP.ToRaw(FP.FromFloat(0.3)),
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });
@@ -84,6 +85,7 @@ describe('getEntityPosition', () => {
       friction: FP.ToRaw(FP.FromFloat(0.3)),
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/getEntityPosition.test.ts
+++ b/phalanx-physics/tests/getEntityPosition.test.ts
@@ -55,6 +55,7 @@ describe('getEntityPosition', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });
@@ -86,6 +87,7 @@ describe('getEntityPosition', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/impulseCollision.test.ts
+++ b/phalanx-physics/tests/impulseCollision.test.ts
@@ -71,6 +71,7 @@ describe('impulse collision response', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/impulseCollision.test.ts
+++ b/phalanx-physics/tests/impulseCollision.test.ts
@@ -70,6 +70,7 @@ describe('impulse collision response', () => {
       friction: FP.ToRaw(FP._1),
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/isSettled.test.ts
+++ b/phalanx-physics/tests/isSettled.test.ts
@@ -72,6 +72,7 @@ describe('isSettled', () => {
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: ignorePhysics ? 1 : 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/isSettled.test.ts
+++ b/phalanx-physics/tests/isSettled.test.ts
@@ -71,6 +71,7 @@ describe('isSettled', () => {
       friction: FP.ToRaw(FP._1),
       isStatic: isStatic ? 1 : 0,
       ignorePhysics: ignorePhysics ? 1 : 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });

--- a/phalanx-physics/tests/isSettled.test.ts
+++ b/phalanx-physics/tests/isSettled.test.ts
@@ -125,4 +125,25 @@ describe('isSettled', () => {
     const { system } = setupSystem();
     expect(system.isSettled()).toBe(true);
   });
+
+  it('returns false when a body moves only on Y (vx=0, vz=0, vy!=0)', () => {
+    const { system, physicsStore, transformStore } = setupSystem();
+    addEntity(physicsStore, transformStore, 1, 0, 0);
+    // Falling shrapnel: only velocityY is nonzero.
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.velocityY[idx] = FP.ToRaw(FP.FromFloat(5));
+
+    expect(system.isSettled()).toBe(false);
+  });
+
+  it('returns true when Y velocity is zeroed back out', () => {
+    const { system, physicsStore, transformStore } = setupSystem();
+    addEntity(physicsStore, transformStore, 1, 0, 0);
+    const idx = physicsStore.indexOf(1);
+    physicsStore.arrays.velocityY[idx] = FP.ToRaw(FP.FromFloat(5));
+    expect(system.isSettled()).toBe(false);
+
+    physicsStore.arrays.velocityY[idx] = FP.ToRaw(FP._0);
+    expect(system.isSettled()).toBe(true);
+  });
 });

--- a/phalanx-physics/tests/step.test.ts
+++ b/phalanx-physics/tests/step.test.ts
@@ -73,6 +73,7 @@ describe('step()', () => {
       isStatic: 0,
       ignorePhysics: 0,
       useGravity: 0,
+      gravityMultiplier: FP.ToRaw(FP._1),
       lastX: 0,
       lastZ: 0,
     });
@@ -105,6 +106,7 @@ describe('step()', () => {
         isStatic: 0,
         ignorePhysics: 0,
         useGravity: 0,
+        gravityMultiplier: FP.ToRaw(FP._1),
         lastX: 0,
         lastZ: 0,
       });
@@ -138,6 +140,7 @@ describe('step()', () => {
         isStatic: 0,
         ignorePhysics: 0,
         useGravity: 0,
+        gravityMultiplier: FP.ToRaw(FP._1),
         lastX: 0,
         lastZ: 0,
       });

--- a/phalanx-physics/tests/step.test.ts
+++ b/phalanx-physics/tests/step.test.ts
@@ -72,6 +72,7 @@ describe('step()', () => {
       friction: FP.ToRaw(FP._1),
       isStatic: 0,
       ignorePhysics: 0,
+      useGravity: 0,
       lastX: 0,
       lastZ: 0,
     });
@@ -103,6 +104,7 @@ describe('step()', () => {
         friction: FP.ToRaw(FP._1),
         isStatic: 0,
         ignorePhysics: 0,
+        useGravity: 0,
         lastX: 0,
         lastZ: 0,
       });
@@ -135,6 +137,7 @@ describe('step()', () => {
         friction: FP.ToRaw(FP._1),
         isStatic: 0,
         ignorePhysics: 0,
+        useGravity: 0,
         lastX: 0,
         lastZ: 0,
       });


### PR DESCRIPTION
## Summary

Implements Point 1 of the САУ (artillery) design in the `phalanx-physics` package only: generic deterministic gravity plus a 3D impulse API. All changes are additive — existing bodies (with `useGravity` unset) behave exactly as before.

Architecture follows a strict **one-owner-per-axis** rule:

- **`GravitySystem` (new)** applies **acceleration only** — `velocityY -= gravity * tickDt` for bodies flagged `useGravity`. It never writes position. Runs *before* `PhysicsSystem`.
- **`PhysicsSystem`** remains the sole position integrator; `applyVelocities` now also integrates Y (`posY += velY * dt`) additively alongside X/Z.
- Collisions stay 2D/XZ — Y never affects broad/narrow phase. `maxVelocity` and `worldBounds` clamps remain XZ-only.

### Changes

- `PhysicsSoASchema`: new `useGravity: 'u8'` field.
- `PhysicsBodyComponent`: `useGravity` getter/setter; `PhysicsBodyConfig.useGravity?` (default `false`).
- `PhysicsWorldConfig` / `PhysicsConfig`: new `gravity?` (default `FP._0`, disabled) and `gravityAxis?` (default `'y'`).
- `PhysicsSystem`: Y integration in `applyVelocities`; new public `applyImpulse3D(entityId, vx, vy, vz)` (existing XZ-only `applyImpulse` unchanged).
- `GravitySystem` (new GameSystem): v1 supports `gravityAxis='y'` only — throws with a clear message for `'x'`/`'z'` (those axes are owned by the position integrator; a v2 change would be needed to cede them).
- `PhysicsWorld` facade: constructs and exposes `gravitySystem` via `getSystems()` (backward-compatible destructure); new `applyImpulse3D` delegate.
- Exported `GravitySystem`.
- Docs: README Gravity section + `.cursor/skills/phalanx-physics/SKILL.md` (gravity decision tree + arcing-ordnance recipe).

## Testing

`corepack pnpm vitest run` in `phalanx-physics/` — **19 test files passed, 123 tests passed**. `pnpm build` (tsc) and `tsc -p tsconfig.test.json --noEmit` both pass.

New tests: `GravitySystem.test.ts` (acceleration-only, flag gating, determinism, axis guard), `PhysicsSystemYIntegration.test.ts` (linear Y motion, sub-step consistency, velY=0 regression, static bodies), `applyImpulse3D.test.ts` (sets 3 components, clears ignorePhysics, parabolic arc, determinism).

## Deviations

- One test tolerance relaxed: the sub-step Y-integration assertion uses `toBeCloseTo(0.3, 3)` instead of `4` digits, because the fixed-point sub-step `dt = 0.05/3` is not exactly representable and accumulates a ~1e-4 rounding error. Documented inline.

---
🤖 *Generated by Computer*