### PR TITLE
Add swept-segment (raycast) collision query to phalanx-physics

### DIFF
--- a/.cursor/skills/phalanx-physics/SKILL.md
+++ b/.cursor/skills/phalanx-physics/SKILL.md
@@ -19,6 +19,7 @@ Use this skill when the user asks to:
 - Implement deterministic collision resolution for lockstep multiplayer
 - Add game-specific collision filtering (e.g., team-based rules)
 - Query entities by spatial proximity (range queries)
+- Raycast / swept-segment a fast-moving projectile against static 3D obstacles
 - Wire physics systems into a GameWorld tick pipeline
 - Set up tick-to-frame interpolation for rendering
 
@@ -393,6 +394,33 @@ const manifold = NarrowPhase.circleVsCircle(
 
 Returns `CollisionManifold | null`: `{ entityA, entityB, normalX, normalZ, penetration }`.
 
+### Swept-segment raycast — segmentVsAABB / PhysicsWorld.raycastSegment
+
+```typescript
+const hit = segmentVsAABB(prev, cur, box);            // pure math, single box
+const nearest = world.raycastSegment(prev, cur, boxes); // nearest of many boxes
+```
+
+Returns `RayHit | null`: `{ t, point: {x,y,z}, normal: {x,y,z} }`, where `t ∈ [0,1]`
+(0 at `prev`, 1 at `cur`), `point = lerp(prev, cur, t)`, and `normal` is the outward
+entry-face normal (±X/±Y/±Z). Segment-starts-inside → `{ t: 0, point: prev, normal:
+nearest face }`. All-fixed-point slab method; degenerate/parallel/zero-length inputs
+are deterministic (no NaN, no divide-by-zero).
+
+**Which collision query do I reach for?**
+
+- Two round units overlapping on the ground (XZ)? → `NarrowPhase.circleVsCircle`
+  (this is what `PhysicsSystem` runs automatically).
+- A fast-moving projectile / shrapnel / shell that could tunnel through a static
+  building or cover in one tick, and you need the impact point + face normal? →
+  `segmentVsAABB` (one box) or `PhysicsWorld.raycastSegment` (caller-supplied box
+  list). Generic math only — the game owns "what is a building / ground" and what
+  happens on impact.
+
+**v1 limitations:** linear scan over caller-supplied boxes (no broad-phase for
+raycasts), no ECS collider component, unit-vs-unit stays 2D/XZ. **v2 path:**
+`BoxColliderComponent` + grid-accelerated raycast + full 3D body-vs-body.
+
 ## Exports from phalanx-physics
 
 ```typescript
@@ -410,8 +438,8 @@ import {
 import type { PhysicsBodyConfig } from '@phalanx-engine/physics';
 
 // Collision primitives
-import { SpatialHashGrid, NarrowPhase } from '@phalanx-engine/physics';
-import type { CollisionManifold } from '@phalanx-engine/physics';
+import { SpatialHashGrid, NarrowPhase, segmentVsAABB } from '@phalanx-engine/physics';
+import type { CollisionManifold, RayHit, Vec3FP, AABB } from '@phalanx-engine/physics';
 
 // Systems
 import { PhysicsSystem, InterpolationSystem } from '@phalanx-engine/physics';

--- a/phalanx-physics/README.md
+++ b/phalanx-physics/README.md
@@ -280,6 +280,9 @@ class PhysicsWorld {
   getEntityPosition(entityId: number): { x: FixedPoint; z: FixedPoint } | undefined;
   getInterpolatedTransform(entityId: number): InterpolatedTransformSample | undefined;
 
+  // Swept-segment (raycast) query
+  raycastSegment(prev: Vec3FP, cur: Vec3FP, boxes: ReadonlyArray<AABB>): RayHit | null;
+
   // Cleanup
   dispose(): void;
 }
@@ -293,6 +296,48 @@ class PhysicsWorld {
 - **`isSettled(threshold?)`** — Pure query: `true` when all non-static, non-ignored bodies are below velocity threshold (default from config, falling back to `FP.FromFloat(0.01)`).
 - **`onBoundsExit(callback)`** — Subscribe to `BOUNDS_EXIT` events (requires `ejectOnBoundsExit: true`).
 - **`setCollisionFilter(filter)`** — Inject a per-pair predicate. Return `false` to skip collision resolution for that pair.
+- **`raycastSegment(prev, cur, boxes)`** — See [Raycast / swept-segment queries](#raycast--swept-segment-queries).
+
+## Raycast / swept-segment queries
+
+A minimal, generic swept-segment (raycast) query for **fast-moving ordnance vs
+static 3D obstacles** — e.g. artillery shrapnel / a shell / a projectile moves
+from `prev` to `cur` in one tick and you need the **impact point + face normal**
+against a building or piece of cover.
+
+```typescript
+import { segmentVsAABB, type RayHit, type Vec3FP, type AABB } from '@phalanx-engine/physics';
+
+// Pure math query against a single box.
+function segmentVsAABB(prev: Vec3FP, cur: Vec3FP, box: AABB): RayHit | null;
+
+interface RayHit {
+  t: FixedPoint;                         // parametric hit in [0, 1] (0 at prev, 1 at cur)
+  point: { x: FixedPoint; y: FixedPoint; z: FixedPoint };  // = lerp(prev, cur, t)
+  normal: { x: FixedPoint; y: FixedPoint; z: FixedPoint }; // outward entry-face normal (±X/±Y/±Z)
+}
+```
+
+- **`segmentVsAABB(prev, cur, box)`** — Slab method, evaluated entirely in
+  fixed-point. Returns the entry `RayHit` (smallest `t` in `[0, 1]`) or `null`
+  if the segment misses the box within that range. `normal` is the outward face
+  normal of the entry slab (a ±X/±Y/±Z unit vector).
+- **`PhysicsWorld.raycastSegment(prev, cur, boxes)`** — Convenience facade that
+  linearly scans a **caller-supplied** list of boxes and returns the nearest hit
+  (smallest `t`), or `null`. Pure query, no side effects.
+
+**Conventions & degenerate cases (deterministic, no NaN / divide-by-zero):**
+
+- Segment starting **inside** the box → `{ t: 0, point: prev, normal: <nearest face normal> }`.
+- Zero-length segment (`prev == cur`) → `null` when outside, inside-hit (`t = 0`) when inside.
+- Segment parallel to a slab → handled without dividing by a zero direction component.
+
+**v1 limitations:** linear scan over caller-supplied boxes (no broad-phase / grid
+acceleration for raycasts), no ECS component, and the unit-vs-unit collision
+pipeline remains 2D/XZ circle-based — this query does not touch it.
+
+**v2 path:** a `BoxColliderComponent`, grid-accelerated raycasts (reuse
+`SpatialHashGrid` for broad-phase), and full 3D body-vs-body collision.
 
 ### `PhysicsWorldConfig`
 

--- a/phalanx-physics/src/PhysicsWorld.ts
+++ b/phalanx-physics/src/PhysicsWorld.ts
@@ -4,6 +4,8 @@ import { PhysicsSystem } from './systems/PhysicsSystem';
 import { InterpolationSystem } from './systems/InterpolationSystem';
 import type { InterpolatedTransformSample } from './systems/InterpolationSystem';
 import { SpatialHashGrid } from './collision/SpatialHashGrid';
+import { segmentVsAABB } from './collision/Raycast';
+import type { RayHit, Vec3FP, AABB } from './collision/Raycast';
 import { PhysicsEvents } from './events';
 import type { PhysicsWorldConfig } from './PhysicsWorldConfig';
 import type { FixedPoint } from '@phalanx-engine/math';
@@ -158,6 +160,29 @@ export class PhysicsWorld {
    */
   public getInterpolatedTransform(entityId: number): InterpolatedTransformSample | undefined {
     return this.interpolationSystem.getInterpolatedTransform(entityId);
+  }
+
+  /**
+   * Swept-segment (raycast) query against a caller-supplied list of static AABBs.
+   *
+   * Scans every box and returns the nearest hit along the segment (smallest `t`
+   * in [0, 1]), or `null` if none intersect. Pure query with no side effects —
+   * intended for fast-moving ordnance vs static obstacles (impact point + normal).
+   * The caller owns box construction and lifetime; there is no broad-phase in v1.
+   */
+  public raycastSegment(
+    prev: Vec3FP,
+    cur: Vec3FP,
+    boxes: ReadonlyArray<AABB>
+  ): RayHit | null {
+    let nearest: RayHit | null = null;
+    for (const box of boxes) {
+      const hit = segmentVsAABB(prev, cur, box);
+      if (hit !== null && (nearest === null || FP.Lt(hit.t, nearest.t))) {
+        nearest = hit;
+      }
+    }
+    return nearest;
   }
 
   /** Clean up all subscriptions and system resources */

--- a/phalanx-physics/src/collision/Raycast.ts
+++ b/phalanx-physics/src/collision/Raycast.ts
@@ -1,0 +1,185 @@
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+
+/** A 3D point / vector in fixed-point space. */
+export interface Vec3FP {
+  x: FixedPoint;
+  y: FixedPoint;
+  z: FixedPoint;
+}
+
+/** An axis-aligned bounding box in fixed-point space. */
+export interface AABB {
+  minX: FixedPoint;
+  minY: FixedPoint;
+  minZ: FixedPoint;
+  maxX: FixedPoint;
+  maxY: FixedPoint;
+  maxZ: FixedPoint;
+}
+
+/**
+ * Result of a swept-segment (raycast) query against an AABB.
+ */
+export interface RayHit {
+  /** Parametric hit position along the segment, in [0, 1] (0 at `prev`, 1 at `cur`). */
+  t: FixedPoint;
+  /** World-space impact point = lerp(prev, cur, t). */
+  point: Vec3FP;
+  /** Outward face normal at the impact point (one of ±X / ±Y / ±Z unit vectors). */
+  normal: Vec3FP;
+}
+
+const NEG_1 = FP.Neg(FP._1);
+
+/** Unit outward normals per face. */
+const NORMAL_NEG_X: Vec3FP = { x: NEG_1, y: FP._0, z: FP._0 };
+const NORMAL_POS_X: Vec3FP = { x: FP._1, y: FP._0, z: FP._0 };
+const NORMAL_NEG_Y: Vec3FP = { x: FP._0, y: NEG_1, z: FP._0 };
+const NORMAL_POS_Y: Vec3FP = { x: FP._0, y: FP._1, z: FP._0 };
+const NORMAL_NEG_Z: Vec3FP = { x: FP._0, y: FP._0, z: NEG_1 };
+const NORMAL_POS_Z: Vec3FP = { x: FP._0, y: FP._0, z: FP._1 };
+
+/** Linear interpolation of a point along the segment. */
+function lerpPoint(prev: Vec3FP, cur: Vec3FP, t: FixedPoint): Vec3FP {
+  return {
+    x: FP.Lerp(prev.x, cur.x, t),
+    y: FP.Lerp(prev.y, cur.y, t),
+    z: FP.Lerp(prev.z, cur.z, t),
+  };
+}
+
+/** Per-axis slab intersection result. */
+interface SlabResult {
+  low: FixedPoint;
+  high: FixedPoint;
+  /** Outward normal of the face crossed at `low` (the entry face for this axis). */
+  lowNormal: Vec3FP;
+}
+
+/**
+ * Intersect the segment against a single slab [min, max] on one axis.
+ *
+ * Returns the [low, high] parametric interval plus the outward normal of the
+ * entry face, or `null` if the segment is parallel to the slab and lies outside
+ * it (never enters). A `null` return means "no intersection" for the whole box.
+ *
+ * `negNormal` / `posNormal` are the outward normals of the min-face and max-face.
+ */
+function intersectSlab(
+  origin: FixedPoint,
+  delta: FixedPoint,
+  min: FixedPoint,
+  max: FixedPoint,
+  negNormal: Vec3FP,
+  posNormal: Vec3FP
+): SlabResult | 'parallel-inside' | null {
+  if (FP.Eq(delta, FP._0)) {
+    // Segment is parallel to this slab: it can only intersect the box if its
+    // origin already lies within the slab. Otherwise there is no intersection.
+    if (FP.Lt(origin, min) || FP.Gt(origin, max)) {
+      return null;
+    }
+    return 'parallel-inside';
+  }
+
+  // Guard against division by zero handled above; safe to divide here.
+  const tAtMin = FP.Div(FP.Sub(min, origin), delta);
+  const tAtMax = FP.Div(FP.Sub(max, origin), delta);
+
+  if (FP.Gt(delta, FP._0)) {
+    // Moving in +axis: enters through the min face, exits through the max face.
+    return { low: tAtMin, high: tAtMax, lowNormal: negNormal };
+  }
+  // Moving in -axis: enters through the max face, exits through the min face.
+  return { low: tAtMax, high: tAtMin, lowNormal: posNormal };
+}
+
+/** Find the outward normal of the box face nearest to a point known to be inside. */
+function nearestFaceNormal(point: Vec3FP, box: AABB): Vec3FP {
+  let bestDist = FP.Sub(point.x, box.minX);
+  let bestNormal = NORMAL_NEG_X;
+
+  const consider = (dist: FixedPoint, normal: Vec3FP): void => {
+    if (FP.Lt(dist, bestDist)) {
+      bestDist = dist;
+      bestNormal = normal;
+    }
+  };
+
+  consider(FP.Sub(box.maxX, point.x), NORMAL_POS_X);
+  consider(FP.Sub(point.y, box.minY), NORMAL_NEG_Y);
+  consider(FP.Sub(box.maxY, point.y), NORMAL_POS_Y);
+  consider(FP.Sub(point.z, box.minZ), NORMAL_NEG_Z);
+  consider(FP.Sub(box.maxZ, point.z), NORMAL_POS_Z);
+
+  return bestNormal;
+}
+
+/**
+ * Swept-segment (raycast) vs axis-aligned bounding box using the slab method,
+ * evaluated entirely in fixed-point.
+ *
+ * The segment runs from `prev` (t = 0) to `cur` (t = 1). Returns the entry
+ * `RayHit` with the smallest `t` in [0, 1], or `null` if the segment does not
+ * intersect the box within that range.
+ *
+ * Conventions:
+ * - `normal` is the outward face normal of the entry slab (a ±X/±Y/±Z unit vector).
+ * - If the segment starts inside the box, returns `{ t: FP._0, point: prev,
+ *   normal: <nearest face normal> }`.
+ * - A zero-length segment (`prev == cur`) returns `null` when outside the box
+ *   and the inside-convention hit (t = 0) when inside.
+ * - Degenerate segments parallel to a slab are handled without division by zero
+ *   and resolve deterministically (hit or `null`, never NaN).
+ */
+export function segmentVsAABB(prev: Vec3FP, cur: Vec3FP, box: AABB): RayHit | null {
+  const dx = FP.Sub(cur.x, prev.x);
+  const dy = FP.Sub(cur.y, prev.y);
+  const dz = FP.Sub(cur.z, prev.z);
+
+  const slabs = [
+    intersectSlab(prev.x, dx, box.minX, box.maxX, NORMAL_NEG_X, NORMAL_POS_X),
+    intersectSlab(prev.y, dy, box.minY, box.maxY, NORMAL_NEG_Y, NORMAL_POS_Y),
+    intersectSlab(prev.z, dz, box.minZ, box.maxZ, NORMAL_NEG_Z, NORMAL_POS_Z),
+  ];
+
+  let tEnter: FixedPoint | null = null;
+  let tExit: FixedPoint | null = null;
+  let entryNormal: Vec3FP = NORMAL_POS_X;
+
+  for (const slab of slabs) {
+    if (slab === null) {
+      // Parallel to a slab and outside it: no intersection.
+      return null;
+    }
+    if (slab === 'parallel-inside') {
+      // Axis imposes no parametric bound; only the outside check mattered.
+      continue;
+    }
+    if (tEnter === null || FP.Gt(slab.low, tEnter)) {
+      tEnter = slab.low;
+      entryNormal = slab.lowNormal;
+    }
+    if (tExit === null || FP.Lt(slab.high, tExit)) {
+      tExit = slab.high;
+    }
+  }
+
+  // All three axes were parallel-inside: the (possibly zero-length) segment lies
+  // within every slab, i.e. entirely inside the box. Report the inside hit.
+  if (tEnter === null || tExit === null) {
+    return { t: FP._0, point: prev, normal: nearestFaceNormal(prev, box) };
+  }
+
+  // Slabs do not overlap, or the overlap falls entirely outside the segment.
+  if (FP.Gt(tEnter, tExit) || FP.Lt(tExit, FP._0) || FP.Gt(tEnter, FP._1)) {
+    return null;
+  }
+
+  // Entry is behind `prev`: the segment starts inside the box.
+  if (FP.Lt(tEnter, FP._0)) {
+    return { t: FP._0, point: prev, normal: nearestFaceNormal(prev, box) };
+  }
+
+  return { t: tEnter, point: lerpPoint(prev, cur, tEnter), normal: entryNormal };
+}

--- a/phalanx-physics/src/collision/index.ts
+++ b/phalanx-physics/src/collision/index.ts
@@ -1,3 +1,5 @@
 export type { CollisionManifold } from './CollisionManifold';
 export { SpatialHashGrid } from './SpatialHashGrid';
 export { NarrowPhase } from './NarrowPhase';
+export { segmentVsAABB } from './Raycast';
+export type { RayHit, Vec3FP, AABB } from './Raycast';

--- a/phalanx-physics/src/index.ts
+++ b/phalanx-physics/src/index.ts
@@ -15,6 +15,8 @@ export type { PhysicsBodyConfig } from './types';
 export { SpatialHashGrid } from './collision/SpatialHashGrid';
 export { NarrowPhase } from './collision/NarrowPhase';
 export type { CollisionManifold } from './collision/CollisionManifold';
+export { segmentVsAABB } from './collision/Raycast';
+export type { RayHit, Vec3FP, AABB } from './collision/Raycast';
 
 // Systems
 export { PhysicsSystem, InterpolationSystem } from './systems';

--- a/phalanx-physics/tests/Raycast.test.ts
+++ b/phalanx-physics/tests/Raycast.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { FP } from '@phalanx-engine/math';
+import { segmentVsAABB } from '../src/collision/Raycast';
+import type { Vec3FP, AABB } from '../src/collision/Raycast';
+import { PhysicsWorld } from '../src/PhysicsWorld';
+
+const v = (x: number, y: number, z: number): Vec3FP => ({
+  x: FP.FromFloat(x),
+  y: FP.FromFloat(y),
+  z: FP.FromFloat(z),
+});
+
+/** Unit box centered at the origin: [-1, 1] on every axis. */
+const unitBox: AABB = {
+  minX: FP.FromFloat(-1),
+  minY: FP.FromFloat(-1),
+  minZ: FP.FromFloat(-1),
+  maxX: FP.FromFloat(1),
+  maxY: FP.FromFloat(1),
+  maxZ: FP.FromFloat(1),
+};
+
+const near = (a: number, b: number, tol = 1e-3): boolean => Math.abs(a - b) <= tol;
+
+describe('segmentVsAABB', () => {
+  it('hits the +X face from outside with normal (1,0,0)', () => {
+    // Travelling in -X toward the box, entering through the +X (max-X) face.
+    const hit = segmentVsAABB(v(3, 0, 0), v(-3, 0, 0), unitBox);
+    expect(hit).not.toBeNull();
+    expect(near(FP.ToFloat(hit!.normal.x), 1)).toBe(true);
+    expect(near(FP.ToFloat(hit!.normal.y), 0)).toBe(true);
+    expect(near(FP.ToFloat(hit!.normal.z), 0)).toBe(true);
+    // Entry at x = 1 → t = (3 - 1) / 6 = 1/3.
+    expect(near(FP.ToFloat(hit!.t), 1 / 3)).toBe(true);
+    expect(FP.Gt(hit!.t, FP._0)).toBe(true);
+    expect(FP.Lt(hit!.t, FP._1)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.x), 1)).toBe(true);
+  });
+
+  it('hits the +Y (top) face when entering from above with normal (0,1,0)', () => {
+    const hit = segmentVsAABB(v(0, 3, 0), v(0, -3, 0), unitBox);
+    expect(hit).not.toBeNull();
+    expect(near(FP.ToFloat(hit!.normal.x), 0)).toBe(true);
+    expect(near(FP.ToFloat(hit!.normal.y), 1)).toBe(true);
+    expect(near(FP.ToFloat(hit!.normal.z), 0)).toBe(true);
+    // Impact point lies on the top face (y = 1).
+    expect(near(FP.ToFloat(hit!.point.y), 1)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.x), 0)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.z), 0)).toBe(true);
+  });
+
+  it('returns null when the segment passes outside the box', () => {
+    // Parallel to X at y = 5, well above the box.
+    const hit = segmentVsAABB(v(-5, 5, 0), v(5, 5, 0), unitBox);
+    expect(hit).toBeNull();
+  });
+
+  it('returns t=0 and point=prev when the segment starts inside the box', () => {
+    const prev = v(0, 0, 0);
+    const hit = segmentVsAABB(prev, v(5, 0, 0), unitBox);
+    expect(hit).not.toBeNull();
+    expect(FP.Eq(hit!.t, FP._0)).toBe(true);
+    expect(FP.Eq(hit!.point.x, prev.x)).toBe(true);
+    expect(FP.Eq(hit!.point.y, prev.y)).toBe(true);
+    expect(FP.Eq(hit!.point.z, prev.z)).toBe(true);
+  });
+
+  it('produces point == lerp(prev, cur, t)', () => {
+    const prev = v(4, 2, -3);
+    const cur = v(-2, -1, 1);
+    const hit = segmentVsAABB(prev, cur, unitBox);
+    expect(hit).not.toBeNull();
+    const t = FP.ToFloat(hit!.t);
+    const expX = FP.ToFloat(FP.Lerp(prev.x, cur.x, hit!.t));
+    const expY = FP.ToFloat(FP.Lerp(prev.y, cur.y, hit!.t));
+    const expZ = FP.ToFloat(FP.Lerp(prev.z, cur.z, hit!.t));
+    expect(near(FP.ToFloat(hit!.point.x), expX)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.y), expY)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.z), expZ)).toBe(true);
+    expect(t).toBeGreaterThan(0);
+    expect(t).toBeLessThan(1);
+  });
+
+  it('handles a zero-length segment outside the box (null)', () => {
+    const hit = segmentVsAABB(v(5, 5, 5), v(5, 5, 5), unitBox);
+    expect(hit).toBeNull();
+  });
+
+  it('handles a zero-length segment inside the box (t=0)', () => {
+    const prev = v(0, 0, 0);
+    const hit = segmentVsAABB(prev, prev, unitBox);
+    expect(hit).not.toBeNull();
+    expect(FP.Eq(hit!.t, FP._0)).toBe(true);
+    expect(FP.Eq(hit!.point.x, prev.x)).toBe(true);
+  });
+
+  it('resolves a segment parallel to a slab deterministically (no NaN)', () => {
+    // dy = 0, dz = 0; only X varies. Grazes at y = 1 (top plane), outside interior.
+    const hit = segmentVsAABB(v(-5, 1, 0), v(5, 1, 0), unitBox);
+    // Either a deterministic hit or null — never NaN.
+    if (hit !== null) {
+      expect(Number.isNaN(FP.ToFloat(hit.t))).toBe(false);
+      expect(Number.isNaN(FP.ToFloat(hit.point.x))).toBe(false);
+      expect(Number.isNaN(FP.ToFloat(hit.normal.x))).toBe(false);
+    }
+    // Clearly-outside parallel segment must miss.
+    expect(segmentVsAABB(v(-5, 2, 0), v(5, 2, 0), unitBox)).toBeNull();
+  });
+
+  it('is deterministic: identical inputs yield identical results', () => {
+    const a = segmentVsAABB(v(3, 0.25, -0.5), v(-3, 0.25, -0.5), unitBox);
+    const b = segmentVsAABB(v(3, 0.25, -0.5), v(-3, 0.25, -0.5), unitBox);
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(FP.Eq(a!.t, b!.t)).toBe(true);
+    expect(FP.Eq(a!.point.x, b!.point.x)).toBe(true);
+    expect(FP.Eq(a!.point.y, b!.point.y)).toBe(true);
+    expect(FP.Eq(a!.point.z, b!.point.z)).toBe(true);
+    expect(FP.Eq(a!.normal.x, b!.normal.x)).toBe(true);
+    expect(FP.Eq(a!.normal.y, b!.normal.y)).toBe(true);
+    expect(FP.Eq(a!.normal.z, b!.normal.z)).toBe(true);
+  });
+});
+
+describe('PhysicsWorld.raycastSegment', () => {
+  const boxAt = (cx: number): AABB => ({
+    minX: FP.FromFloat(cx - 1),
+    minY: FP.FromFloat(-1),
+    minZ: FP.FromFloat(-1),
+    maxX: FP.FromFloat(cx + 1),
+    maxY: FP.FromFloat(1),
+    maxZ: FP.FromFloat(1),
+  });
+
+  it('returns the nearest box hit (smallest t)', () => {
+    const world = new PhysicsWorld();
+    const farBox = boxAt(10);
+    const nearBox = boxAt(4);
+    const prev = v(0, 0, 0);
+    const cur = v(20, 0, 0);
+
+    const hit = world.raycastSegment(prev, cur, [farBox, nearBox]);
+    expect(hit).not.toBeNull();
+    // Nearer box entry is at x = 3 → t = 3/20 = 0.15.
+    expect(near(FP.ToFloat(hit!.t), 0.15)).toBe(true);
+    expect(near(FP.ToFloat(hit!.point.x), 3)).toBe(true);
+    world.dispose();
+  });
+
+  it('returns null for an empty box list', () => {
+    const world = new PhysicsWorld();
+    const hit = world.raycastSegment(v(0, 0, 0), v(10, 0, 0), []);
+    expect(hit).toBeNull();
+    world.dispose();
+  });
+
+  it('returns null when no box is intersected', () => {
+    const world = new PhysicsWorld();
+    const hit = world.raycastSegment(v(0, 5, 0), v(20, 5, 0), [boxAt(4), boxAt(10)]);
+    expect(hit).toBeNull();
+    world.dispose();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a minimal, generic swept-segment (raycast) collision query to `phalanx-physics` — the foundation for "fast-moving ordnance (artillery shrapnel / shell / projectile) hits a static 3D obstacle (building / cover) and we need the impact point + normal."

This is purely additive: it does **not** touch the existing 2D/XZ circle-vs-circle unit collision pipeline, `PhysicsSystem` integration, or the gravity work in #53.

### What's included

- **`segmentVsAABB(prev, cur, box): RayHit | null`** (`src/collision/Raycast.ts`) — slab method evaluated entirely in fixed-point (`FP.*`). `t ∈ [0,1]` along the segment, `point = lerp(prev, cur, t)`, `normal` = outward entry-face normal (one of ±X/±Y/±Z).
- **`RayHit` / `Vec3FP` / `AABB`** interfaces, exported from both the package root (`src/index.ts`) and the collision barrel (`src/collision/index.ts`).
- **`PhysicsWorld.raycastSegment(prev, cur, boxes): RayHit | null`** — pure query that linearly scans a caller-supplied box list and returns the nearest hit (smallest `t`).
- Docs: new "Raycast / swept-segment queries" section in `phalanx-physics/README.md` and a matching decision-tree note in `.cursor/skills/phalanx-physics/SKILL.md` (use case, v1 limitations, v2 path).

### Conventions & degenerate handling (deterministic, no NaN / divide-by-zero)

- Segment starting **inside** the box → `{ t: 0, point: prev, normal: <nearest face normal> }`.
- Zero-length segment (`prev == cur`) → `null` when outside, inside-hit (`t = 0`) when inside.
- Segment parallel to a slab → handled explicitly without dividing by a zero direction component.

> Note: `FP.Div` by zero **throws** in this version of `@hastom/fixed-point` (verified at runtime), so the slab method guards every division against a zero-direction axis rather than relying on a divide-by-zero-returns-0 convention.

### v1 limitations / v2 path

- **v1:** linear scan over caller-supplied boxes (no broad-phase for raycasts), no ECS collider component; unit-vs-unit stays 2D/XZ.
- **v2:** `BoxColliderComponent` + grid-accelerated raycast + full 3D body-vs-body.

## Testing

- `corepack pnpm vitest run` in `phalanx-physics` → **116 passed** (17 files), including the new `tests/Raycast.test.ts` (12 tests: +X / +Y face hits, miss, starts-inside, `point == lerp` correctness, nearest-box selection, zero-length in/out, parallel-slab determinism, run-to-run determinism, empty-box list).
- `corepack pnpm -r build` (tsc) → math + ecs + physics all build clean.

---
🤖 *Generated by Computer*