### PR TITLE
feat(playground): SAU self-propelled artillery unit (Stage 2)

### DIFF
--- a/abilities-playground/index.html
+++ b/abilities-playground/index.html
@@ -294,6 +294,9 @@
           <button id="unit-btn-plasma-tank" type="button" data-unit-type="plasmaTank">
             Plasma Tank
           </button>
+          <button id="unit-btn-sau" type="button" data-unit-type="sau">
+            SAU
+          </button>
         </div>
       </div>
 

--- a/abilities-playground/src/components/ArtilleryShellComponent.ts
+++ b/abilities-playground/src/components/ArtilleryShellComponent.ts
@@ -1,0 +1,52 @@
+import type { IComponent } from './Component.ts';
+import { ComponentType } from './Component.ts';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import type { FPVector3 as FPVector3Type } from '@phalanx-engine/math';
+import type { TeamId } from './UnitComponents';
+
+/** Deterministic shrapnel spray configuration carried by a shell. */
+export interface ShrapnelConfig {
+  /** Number of fragments to spawn on detonation. */
+  count: number;
+  /** Half-angle (radians) of the upward launch cone. */
+  cone: FixedPoint;
+  /** Launch speed (world units/s) of each fragment. */
+  speed: FixedPoint;
+}
+
+/**
+ * ArtilleryShellComponent — logic-only marker for an in-flight SAU shell.
+ *
+ * The shell is NOT a visible flying projectile: it has no PhysicsBody and no
+ * mesh. It is a delayed-detonation timer that records the snapshotted impact
+ * point and the parameters ArtilleryShellSystem needs to resolve the blast and
+ * spawn shrapnel at `detonateTick`.
+ */
+export class ArtilleryShellComponent implements IComponent {
+  public readonly type = ComponentType.ArtilleryShell;
+
+  /** World-space point where the shell detonates (snapshotted at fire time). */
+  public readonly impactPoint: FPVector3Type = { x: FP._0, y: FP._0, z: FP._0 };
+
+  /** Firing unit (source of the resulting damage effects). */
+  public sourceEntityId = -1;
+  /** Firing unit's team; enemy-only blasts filter against this. */
+  public teamId: TeamId = 0;
+
+  /** Tick at which the shell detonates. */
+  public detonateTick = 0;
+
+  public primaryRadius: FixedPoint = FP._0;
+  public primaryEffectId = 'Effect.Damage.SAU.Primary';
+  public secondaryRadius: FixedPoint = FP._0;
+  public secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+
+  public shrapnelConfig: ShrapnelConfig = {
+    count: 0,
+    cone: FP._0,
+    speed: FP._0,
+  };
+
+  /** One-shot latch so the falling-shadow cue is emitted exactly once. */
+  public shadowEmitted = false;
+}

--- a/abilities-playground/src/components/Component.ts
+++ b/abilities-playground/src/components/Component.ts
@@ -28,6 +28,8 @@ export const ComponentType = createComponentTypeRegistry({
   AutoAttackTimer: 'AutoAttackTimer',
   Missile: 'Missile',
   SupportUnitTargeting: 'SupportUnitTargeting',
+  ArtilleryShell: 'ArtilleryShell',
+  ShrapnelPayload: 'ShrapnelPayload',
 });
 
 (ComponentType as Record<string, symbol>).PhysicsBody =

--- a/abilities-playground/src/components/ShrapnelPayloadComponent.ts
+++ b/abilities-playground/src/components/ShrapnelPayloadComponent.ts
@@ -1,0 +1,31 @@
+import type { IComponent } from './Component.ts';
+import { ComponentType } from './Component.ts';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import type { TeamId } from './UnitComponents';
+
+/**
+ * ShrapnelPayloadComponent — secondary-blast data carried by a flying shrapnel
+ * fragment plus the previous-tick position needed for swept landing detection.
+ *
+ * ShrapnelLandingSystem sweeps prev→cur each tick to find the exact ground
+ * crossing (v1: ground plane only), then applies the secondary AoE from the
+ * original firing unit — resolved even if that unit has since died.
+ */
+export class ShrapnelPayloadComponent implements IComponent {
+  public readonly type = ComponentType.ShrapnelPayload;
+
+  /** Firing unit (source of the secondary damage; may be dead by landing). */
+  public sourceEntityId = -1;
+  public teamId: TeamId = 0;
+
+  public secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+  public secondaryRadius: FixedPoint = FP._0;
+
+  /** Previous-tick world position, for the prev→cur landing sweep. */
+  public prevPosX: FixedPoint = FP._0;
+  public prevPosY: FixedPoint = FP._0;
+  public prevPosZ: FixedPoint = FP._0;
+
+  /** Set true once the fragment has landed and resolved its blast. */
+  public landed = false;
+}

--- a/abilities-playground/src/components/index.ts
+++ b/abilities-playground/src/components/index.ts
@@ -23,3 +23,6 @@ export {
 export type { TeamId } from './UnitComponents';
 export { SpawnPointComponent } from './SpawnPointComponent';
 export { MissileComponent } from './MissileComponent';
+export { ArtilleryShellComponent } from './ArtilleryShellComponent';
+export type { ShrapnelConfig } from './ArtilleryShellComponent';
+export { ShrapnelPayloadComponent } from './ShrapnelPayloadComponent';

--- a/abilities-playground/src/config/abilityDefinitions.ts
+++ b/abilities-playground/src/config/abilityDefinitions.ts
@@ -116,6 +116,40 @@ export const VOLT_COOLDOWN_TAG = 'Cooldown.Ability.VoltAttack';
  */
 export const MISSILE_VOLLEY_COOLDOWN_TAG = 'Cooldown.Ability.MissileVolley';
 
+/**
+ * SAU (self-propelled artillery). A slow, long-range siege unit that lobs a
+ * delayed-detonation shell onto a snapshotted impact point. On detonation it
+ * deals a primary AoE and sprays gravity-affected shrapnel that deals a smaller
+ * secondary AoE where each fragment lands.
+ */
+export const SAU_MAX_HEALTH = 140;
+/** Primary AoE damage dealt to enemies inside {@link SAU_PRIMARY_RADIUS} at detonation. */
+export const SAU_ATTACK_DAMAGE = 45;
+/** Secondary AoE damage dealt where each shrapnel fragment lands. */
+export const SAU_SECONDARY_DAMAGE = 20;
+/** Radius (world units) of the primary blast around the impact point. */
+export const SAU_PRIMARY_RADIUS = 10;
+/** Radius (world units) of each shrapnel fragment's secondary blast. */
+export const SAU_SECONDARY_RADIUS = 5;
+/** Number of shrapnel fragments sprayed on detonation. */
+export const SAU_SHRAPNEL_COUNT = 6;
+/** Attack cooldown in ticks (80 ticks = 4 s @ 20 TPS) — deliberately slow siege cadence. */
+export const SAU_COOLDOWN_TICKS = 80;
+export const SAU_DETECTION_RANGE = 80;
+export const SAU_STOP_RANGE = 70;
+/** Minimum engagement range (world units, XZ): the SAU refuses to fire on enemies inside this dead zone. */
+export const SAU_MIN_ENGAGEMENT_RANGE = 30;
+
+/**
+ * Whether SAU blasts (primary + secondary) hit allied units. Enemy-only by
+ * default; flip to true to enable friendly fire. Named so the intent is explicit
+ * at every call site rather than a bare boolean literal.
+ */
+export const SAU_FRIENDLY_FIRE = false;
+
+/** Tag granted to a SAU while its artillery ability is on cooldown. */
+export const SAU_COOLDOWN_TAG = 'Cooldown.Ability.SAU';
+
 export const combatDefs = defineAbilitySystem({
   attributes: [
     defineAttribute({
@@ -200,6 +234,37 @@ export const combatDefs = defineAbilitySystem({
       durationTicks: VOLT_ATTACK_COOLDOWN_TICKS,
       modifiers: [],
       tagsGranted: [VOLT_COOLDOWN_TAG],
+    }),
+    defineEffect({
+      id: 'Effect.SAU.Cooldown',
+      type: 'Duration',
+      durationTicks: SAU_COOLDOWN_TICKS,
+      modifiers: [],
+      tagsGranted: [SAU_COOLDOWN_TAG],
+    }),
+    defineEffect({
+      id: 'Effect.Damage.SAU.Primary',
+      type: 'Instant',
+      modifiers: [
+        {
+          attributeId: 'Health',
+          op: 'Add',
+          magnitude: FP.FromFloat(-SAU_ATTACK_DAMAGE),
+        },
+      ],
+      cues: ['Cue.SAU.Impact'],
+    }),
+    defineEffect({
+      id: 'Effect.Damage.SAU.Secondary',
+      type: 'Instant',
+      modifiers: [
+        {
+          attributeId: 'Health',
+          op: 'Add',
+          magnitude: FP.FromFloat(-SAU_SECONDARY_DAMAGE),
+        },
+      ],
+      cues: ['Cue.SAU.SecondaryImpact'],
     }),
     defineEffect({
       id: 'Effect.Damage.Volt.Primary',
@@ -329,6 +394,16 @@ export const combatDefs = defineAbilitySystem({
       hookId: 'Hook.Volt.ChainLightning',
       cooldownEffectId: 'Effect.Volt.Cooldown',
       activationBlockedTags: [VOLT_COOLDOWN_TAG],
+    }),
+    defineAbility({
+      id: 'Ability.SAU.Artillery',
+      // Entity target from the caller-supplied lock; the hook snapshots the
+      // target's position into a fixed impact point (no targetEffectIds — all
+      // damage is AoE, applied later by ArtilleryShellSystem/ShrapnelLandingSystem).
+      target: { kind: 'Entity', origin: { kind: 'Caller' } },
+      hookId: 'Hook.SAU.Fire',
+      cooldownEffectId: 'Effect.SAU.Cooldown',
+      activationBlockedTags: [SAU_COOLDOWN_TAG],
     }),
   ],
 });

--- a/abilities-playground/src/config/constants.ts
+++ b/abilities-playground/src/config/constants.ts
@@ -14,6 +14,26 @@ export const PROJECTILE_SPEED = 180;
 /** Radians of Y rotation applied per simulation tick when turning to face a target. */
 export const UNIT_TURN_SPEED_RADIANS_PER_TICK = Math.PI / 15;
 
+/**
+ * SAU (self-propelled artillery) shrapnel physics tuning.
+ *
+ * Gravity in phalanx-physics v1 is GLOBAL (a single PhysicsWorldConfig.gravity
+ * applied by GravitySystem to every body with useGravity=true). Shrapnel is the
+ * only body in the playground that opts into gravity, so we set the world's
+ * global gravity to {@link SAU_SHRAPNEL_GRAVITY} and mark only shrapnel bodies
+ * useGravity — no per-shrapnel gravity is faked. The shrapnel config therefore
+ * carries count/cone/speed only; gravity lives here on the world config.
+ */
+export const SAU_SHRAPNEL_GRAVITY = 30;
+/** Launch speed (world units/s) of each shrapnel fragment along its cone ray. */
+export const SAU_SHRAPNEL_SPEED = 42;
+/** Half-angle (radians) of the upward cone the shrapnel fragments fan out into. */
+export const SAU_SHRAPNEL_CONE = Math.PI / 5;
+/** Ticks between the shell being fired and its detonation (4–6 = 0.2–0.3 s @ 20 TPS). */
+export const SAU_SHELL_DELAY_TICKS = 5;
+/** Ground plane Y (world units) shrapnel fragments land on in v1 (no building AABBs yet). */
+export const SAU_GROUND_Y = 0;
+
 export const physicsConfig = {
   subSteps: 3,
   gridCellSize: 8,
@@ -23,6 +43,8 @@ export const physicsConfig = {
    */
   maxVelocity: Math.max(PROJECTILE_SPEED, 18),
   pushStrength: 12,
+  /** Global downward acceleration applied to useGravity bodies (SAU shrapnel). */
+  gravity: SAU_SHRAPNEL_GRAVITY,
 };
 
 /** Seconds before an active projectile is returned to the pool. */
@@ -108,6 +130,7 @@ export const arenaParams = {
     rocket: '#B6A8FF',
     volt: '#9DB8FF',
     plasmaTank: '#A3C9F9',
+    sau: '#8FA98C',
   } as Record<string, string>,
   team2Palette: {
     sphere: '#FF8A8A',
@@ -116,6 +139,7 @@ export const arenaParams = {
     rocket: '#FFA37A',
     volt: '#FF9E7A',
     plasmaTank: '#FFB08A',
+    sau: '#C9A98F',
   } as Record<string, string>,
   /**
    * Local formation grid dimensions. The grid is centered on each team's spawn line

--- a/abilities-playground/src/core/GameUI.ts
+++ b/abilities-playground/src/core/GameUI.ts
@@ -39,6 +39,7 @@ export class GameUI {
       { id: 'unit-btn-rocket', type: 'rocket', label: 'Rocket' },
       { id: 'unit-btn-volt', type: 'volt', label: 'Volt' },
       { id: 'unit-btn-plasma-tank', type: 'plasmaTank', label: 'Plasma Tank' },
+      { id: 'unit-btn-sau', type: 'sau', label: 'SAU' },
     ];
 
     for (const { id, type, label } of unitButtonIds) {

--- a/abilities-playground/src/core/SimulationContainer.ts
+++ b/abilities-playground/src/core/SimulationContainer.ts
@@ -27,6 +27,7 @@ import {
 } from '../components';
 
 import {
+  ArtilleryShellSystem,
   AttackSystem,
   ChainLightningJumpSystem,
   CubeTargetingSystem,
@@ -39,16 +40,20 @@ import {
   MovementSystem,
   RenderSyncSystem,
   RotationSystem,
+  ShrapnelLandingSystem,
   TargetingSystem,
   VoltAttackSystem,
 } from '../systems';
 import { UnitFactory } from '../units';
 import { ProjectileEntity } from '../entities/Projectile.ts';
 import { MissileEntity } from '../entities/Missile';
+import { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import { ShrapnelEntity } from '../entities/Shrapnel';
 import { autoAttack } from '../hooks/AutoAttack.ts';
 import { missileVolley } from '../hooks/MissileVolley';
 import { voltChainLightning } from '../hooks/VoltChainLightning';
 import { plasmaTankMachineGun } from '../hooks/PlasmaTankMachineGun';
+import { sauArtillery } from '../hooks/SauArtillery';
 import {
   ProjectileDespawnQueueSystem,
   ProjectileCollisionSystem,
@@ -64,6 +69,10 @@ import {
   ChainLightningCue,
   MachineGunFireCue,
   MachineGunImpactCue,
+  SauMuzzleFlashCue,
+  SauImpactCue,
+  SauSecondaryImpactCue,
+  SauFallingShadowCue,
 } from '../cues';
 
 export class SimulationContainer {
@@ -95,6 +104,14 @@ export class SimulationContainer {
             factory: () => new MissileEntity(),
             pool: { initialSize: 30, maxSize: 120 },
           },
+          artilleryShell: {
+            factory: () => new ArtilleryShellEntity(),
+            pool: { initialSize: 12, maxSize: 60 },
+          },
+          shrapnel: {
+            factory: () => new ShrapnelEntity(),
+            pool: { initialSize: 60, maxSize: 300 },
+          },
         },
       },
     });
@@ -105,6 +122,9 @@ export class SimulationContainer {
       tickRate: networkConfig.tickRate,
       maxVelocity: FP.FromFloat(physicsConfig.maxVelocity),
       pushStrength: FP.FromFloat(physicsConfig.pushStrength),
+      // Global gravity (v1): only shrapnel bodies opt in via useGravity, so this
+      // affects nothing else in the playground. See config/constants.ts.
+      gravity: FP.FromFloat(physicsConfig.gravity),
       worldBounds: {
         minX: FP.FromFloat(-arenaParams.width / 2),
         maxX: FP.FromFloat(arenaParams.width / 2),
@@ -133,6 +153,10 @@ export class SimulationContainer {
           new MachineGunFireCue(this.scene),
         'Cue.PlasmaTank.MachineGun.Impact': () =>
           new MachineGunImpactCue(this.scene),
+        'Cue.SAU.MuzzleFlash': () => new SauMuzzleFlashCue(this.scene),
+        'Cue.SAU.Impact': () => new SauImpactCue(this.scene),
+        'Cue.SAU.SecondaryImpact': () => new SauSecondaryImpactCue(this.scene),
+        'Cue.SAU.FallingShadow': () => new SauFallingShadowCue(this.scene),
       },
       hooks: {
         'Hook.AutoAttack': (ctx: AbilityActivationContext) =>
@@ -143,6 +167,8 @@ export class SimulationContainer {
           voltChainLightning(ctx, this.world, this.abilities),
         'Hook.PlasmaTank.MachineGun': (ctx: AbilityActivationContext) =>
           plasmaTankMachineGun(ctx, this.world),
+        'Hook.SAU.Fire': (ctx: AbilityActivationContext) =>
+          sauArtillery(ctx, this.world),
       },
     });
 
@@ -156,6 +182,15 @@ export class SimulationContainer {
       if (statsA && !statsA.alive) return false;
       const statsB = eB.getComponent<StatsComponent>(ComponentType.UnitStats);
       if (statsB && !statsB.alive) return false;
+
+      // Shrapnel is gravity-affected and physics-integrated, but it must not be
+      // pushed around by (or push) units or other fragments — its only job is to
+      // arc and land. Exclude shrapnel↔unit and shrapnel↔shrapnel pairs so the
+      // collision filter (not ignorePhysics) protects it. Ground landing is
+      // resolved geometrically by ShrapnelLandingSystem.
+      const aShrapnel = eA.hasComponent(ComponentType.ShrapnelPayload);
+      const bShrapnel = eB.hasComponent(ComponentType.ShrapnelPayload);
+      if (aShrapnel || bShrapnel) return false;
 
       const aProjectile = eA.hasComponent(ComponentType.Projectile);
       const bProjectile = eB.hasComponent(ComponentType.Projectile);
@@ -185,8 +220,14 @@ export class SimulationContainer {
     this.unitFactory = new UnitFactory(this.scene, this.abilities);
     this.formationSystem = new FormationSystem(this.unitFactory);
 
-    const { physicsSystem, interpolationSystem } =
+    const { physicsSystem, gravitySystem, interpolationSystem } =
       this.physicsWorld.getSystems();
+    // SAU order (documented): AttackSystem → abilities (Hook.SAU.Fire) →
+    // ArtilleryShellSystem → GravitySystem → physicsSystem →
+    // ShrapnelLandingSystem. The shell system spawns shrapnel before gravity +
+    // integration so fragments get their first arc step on their birth tick;
+    // the landing system runs after integration to sweep prev→cur for ground
+    // crossings.
     this.world.registerSystems(
       [
         this.formationSystem,
@@ -199,7 +240,10 @@ export class SimulationContainer {
         new ProjectileMovementSystem(),
         new MissileTargetingSystem(),
         new MissileMovementSystem(),
+        new ArtilleryShellSystem(),
+        gravitySystem,
         physicsSystem,
+        new ShrapnelLandingSystem(),
         new HealingAuraSystem(),
         new ProjectileCollisionSystem(),
         new RotationSystem(),
@@ -265,7 +309,9 @@ export class SimulationContainer {
 
       const isPooled =
         entity.hasComponent(ComponentType.Projectile) ||
-        entity.hasComponent(ComponentType.Missile);
+        entity.hasComponent(ComponentType.Missile) ||
+        entity.hasComponent(ComponentType.ArtilleryShell) ||
+        entity.hasComponent(ComponentType.ShrapnelPayload);
 
       if (pools && isPooled) {
         pools.despawn(entity);

--- a/abilities-playground/src/cues/SauFallingShadowCue.ts
+++ b/abilities-playground/src/cues/SauFallingShadowCue.ts
@@ -1,0 +1,118 @@
+import * as THREE from 'three';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { clamp01 } from './vfxHelpers';
+import { tryGetSourcePoint } from './SauImpactCue';
+
+/**
+ * Duration of the ground warning marker. Emitted a couple of ticks before
+ * detonation, it should read as a brief "incoming" telegraph and then fade as
+ * the shell lands.
+ */
+const DURATION_SECONDS = 0.5;
+const MARKER_RADIUS = 4.5;
+
+/**
+ * SAU falling-shadow VFX: a pulsing red targeting reticle on the ground where
+ * the shell is about to land — an incoming-fire telegraph. Render-only. The
+ * impact point is snapshotted in `onSpawn` from the shell's Transform.
+ */
+export class SauFallingShadowCue extends Cue {
+  private readonly scene: THREE.Scene;
+  private group: THREE.Group | null = null;
+  private ringMaterial: THREE.MeshBasicMaterial | null = null;
+  private discMaterial: THREE.MeshBasicMaterial | null = null;
+  private disc: THREE.Mesh | null = null;
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.group) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+    // Pulse the outline; shrink the inner disc as if the shell is closing in.
+    const pulse = 0.6 + 0.4 * Math.sin(this.elapsed * 24);
+    if (this.ringMaterial) this.ringMaterial.opacity = 0.85 * pulse;
+    if (this.disc && this.discMaterial) {
+      this.disc.scale.setScalar(clamp01(1 - t));
+      this.discMaterial.opacity = 0.5 * (1 - t);
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.group) this.scene.remove(this.group);
+    this.group?.traverse((child) => {
+      if (child instanceof THREE.Mesh) {
+        child.geometry.dispose();
+      }
+    });
+    this.ringMaterial?.dispose();
+    this.discMaterial?.dispose();
+    this.group = null;
+    this.ringMaterial = null;
+    this.discMaterial = null;
+    this.disc = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    this.group = new THREE.Group();
+    this.group.position.set(point.x, point.y + 0.05, point.z);
+    this.group.renderOrder = 9_998;
+
+    this.ringMaterial = new THREE.MeshBasicMaterial({
+      color: 0xff3322,
+      transparent: true,
+      opacity: 0.85,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+    const ring = new THREE.Mesh(
+      new THREE.RingGeometry(MARKER_RADIUS * 0.85, MARKER_RADIUS, 48),
+      this.ringMaterial
+    );
+    ring.rotation.x = -Math.PI / 2;
+    this.group.add(ring);
+
+    this.discMaterial = new THREE.MeshBasicMaterial({
+      color: 0xff5533,
+      transparent: true,
+      opacity: 0.5,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+    });
+    this.disc = new THREE.Mesh(
+      new THREE.CircleGeometry(MARKER_RADIUS * 0.8, 40),
+      this.discMaterial
+    );
+    this.disc.rotation.x = -Math.PI / 2;
+    this.group.add(this.disc);
+
+    this.scene.add(this.group);
+  }
+}

--- a/abilities-playground/src/cues/SauImpactCue.ts
+++ b/abilities-playground/src/cues/SauImpactCue.ts
@@ -1,0 +1,210 @@
+import * as THREE from 'three';
+import { FPVector3 } from '@phalanx-engine/math';
+import type { EntityManager } from '@phalanx-engine/ecs';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { ComponentType, TransformComponent } from '../components';
+import { easeOutCubic, easeOutExpo } from './vfxHelpers';
+
+const DURATION_SECONDS = 0.6;
+const PARTICLE_COUNT = 120;
+const DEBRIS_SPEED = 16;
+/** Ground shockwave ring final radius (world units). */
+const RING_MAX_RADIUS = 9;
+
+/**
+ * SAU primary-impact VFX: a bright ground flash, an expanding shockwave ring,
+ * and an upward debris/smoke burst at the shell impact point. Render-only; the
+ * damage is applied by {@link ArtilleryShellSystem}.
+ *
+ * The impact point is snapshotted in `onSpawn` from the shell's Transform: the
+ * shell is returned to the pool on the detonation tick, so re-reading it later
+ * would be unsafe.
+ */
+export class SauImpactCue extends Cue {
+  private readonly scene: THREE.Scene;
+
+  private debris: THREE.Points | null = null;
+  private debrisGeometry: THREE.BufferGeometry | null = null;
+  private debrisMaterial: THREE.PointsMaterial | null = null;
+  private readonly velocities = new Float32Array(PARTICLE_COUNT * 3);
+
+  private ring: THREE.Mesh | null = null;
+  private ringMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private flash: THREE.Mesh | null = null;
+  private flashMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+
+    if (this.debris && this.debrisMaterial && this.debrisGeometry) {
+      const positions = this.debrisGeometry.getAttribute(
+        'position'
+      ) as THREE.BufferAttribute;
+      for (let i = 0; i < PARTICLE_COUNT; i++) {
+        const ix = i * 3;
+        positions.setXYZ(
+          i,
+          positions.getX(i) + this.velocities[ix] * deltaTimeSeconds,
+          positions.getY(i) + this.velocities[ix + 1] * deltaTimeSeconds,
+          positions.getZ(i) + this.velocities[ix + 2] * deltaTimeSeconds
+        );
+        this.velocities[ix + 1] -= 22 * deltaTimeSeconds;
+      }
+      positions.needsUpdate = true;
+      this.debrisMaterial.opacity = 0.95 * (1 - easeOutCubic(t));
+    }
+
+    if (this.ring && this.ringMaterial) {
+      const r = RING_MAX_RADIUS * easeOutExpo(t);
+      this.ring.scale.setScalar(Math.max(0.001, r));
+      this.ringMaterial.opacity = 0.7 * (1 - t);
+    }
+
+    if (this.flash && this.flashMaterial) {
+      const flashT = Math.min(1, this.elapsed / 0.1);
+      this.flash.scale.setScalar(1 + flashT * 3);
+      this.flashMaterial.opacity = 0.95 * (1 - flashT);
+      if (flashT >= 1) this.flash.visible = false;
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.debris) this.scene.remove(this.debris);
+    if (this.ring) this.scene.remove(this.ring);
+    if (this.flash) this.scene.remove(this.flash);
+    this.debrisGeometry?.dispose();
+    this.debrisMaterial?.dispose();
+    this.ring?.geometry.dispose();
+    this.ringMaterial?.dispose();
+    this.flash?.geometry.dispose();
+    this.flashMaterial?.dispose();
+    this.debris = null;
+    this.debrisGeometry = null;
+    this.debrisMaterial = null;
+    this.ring = null;
+    this.ringMaterial = null;
+    this.flash = null;
+    this.flashMaterial = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    const positions = new Float32Array(PARTICLE_COUNT * 3);
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      let x = 0;
+      let y = 0;
+      let z = 0;
+      do {
+        x = Math.random() * 2 - 1;
+        y = Math.random() * 2 - 1;
+        z = Math.random() * 2 - 1;
+      } while (x * x + y * y + z * z > 1);
+      const len = Math.sqrt(x * x + y * y + z * z) || 1;
+      positions[i * 3] = (x / len) * 0.2;
+      positions[i * 3 + 1] = Math.abs(y / len) * 0.2;
+      positions[i * 3 + 2] = (z / len) * 0.2;
+      const speed = DEBRIS_SPEED * (0.4 + Math.random() * 0.9);
+      this.velocities[i * 3] = (x / len) * speed;
+      this.velocities[i * 3 + 1] = Math.abs(y / len) * speed + 6;
+      this.velocities[i * 3 + 2] = (z / len) * speed;
+    }
+    this.debrisGeometry = new THREE.BufferGeometry();
+    this.debrisGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.debrisMaterial = new THREE.PointsMaterial({
+      color: new THREE.Color(0xff8833),
+      size: 0.9,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.95,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.debris = new THREE.Points(this.debrisGeometry, this.debrisMaterial);
+    this.debris.position.copy(point);
+    this.debris.frustumCulled = false;
+    this.debris.renderOrder = 10_000;
+    this.scene.add(this.debris);
+
+    this.ringMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffc060,
+      transparent: true,
+      opacity: 0.7,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+    });
+    this.ring = new THREE.Mesh(
+      new THREE.RingGeometry(0.85, 1, 40),
+      this.ringMaterial
+    );
+    this.ring.rotation.x = -Math.PI / 2;
+    this.ring.position.set(point.x, point.y + 0.1, point.z);
+    this.ring.renderOrder = 9_999;
+    this.scene.add(this.ring);
+
+    this.flashMaterial = new THREE.MeshBasicMaterial({
+      color: 0xfff0c0,
+      transparent: true,
+      opacity: 0.95,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.flash = new THREE.Mesh(
+      new THREE.SphereGeometry(1, 12, 10),
+      this.flashMaterial
+    );
+    this.flash.position.set(point.x, point.y + 0.5, point.z);
+    this.flash.renderOrder = 10_001;
+    this.scene.add(this.flash);
+  }
+}
+
+/** Read the source entity's Transform world position, or null if unavailable. */
+export function tryGetSourcePoint(
+  entityManager: EntityManager,
+  event: GameplayCueDispatchedEvent
+): THREE.Vector3 | null {
+  const source = entityManager.getEntity(event.sourceEntityId);
+  const transform = source?.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  if (!transform) return null;
+  const p = FPVector3.ToFloat(transform.fpPosition);
+  return new THREE.Vector3(p.x, p.y, p.z);
+}

--- a/abilities-playground/src/cues/SauMuzzleFlashCue.ts
+++ b/abilities-playground/src/cues/SauMuzzleFlashCue.ts
@@ -1,0 +1,203 @@
+import * as THREE from 'three';
+import { FPQuaternion, FPVector3 } from '@phalanx-engine/math';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { ComponentType, TransformComponent } from '../components';
+
+const LIFETIME_SECONDS = 0.18;
+const SPARK_COUNT = 16;
+
+/**
+ * SAU muzzle-flash VFX: a bright additive flash plus a short directional flare
+ * and spark spray at the artillery barrel tip. Like the machine-gun fire cue but
+ * without tracers (the shell is a delayed-detonation logic entity that never
+ * visibly flies). The muzzle world position/orientation is snapshotted in
+ * `onSpawn` from the caster Transform, so the flash stays put even if the unit
+ * rotates or dies afterward.
+ *
+ * The local muzzle offset is expressed in caster-mesh space and must track the
+ * barrel tip built by `createSauBody`.
+ */
+const MUZZLE_LOCAL = { x: 0, y: 2.6, z: 7.8 };
+
+export class SauMuzzleFlashCue extends Cue {
+  private readonly scene: THREE.Scene;
+
+  private group: THREE.Group | null = null;
+  private core: THREE.Mesh | null = null;
+  private halo: THREE.Mesh | null = null;
+  private coreMaterial: THREE.MeshBasicMaterial | null = null;
+  private haloMaterial: THREE.MeshBasicMaterial | null = null;
+
+  private sparks: THREE.Points | null = null;
+  private sparkGeometry: THREE.BufferGeometry | null = null;
+  private sparkMaterial: THREE.PointsMaterial | null = null;
+  private readonly sparkVelocities = new Float32Array(SPARK_COUNT * 3);
+
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const caster = context.entityManager.getEntity(event.sourceEntityId);
+    const transform = caster?.getComponent<TransformComponent>(
+      ComponentType.Transform
+    );
+    if (!transform) {
+      this.done = true;
+      return;
+    }
+
+    const local = FPVector3.FromFloat(
+      MUZZLE_LOCAL.x,
+      MUZZLE_LOCAL.y,
+      MUZZLE_LOCAL.z
+    );
+    const world = FPVector3.ToFloat(
+      FPVector3.Add(
+        transform.fpPosition,
+        FPQuaternion.RotateVector(transform.fpRotation, local)
+      )
+    );
+    const forward = FPVector3.ToFloat(
+      FPQuaternion.RotateVector(
+        transform.fpRotation,
+        FPVector3.FromFloat(0, 0, 1)
+      )
+    );
+    const dir = new THREE.Vector3(forward.x, 0, forward.z);
+    if (dir.lengthSq() < 1e-6) dir.set(0, 0, 1);
+    dir.normalize();
+
+    this.build(new THREE.Vector3(world.x, world.y, world.z), dir);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.group) return;
+    this.elapsed += deltaTimeSeconds;
+    const k = this.elapsed / LIFETIME_SECONDS;
+    if (k >= 1) {
+      this.done = true;
+      return;
+    }
+    const fade = 1 - k;
+    const scale = 0.7 + 1.6 * Math.sin(Math.min(1, k * 1.6) * Math.PI * 0.5);
+    if (this.core && this.coreMaterial) {
+      this.core.scale.setScalar(scale);
+      this.coreMaterial.opacity = fade;
+    }
+    if (this.halo && this.haloMaterial) {
+      this.halo.scale.setScalar(scale * 1.4);
+      this.haloMaterial.opacity = 0.75 * fade;
+    }
+    if (this.sparks && this.sparkMaterial && this.sparkGeometry) {
+      this.sparkMaterial.opacity = fade;
+      const positions = this.sparkGeometry.getAttribute(
+        'position'
+      ) as THREE.BufferAttribute;
+      for (let i = 0; i < SPARK_COUNT; i++) {
+        const ix = i * 3;
+        positions.setXYZ(
+          i,
+          positions.getX(i) + this.sparkVelocities[ix] * deltaTimeSeconds,
+          positions.getY(i) + this.sparkVelocities[ix + 1] * deltaTimeSeconds,
+          positions.getZ(i) + this.sparkVelocities[ix + 2] * deltaTimeSeconds
+        );
+      }
+      positions.needsUpdate = true;
+    }
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.group) this.scene.remove(this.group);
+    this.core?.geometry.dispose();
+    this.halo?.geometry.dispose();
+    this.coreMaterial?.dispose();
+    this.haloMaterial?.dispose();
+    this.sparkGeometry?.dispose();
+    this.sparkMaterial?.dispose();
+    this.group = null;
+    this.core = null;
+    this.halo = null;
+    this.coreMaterial = null;
+    this.haloMaterial = null;
+    this.sparks = null;
+    this.sparkGeometry = null;
+    this.sparkMaterial = null;
+  }
+
+  private build(muzzle: THREE.Vector3, dir: THREE.Vector3): void {
+    this.group = new THREE.Group();
+    this.group.position.copy(muzzle);
+    this.group.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), dir);
+    this.group.renderOrder = 10_000;
+
+    this.haloMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffaa44,
+      transparent: true,
+      opacity: 0.85,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.halo = new THREE.Mesh(
+      new THREE.SphereGeometry(0.7, 10, 8),
+      this.haloMaterial
+    );
+    this.group.add(this.halo);
+
+    this.coreMaterial = new THREE.MeshBasicMaterial({
+      color: 0xfff6d0,
+      transparent: true,
+      opacity: 1,
+      depthWrite: false,
+      depthTest: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.core = new THREE.Mesh(
+      new THREE.SphereGeometry(0.36, 10, 8),
+      this.coreMaterial
+    );
+    this.group.add(this.core);
+
+    this.sparkMaterial = new THREE.PointsMaterial({
+      color: 0xffe8a0,
+      size: 0.5,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 1,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.sparkGeometry = new THREE.BufferGeometry();
+    const positions = new Float32Array(SPARK_COUNT * 3);
+    for (let i = 0; i < SPARK_COUNT; i++) {
+      const angle = (i / SPARK_COUNT) * Math.PI * 2;
+      const spread = 0.35 + (i % 3) * 0.15;
+      this.sparkVelocities[i * 3] = Math.cos(angle) * spread * 4;
+      this.sparkVelocities[i * 3 + 1] = Math.sin(angle) * spread * 3;
+      this.sparkVelocities[i * 3 + 2] = 7 + (i % 4) * 1.5;
+    }
+    this.sparkGeometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.sparks = new THREE.Points(this.sparkGeometry, this.sparkMaterial);
+    this.sparks.frustumCulled = false;
+    this.group.add(this.sparks);
+
+    this.scene.add(this.group);
+  }
+}

--- a/abilities-playground/src/cues/SauSecondaryImpactCue.ts
+++ b/abilities-playground/src/cues/SauSecondaryImpactCue.ts
@@ -1,0 +1,123 @@
+import * as THREE from 'three';
+import { Cue } from '@phalanx-engine/abilities';
+import type {
+  CueContext,
+  GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { easeOutCubic } from './vfxHelpers';
+import { tryGetSourcePoint } from './SauImpactCue';
+
+const DURATION_SECONDS = 0.35;
+const PARTICLE_COUNT = 36;
+const SPARK_SPEED = 9;
+
+/**
+ * SAU secondary-impact VFX: a compact spark burst where a shrapnel fragment
+ * lands. Render-only; damage is applied by {@link ShrapnelLandingSystem}. The
+ * landing point is snapshotted in `onSpawn` from the fragment's Transform (the
+ * fragment is pooled immediately after landing).
+ */
+export class SauSecondaryImpactCue extends Cue {
+  private readonly scene: THREE.Scene;
+  private points: THREE.Points | null = null;
+  private geometry: THREE.BufferGeometry | null = null;
+  private material: THREE.PointsMaterial | null = null;
+  private readonly velocities = new Float32Array(PARTICLE_COUNT * 3);
+  private elapsed = 0;
+  private done = false;
+
+  public constructor(scene: THREE.Scene) {
+    super();
+    this.scene = scene;
+  }
+
+  public onSpawn(event: GameplayCueDispatchedEvent, context: CueContext): void {
+    const point = tryGetSourcePoint(context.entityManager, event);
+    if (!point) {
+      this.done = true;
+      return;
+    }
+    this.build(point);
+  }
+
+  public override update(deltaTimeSeconds: number): void {
+    if (this.done || !this.points || !this.material || !this.geometry) return;
+    this.elapsed += deltaTimeSeconds;
+    const t = this.elapsed / DURATION_SECONDS;
+    if (t >= 1) {
+      this.done = true;
+      return;
+    }
+    const positions = this.geometry.getAttribute(
+      'position'
+    ) as THREE.BufferAttribute;
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      const ix = i * 3;
+      positions.setXYZ(
+        i,
+        positions.getX(i) + this.velocities[ix] * deltaTimeSeconds,
+        positions.getY(i) + this.velocities[ix + 1] * deltaTimeSeconds,
+        positions.getZ(i) + this.velocities[ix + 2] * deltaTimeSeconds
+      );
+      this.velocities[ix + 1] -= 14 * deltaTimeSeconds;
+    }
+    positions.needsUpdate = true;
+    this.material.opacity = 0.9 * (1 - easeOutCubic(t));
+    this.material.size = 0.5 * (1 - t * 0.5);
+  }
+
+  public override isFinished(): boolean {
+    return this.done;
+  }
+
+  public override dispose(): void {
+    if (this.points) this.scene.remove(this.points);
+    this.geometry?.dispose();
+    this.material?.dispose();
+    this.points = null;
+    this.geometry = null;
+    this.material = null;
+  }
+
+  private build(point: THREE.Vector3): void {
+    const positions = new Float32Array(PARTICLE_COUNT * 3);
+    for (let i = 0; i < PARTICLE_COUNT; i++) {
+      let x = 0;
+      let y = 0;
+      let z = 0;
+      do {
+        x = Math.random() * 2 - 1;
+        y = Math.random() * 2 - 1;
+        z = Math.random() * 2 - 1;
+      } while (x * x + y * y + z * z > 1);
+      const len = Math.sqrt(x * x + y * y + z * z) || 1;
+      positions[i * 3] = (x / len) * 0.1;
+      positions[i * 3 + 1] = Math.abs(y / len) * 0.1;
+      positions[i * 3 + 2] = (z / len) * 0.1;
+      const speed = SPARK_SPEED * (0.5 + Math.random() * 0.8);
+      this.velocities[i * 3] = (x / len) * speed;
+      this.velocities[i * 3 + 1] = Math.abs(y / len) * speed + 3;
+      this.velocities[i * 3 + 2] = (z / len) * speed;
+    }
+    this.geometry = new THREE.BufferGeometry();
+    this.geometry.setAttribute(
+      'position',
+      new THREE.BufferAttribute(positions, 3)
+    );
+    this.material = new THREE.PointsMaterial({
+      color: new THREE.Color(0xffd24d),
+      size: 0.5,
+      sizeAttenuation: true,
+      transparent: true,
+      opacity: 0.9,
+      depthTest: false,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+    });
+    this.points = new THREE.Points(this.geometry, this.material);
+    this.points.position.copy(point);
+    this.points.frustumCulled = false;
+    this.points.renderOrder = 10_000;
+    this.scene.add(this.points);
+  }
+}

--- a/abilities-playground/src/cues/index.ts
+++ b/abilities-playground/src/cues/index.ts
@@ -7,3 +7,7 @@ export * from './ChainLightningCue.ts';
 export * from './MachineGunFireCue.ts';
 export * from './MachineGunImpactCue.ts';
 export * from './missileExhaustCue.ts';
+export * from './SauMuzzleFlashCue.ts';
+export * from './SauImpactCue.ts';
+export * from './SauSecondaryImpactCue.ts';
+export * from './SauFallingShadowCue.ts';

--- a/abilities-playground/src/entities/ArtilleryShell.ts
+++ b/abilities-playground/src/entities/ArtilleryShell.ts
@@ -1,0 +1,74 @@
+import { Entity, type IPoolableEntity } from '@phalanx-engine/ecs';
+import type { FixedPoint, FPVector3 as FPVector3Type } from '@phalanx-engine/math';
+import { TransformComponent } from '@phalanx-engine/physics';
+import {
+  ArtilleryShellComponent,
+  type ShrapnelConfig,
+} from '../components/ArtilleryShellComponent';
+import type { TeamId } from '../components';
+
+export interface ArtilleryShellSpawnArgs {
+  impactPoint: FPVector3Type;
+  sourceEntityId: number;
+  teamId: TeamId;
+  detonateTick: number;
+  primaryRadius: FixedPoint;
+  primaryEffectId: string;
+  secondaryRadius: FixedPoint;
+  secondaryEffectId: string;
+  shrapnelConfig: ShrapnelConfig;
+}
+
+/**
+ * ArtilleryShellEntity — pooled, logic-only delayed-detonation marker.
+ *
+ * No PhysicsBody, no mesh: nothing flies. It just carries the snapshotted
+ * impact point and blast parameters until ArtilleryShellSystem detonates it at
+ * `detonateTick`, then it is returned to the pool.
+ */
+export class ArtilleryShellEntity
+  extends Entity
+  implements IPoolableEntity<ArtilleryShellSpawnArgs>
+{
+  private _active = false;
+
+  public get active() {
+    return this._active;
+  }
+
+  public set active(value: boolean) {
+    this._active = value;
+  }
+
+  private readonly shell: ArtilleryShellComponent;
+  // Transform (no PhysicsBody, no mesh) so falling-shadow/impact cues can read
+  // the impact point; the shell never moves and never renders a body.
+  private readonly transform: TransformComponent;
+
+  constructor() {
+    super();
+    this.shell = this.addComponent(new ArtilleryShellComponent());
+    this.transform = this.addComponent(new TransformComponent(this.id));
+  }
+
+  onSpawn(args: ArtilleryShellSpawnArgs): void {
+    this._active = true;
+    this.transform.fpPosition = args.impactPoint;
+    this.shell.impactPoint.x = args.impactPoint.x;
+    this.shell.impactPoint.y = args.impactPoint.y;
+    this.shell.impactPoint.z = args.impactPoint.z;
+    this.shell.sourceEntityId = args.sourceEntityId;
+    this.shell.teamId = args.teamId;
+    this.shell.detonateTick = args.detonateTick;
+    this.shell.primaryRadius = args.primaryRadius;
+    this.shell.primaryEffectId = args.primaryEffectId;
+    this.shell.secondaryRadius = args.secondaryRadius;
+    this.shell.secondaryEffectId = args.secondaryEffectId;
+    this.shell.shrapnelConfig = args.shrapnelConfig;
+    this.shell.shadowEmitted = false;
+  }
+
+  onDespawn(): void {
+    this._active = false;
+  }
+}

--- a/abilities-playground/src/entities/Shrapnel.ts
+++ b/abilities-playground/src/entities/Shrapnel.ts
@@ -1,0 +1,100 @@
+import { Entity, type IPoolableEntity } from '@phalanx-engine/ecs';
+import { FP, FPQuaternion } from '@phalanx-engine/math';
+import type {
+  FixedPoint,
+  FPVector3 as FPVector3Type,
+} from '@phalanx-engine/math';
+import {
+  InterpolationComponent,
+  PhysicsBodyComponent,
+  TransformComponent,
+} from '@phalanx-engine/physics';
+import { TeamComponent } from '../components';
+import type { TeamId } from '../components';
+import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
+
+/** Physics radius of a shrapnel fragment (small; landing is by ground sweep). */
+export const SHRAPNEL_RADIUS = 0.25;
+
+export interface ShrapnelSpawnArgs {
+  fpPosition: FPVector3Type;
+  /** Full 3D launch velocity (world units/s); applied via applyImpulse3D by the caller. */
+  sourceEntityId: number;
+  teamId: TeamId;
+  secondaryEffectId: string;
+  secondaryRadius: FixedPoint;
+}
+
+/**
+ * ShrapnelEntity — pooled gravity-affected fragment sprayed on shell detonation.
+ *
+ * Has a real PhysicsBody with useGravity=true so the global GravitySystem arcs
+ * it back to the ground. friction=FP._1 keeps horizontal drift tight. It is NOT
+ * ignorePhysics — it stays in the pipeline but is excluded from unit/shrapnel
+ * collisions by the collision filter, so it never shoves units around.
+ */
+export class ShrapnelEntity
+  extends Entity
+  implements IPoolableEntity<ShrapnelSpawnArgs>
+{
+  private _active = false;
+
+  public get active() {
+    return this._active;
+  }
+
+  public set active(value: boolean) {
+    this._active = value;
+  }
+
+  private readonly team: TeamComponent;
+  private readonly interpolation: InterpolationComponent;
+  private readonly transform: TransformComponent;
+  private readonly body: PhysicsBodyComponent;
+  private readonly payload: ShrapnelPayloadComponent;
+
+  constructor() {
+    super();
+    this.team = this.addComponent(new TeamComponent(0));
+    this.interpolation = this.addComponent(new InterpolationComponent());
+    this.transform = this.addComponent(new TransformComponent(this.id));
+    this.body = this.addComponent(
+      new PhysicsBodyComponent(this.id, {
+        radius: FP.FromFloat(SHRAPNEL_RADIUS),
+        mass: FP._1,
+        friction: FP._1,
+        restitution: FP._0,
+        useGravity: true,
+      })
+    );
+    this.payload = this.addComponent(new ShrapnelPayloadComponent());
+  }
+
+  onSpawn(args: ShrapnelSpawnArgs): void {
+    this._active = true;
+    this.transform.fpPosition = args.fpPosition;
+    this.transform.fpRotation = FPQuaternion.Identity();
+
+    this.team.teamId = args.teamId;
+    this.payload.sourceEntityId = args.sourceEntityId;
+    this.payload.teamId = args.teamId;
+    this.payload.secondaryEffectId = args.secondaryEffectId;
+    this.payload.secondaryRadius = args.secondaryRadius;
+    this.payload.prevPosX = args.fpPosition.x;
+    this.payload.prevPosY = args.fpPosition.y;
+    this.payload.prevPosZ = args.fpPosition.z;
+    this.payload.landed = false;
+
+    // Fragments spawn with gravity on and velocity zeroed; the caller applies
+    // the cone impulse via PhysicsWorld.applyImpulse3D right after spawn.
+    this.body.useGravity = true;
+    this.body.stopVelocity();
+
+    this.interpolation.capture(args.fpPosition, FPQuaternion.Identity());
+    this.interpolation.snapshot();
+  }
+
+  onDespawn(): void {
+    this._active = false;
+  }
+}

--- a/abilities-playground/src/hooks/SauArtillery.ts
+++ b/abilities-playground/src/hooks/SauArtillery.ts
@@ -1,0 +1,98 @@
+import type { TransformComponent } from '@phalanx-engine/physics';
+import { FP } from '@phalanx-engine/math';
+import {
+  gameplayCueKey,
+  type AbilityActivationContext,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { GameWorld } from '@phalanx-engine/ecs';
+import { ComponentType, TeamComponent } from '../components';
+import { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import {
+  SAU_PRIMARY_RADIUS,
+  SAU_SECONDARY_RADIUS,
+  SAU_SHRAPNEL_COUNT,
+  SAU_MIN_ENGAGEMENT_RANGE,
+} from '../config/abilityDefinitions';
+import {
+  SAU_SHELL_DELAY_TICKS,
+  SAU_SHRAPNEL_CONE,
+  SAU_SHRAPNEL_SPEED,
+} from '../config/constants';
+
+export const SAU_MUZZLE_FLASH_CUE_ID = 'Cue.SAU.MuzzleFlash';
+
+/** Squared minimum engagement range: the SAU ignores enemies closer than this. */
+const MIN_ENGAGE_RANGE_SQ = FP.Mul(
+  FP.FromFloat(SAU_MIN_ENGAGEMENT_RANGE),
+  FP.FromFloat(SAU_MIN_ENGAGEMENT_RANGE)
+);
+
+/**
+ * SAU artillery fire hook.
+ *
+ * Snapshots the current target position into a fixed impact point (so the shell
+ * lands where the target *was* when fired, independent of later movement),
+ * enforces the minimum engagement dead zone, emits the muzzle-flash cue, and
+ * spawns a logic-only {@link ArtilleryShellEntity} that detonates after
+ * {@link SAU_SHELL_DELAY_TICKS}.
+ */
+export const sauArtillery = (
+  ctx: AbilityActivationContext,
+  world: GameWorld
+): void => {
+  const target = world.entityManager.getEntity(ctx.resolvedTargets[0]);
+  const caster = world.entityManager.getEntity(ctx.casterEntityId);
+  if (!target || !caster) return;
+  if (!world.pools) return;
+
+  const targetTransform = target.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  const casterTransform = caster.getComponent<TransformComponent>(
+    ComponentType.Transform
+  );
+  const casterTeam = caster.getComponent<TeamComponent>(ComponentType.Team);
+  if (!targetTransform || !casterTransform || !casterTeam) return;
+
+  const casterPos = casterTransform.fpPosition;
+  const targetPos = targetTransform.fpPosition;
+
+  // Dead zone: refuse to fire on enemies inside the minimum engage range.
+  const dx = FP.Sub(targetPos.x, casterPos.x);
+  const dz = FP.Sub(targetPos.z, casterPos.z);
+  const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+  if (FP.Lt(d2, MIN_ENGAGE_RANGE_SQ)) return;
+
+  // Snapshot the impact point by value — decoupled from later target movement.
+  const impactPoint = {
+    x: targetPos.x,
+    y: targetPos.y,
+    z: targetPos.z,
+  };
+
+  const muzzleEvent: GameplayCueDispatchedEvent = {
+    tick: ctx.tick,
+    cueId: SAU_MUZZLE_FLASH_CUE_ID,
+    sourceEntityId: caster.id,
+    targetEntityId: target.id,
+    phase: 'OnApplied',
+  };
+  world.eventBus.emit(gameplayCueKey(SAU_MUZZLE_FLASH_CUE_ID), muzzleEvent);
+
+  world.pools.spawn<ArtilleryShellEntity>('artilleryShell', {
+    impactPoint,
+    sourceEntityId: caster.id,
+    teamId: casterTeam.teamId,
+    detonateTick: ctx.tick + SAU_SHELL_DELAY_TICKS,
+    primaryRadius: FP.FromFloat(SAU_PRIMARY_RADIUS),
+    primaryEffectId: 'Effect.Damage.SAU.Primary',
+    secondaryRadius: FP.FromFloat(SAU_SECONDARY_RADIUS),
+    secondaryEffectId: 'Effect.Damage.SAU.Secondary',
+    shrapnelConfig: {
+      count: SAU_SHRAPNEL_COUNT,
+      cone: FP.FromFloat(SAU_SHRAPNEL_CONE),
+      speed: FP.FromFloat(SAU_SHRAPNEL_SPEED),
+    },
+  });
+};

--- a/abilities-playground/src/systems/ArtilleryShellSystem.ts
+++ b/abilities-playground/src/systems/ArtilleryShellSystem.ts
@@ -1,0 +1,198 @@
+import { GameSystem } from '@phalanx-engine/ecs';
+import type { AbilitySystem } from '@phalanx-engine/abilities';
+import {
+  gameplayCueKey,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+} from '../components';
+import { ArtilleryShellComponent } from '../components/ArtilleryShellComponent';
+import type { ArtilleryShellEntity } from '../entities/ArtilleryShell';
+import { ShrapnelEntity } from '../entities/Shrapnel';
+import { SAU_FRIENDLY_FIRE } from '../config/abilityDefinitions';
+import { GameRandom } from '../core/GameRandom';
+
+export const SAU_IMPACT_CUE_ID = 'Cue.SAU.Impact';
+export const SAU_FALLING_SHADOW_CUE_ID = 'Cue.SAU.FallingShadow';
+
+/** Ticks before detonation that the falling-shadow warning cue is emitted. */
+const SAU_SHADOW_LEAD_TICKS = 2;
+
+/**
+ * ArtilleryShellSystem — detonates SAU shells and sprays shrapnel.
+ *
+ * System order (documented): AttackSystem → abilities (Hook.SAU.Fire spawns the
+ * shell) → **ArtilleryShellSystem** → GravitySystem → physicsSystem →
+ * ShrapnelLandingSystem. Running before GravitySystem/physicsSystem means
+ * shrapnel spawned this tick gets its first gravity + integration step in the
+ * same tick it is born.
+ *
+ * On the detonation tick it applies the primary AoE (enemy-only by default; see
+ * {@link SAU_FRIENDLY_FIRE}) around the snapshotted impact point, spawns N
+ * gravity-affected shrapnel fragments along a deterministic cone (seeded via
+ * {@link GameRandom} so replays match), emits the impact cue, and returns the
+ * shell to the pool. A one-shot falling-shadow cue fires
+ * {@link SAU_SHADOW_LEAD_TICKS} ticks earlier.
+ */
+export class ArtilleryShellSystem extends GameSystem {
+  private get _abilities(): AbilitySystem | undefined {
+    return this.abilities as AbilitySystem | undefined;
+  }
+
+  public override processTick(tick: number): void {
+    const physics = this.physics as PhysicsWorld | undefined;
+    if (!physics) return;
+
+    const shells = this.entityManager.queryEntities(
+      ComponentType.ArtilleryShell
+    );
+
+    for (const entity of shells) {
+      const shell = entity.getComponent<ArtilleryShellComponent>(
+        ComponentType.ArtilleryShell
+      );
+      if (!shell) continue;
+      if ((entity as { active?: boolean }).active === false) continue;
+
+      // One-shot falling-shadow warning ahead of detonation.
+      if (
+        !shell.shadowEmitted &&
+        tick >= shell.detonateTick - SAU_SHADOW_LEAD_TICKS
+      ) {
+        this.emitCue(SAU_FALLING_SHADOW_CUE_ID, entity.id, tick);
+        shell.shadowEmitted = true;
+      }
+
+      if (tick < shell.detonateTick) continue;
+
+      this.detonate(entity as ArtilleryShellEntity, shell, physics, tick);
+    }
+  }
+
+  private detonate(
+    entity: ArtilleryShellEntity,
+    shell: ArtilleryShellComponent,
+    physics: PhysicsWorld,
+    tick: number
+  ): void {
+    const ip = shell.impactPoint;
+
+    // Primary AoE around the impact point.
+    this.applyAoE(
+      ip.x,
+      ip.z,
+      shell.primaryRadius,
+      shell.teamId,
+      shell.primaryEffectId,
+      shell.sourceEntityId,
+      physics
+    );
+
+    this.emitCue(SAU_IMPACT_CUE_ID, entity.id, tick);
+
+    this.spawnShrapnel(shell, physics);
+
+    this.pools?.despawn(entity);
+  }
+
+  private spawnShrapnel(
+    shell: ArtilleryShellComponent,
+    physics: PhysicsWorld
+  ): void {
+    const pools = this.pools;
+    if (!pools) return;
+
+    const { count, cone, speed } = shell.shrapnelConfig;
+    const speedF = FP.ToFloat(speed);
+    const coneF = FP.ToFloat(cone);
+    const useRng = GameRandom.isInitialized();
+
+    for (let i = 0; i < count; i++) {
+      // Deterministic cone direction (upward-biased). Seeded RNG keeps replays
+      // in lockstep; when uninitialized (e.g. isolated tests) fall back to an
+      // even fan so behaviour stays deterministic without a seed.
+      const azimuth = useRng
+        ? GameRandom.rng.floatRange(0, Math.PI * 2)
+        : (Math.PI * 2 * i) / count;
+      const polar = useRng
+        ? GameRandom.rng.floatRange(0, coneF)
+        : coneF * 0.5;
+
+      const sinP = Math.sin(polar);
+      const dirX = sinP * Math.cos(azimuth);
+      const dirZ = sinP * Math.sin(azimuth);
+      const dirY = Math.cos(polar); // mostly upward
+
+      const shrapnel = pools.spawn<ShrapnelEntity>('shrapnel', {
+        fpPosition: shell.impactPoint,
+        sourceEntityId: shell.sourceEntityId,
+        teamId: shell.teamId,
+        secondaryEffectId: shell.secondaryEffectId,
+        secondaryRadius: shell.secondaryRadius,
+      });
+
+      physics.applyImpulse3D(
+        shrapnel.id,
+        FP.FromFloat(dirX * speedF),
+        FP.FromFloat(dirY * speedF),
+        FP.FromFloat(dirZ * speedF)
+      );
+    }
+  }
+
+  private applyAoE(
+    cx: FixedPoint,
+    cz: FixedPoint,
+    radius: FixedPoint,
+    sourceTeam: number,
+    effectId: string,
+    sourceEntityId: number,
+    physics: PhysicsWorld
+  ): void {
+    const abilities = this._abilities;
+    if (!abilities) return;
+
+    const radiusSq = FP.Mul(radius, radius);
+    const nearby = physics.spatialGrid.queryRadius(cx, cz, radius);
+
+    for (const id of nearby) {
+      const entity = this.entityManager.getEntity(id);
+      if (!entity) continue;
+
+      const stats = entity.getComponent<StatsComponent>(
+        ComponentType.UnitStats
+      );
+      if (!stats?.alive) continue;
+
+      const team = entity.getComponent<TeamComponent>(ComponentType.Team);
+      if (!SAU_FRIENDLY_FIRE && team && team.teamId === sourceTeam) continue;
+
+      // queryRadius is grid-cell coarse; confirm the true XZ distance.
+      const pos = physics.getEntityPosition(id);
+      if (pos) {
+        const dx = FP.Sub(pos.x, cx);
+        const dz = FP.Sub(pos.z, cz);
+        const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+        if (FP.Gt(d2, radiusSq)) continue;
+      }
+
+      abilities.applyEffect(id, effectId, sourceEntityId);
+    }
+  }
+
+  private emitCue(cueId: string, sourceEntityId: number, tick: number): void {
+    const event: GameplayCueDispatchedEvent = {
+      tick,
+      cueId,
+      sourceEntityId,
+      targetEntityId: sourceEntityId,
+      phase: 'OnApplied',
+    };
+    this.eventBus.emit(gameplayCueKey(cueId), event);
+  }
+}

--- a/abilities-playground/src/systems/ShrapnelLandingSystem.ts
+++ b/abilities-playground/src/systems/ShrapnelLandingSystem.ts
@@ -1,0 +1,180 @@
+import { GameSystem } from '@phalanx-engine/ecs';
+import type { AbilitySystem } from '@phalanx-engine/abilities';
+import {
+  gameplayCueKey,
+  type GameplayCueDispatchedEvent,
+} from '@phalanx-engine/abilities';
+import { PhysicsWorld } from '@phalanx-engine/physics';
+import type { TransformComponent } from '@phalanx-engine/physics';
+import { FP, type FixedPoint } from '@phalanx-engine/math';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+} from '../components';
+import { ShrapnelPayloadComponent } from '../components/ShrapnelPayloadComponent';
+import type { ShrapnelEntity } from '../entities/Shrapnel';
+import { SAU_FRIENDLY_FIRE } from '../config/abilityDefinitions';
+import { SAU_GROUND_Y } from '../config/constants';
+
+export const SAU_SECONDARY_IMPACT_CUE_ID = 'Cue.SAU.SecondaryImpact';
+
+const GROUND_Y = FP.FromFloat(SAU_GROUND_Y);
+
+/** A world-space ground landing point. */
+export interface GroundLanding {
+  x: FixedPoint;
+  y: FixedPoint;
+  z: FixedPoint;
+}
+
+/**
+ * Pure swept ground-plane crossing test for a prev→cur segment.
+ *
+ * Returns the interpolated landing point when the segment crosses `groundY`
+ * downward (prevY > groundY && curY <= groundY), else `null`. The lerp
+ * denominator (prevY - curY) is strictly positive under that condition, but we
+ * still guard it explicitly because `FP.Div` throws on divide-by-zero.
+ *
+ * TODO(v2): raycast the prev→cur segment against building AABBs first (via
+ * PhysicsWorld.raycastSegment) and prefer the nearer of building-hit vs ground.
+ */
+export function computeGroundLanding(
+  prevX: FixedPoint,
+  prevY: FixedPoint,
+  prevZ: FixedPoint,
+  curX: FixedPoint,
+  curY: FixedPoint,
+  curZ: FixedPoint,
+  groundY: FixedPoint = GROUND_Y
+): GroundLanding | null {
+  if (!(FP.Gt(prevY, groundY) && FP.Lte(curY, groundY))) return null;
+
+  const denom = FP.Sub(prevY, curY);
+  if (FP.Eq(denom, FP._0)) {
+    // Degenerate (should not happen given the crossing condition) — land at cur.
+    return { x: curX, y: groundY, z: curZ };
+  }
+
+  const t = FP.Div(FP.Sub(prevY, groundY), denom);
+  return {
+    x: FP.Lerp(prevX, curX, t),
+    y: groundY,
+    z: FP.Lerp(prevZ, curZ, t),
+  };
+}
+
+/**
+ * ShrapnelLandingSystem — resolves shrapnel fragments when they hit the ground.
+ *
+ * Runs after physicsSystem (which integrated this tick's position). For each
+ * fragment it sweeps its previous→current position for a ground-plane crossing;
+ * on landing it applies the secondary AoE (enemy-only by default) around the
+ * exact landing point, emits the secondary-impact cue, and returns the fragment
+ * to the pool. The secondary is resolved from the original firing unit's id, so
+ * it still lands even if that unit has since died (applyEffect only needs the
+ * source id for attribution, not a live entity).
+ *
+ * v1 lands on the ground plane only; there is no building-AABB infrastructure in
+ * the playground yet — see {@link computeGroundLanding} for the v2 extension.
+ */
+export class ShrapnelLandingSystem extends GameSystem {
+  private get _abilities(): AbilitySystem | undefined {
+    return this.abilities as AbilitySystem | undefined;
+  }
+
+  public override processTick(tick: number): void {
+    const physics = this.physics as PhysicsWorld | undefined;
+    if (!physics) return;
+
+    const fragments = this.entityManager.queryEntities(
+      ComponentType.ShrapnelPayload,
+      ComponentType.Transform
+    );
+
+    for (const entity of fragments) {
+      if ((entity as { active?: boolean }).active === false) continue;
+
+      const payload = entity.getComponent<ShrapnelPayloadComponent>(
+        ComponentType.ShrapnelPayload
+      );
+      const transform = entity.getComponent<TransformComponent>(
+        ComponentType.Transform
+      );
+      if (!payload || !transform || payload.landed) continue;
+
+      const cur = transform.fpPosition;
+      const landing = computeGroundLanding(
+        payload.prevPosX,
+        payload.prevPosY,
+        payload.prevPosZ,
+        cur.x,
+        cur.y,
+        cur.z
+      );
+
+      if (!landing) {
+        // No crossing yet: advance the swept-segment origin for next tick.
+        payload.prevPosX = cur.x;
+        payload.prevPosY = cur.y;
+        payload.prevPosZ = cur.z;
+        continue;
+      }
+
+      payload.landed = true;
+      this.resolveSecondary(payload, landing, physics);
+      this.emitCue(SAU_SECONDARY_IMPACT_CUE_ID, entity.id, tick);
+      this.pools?.despawn(entity as ShrapnelEntity);
+    }
+  }
+
+  private resolveSecondary(
+    payload: ShrapnelPayloadComponent,
+    landing: GroundLanding,
+    physics: PhysicsWorld
+  ): void {
+    const abilities = this._abilities;
+    if (!abilities) return;
+
+    const radiusSq = FP.Mul(payload.secondaryRadius, payload.secondaryRadius);
+    const nearby = physics.spatialGrid.queryRadius(
+      landing.x,
+      landing.z,
+      payload.secondaryRadius
+    );
+
+    for (const id of nearby) {
+      const entity = this.entityManager.getEntity(id);
+      if (!entity) continue;
+
+      const stats = entity.getComponent<StatsComponent>(
+        ComponentType.UnitStats
+      );
+      if (!stats?.alive) continue;
+
+      const team = entity.getComponent<TeamComponent>(ComponentType.Team);
+      if (!SAU_FRIENDLY_FIRE && team && team.teamId === payload.teamId) continue;
+
+      const pos = physics.getEntityPosition(id);
+      if (pos) {
+        const dx = FP.Sub(pos.x, landing.x);
+        const dz = FP.Sub(pos.z, landing.z);
+        const d2 = FP.Add(FP.Mul(dx, dx), FP.Mul(dz, dz));
+        if (FP.Gt(d2, radiusSq)) continue;
+      }
+
+      abilities.applyEffect(id, payload.secondaryEffectId, payload.sourceEntityId);
+    }
+  }
+
+  private emitCue(cueId: string, sourceEntityId: number, tick: number): void {
+    const event: GameplayCueDispatchedEvent = {
+      tick,
+      cueId,
+      sourceEntityId,
+      targetEntityId: sourceEntityId,
+      phase: 'OnApplied',
+    };
+    this.eventBus.emit(gameplayCueKey(cueId), event);
+  }
+}

--- a/abilities-playground/src/systems/index.ts
+++ b/abilities-playground/src/systems/index.ts
@@ -1,3 +1,4 @@
+export { ArtilleryShellSystem } from './ArtilleryShellSystem';
 export { AttackSystem } from './AttackSystem';
 export { ChainLightningJumpSystem } from './ChainLightningJumpSystem';
 export { CubeTargetingSystem } from './CubeTargetingSystem';
@@ -13,5 +14,6 @@ export { ProjectileMovementSystem } from './ProjectileMovementSystem';
 export { ProjectileDespawnQueueSystem } from './ProjectileDespawnQueueSystem';
 export { RenderSyncSystem } from './RenderSyncSystem';
 export { RotationSystem } from './RotationSystem';
+export { ShrapnelLandingSystem } from './ShrapnelLandingSystem';
 export { TargetingSystem } from './TargetingSystem';
 export { VoltAttackSystem } from './VoltAttackSystem';

--- a/abilities-playground/src/units/UnitDefinition.ts
+++ b/abilities-playground/src/units/UnitDefinition.ts
@@ -3,7 +3,7 @@ import type { UnitType, UnitGridSize } from './UnitType';
 /** View-layer description (geometry + decorations). Data, not behavior. */
 export interface UnitVisualSpec {
   readonly shape:
-    'sphere' | 'box' | 'cone' | 'octahedron' | 'volt' | 'plasmaTank';
+    'sphere' | 'box' | 'cone' | 'octahedron' | 'volt' | 'plasmaTank' | 'sau';
   readonly size: number; // sphere radius / box edge / cone radius / etc.
   readonly hasSpawnArrow: boolean;
   readonly hasAuraRing: boolean;

--- a/abilities-playground/src/units/UnitType.ts
+++ b/abilities-playground/src/units/UnitType.ts
@@ -5,6 +5,7 @@ export const UnitType = {
   Rocket: 'rocket',
   Volt: 'volt',
   PlasmaTank: 'plasmaTank',
+  Sau: 'sau',
 } as const;
 
 export type UnitType = (typeof UnitType)[keyof typeof UnitType];
@@ -25,4 +26,5 @@ export const UNIT_GRID_SIZE: Readonly<Record<UnitType, UnitGridSize>> = {
   [UnitType.Rocket]: { width: 2, depth: 1 },
   [UnitType.Volt]: { width: 1, depth: 1 },
   [UnitType.PlasmaTank]: { width: 1, depth: 1 },
+  [UnitType.Sau]: { width: 1, depth: 2 },
 } as const;

--- a/abilities-playground/src/units/unitDefinitions.ts
+++ b/abilities-playground/src/units/unitDefinitions.ts
@@ -10,6 +10,10 @@ import {
   ROCKET_DETECTION_RANGE,
   ROCKET_MAX_HEALTH,
   ROCKET_STOP_RANGE,
+  SAU_COOLDOWN_TICKS,
+  SAU_DETECTION_RANGE,
+  SAU_MAX_HEALTH,
+  SAU_STOP_RANGE,
   VOLT_DETECTION_RANGE,
 } from '../config/abilityDefinitions';
 
@@ -119,6 +123,29 @@ export const UNIT_DEFINITIONS: Readonly<Record<UnitType, UnitDefinition>> = {
     visual: {
       shape: 'plasmaTank',
       size: 2.2,
+      hasSpawnArrow: false,
+      hasAuraRing: false,
+    },
+  },
+  [UnitType.Sau]: {
+    type: UnitType.Sau,
+    radius: 2.2,
+    mass: 4,
+    stopRange: SAU_STOP_RANGE,
+    maxHealth: SAU_MAX_HEALTH,
+    detectionRange: SAU_DETECTION_RANGE,
+    heightOffset: 2.5,
+    gridSize: { width: 1, depth: 2 },
+    abilities: ['Ability.SAU.Artillery'],
+    hasAutoAttackTimer: true,
+    hasCubeState: false,
+    autoAttack: {
+      abilityId: 'Ability.SAU.Artillery',
+      cooldownTicks: SAU_COOLDOWN_TICKS,
+    },
+    visual: {
+      shape: 'sau',
+      size: 3.8,
       hasSpawnArrow: false,
       hasAuraRing: false,
     },

--- a/abilities-playground/src/units/unitVisuals.ts
+++ b/abilities-playground/src/units/unitVisuals.ts
@@ -81,6 +81,8 @@ function createBody(
       return createVoltBody(spec.size, teamId, unitType);
     case 'plasmaTank':
       return createPlasmaTankBody(spec.size, teamId, unitType);
+    case 'sau':
+      return createSauBody(spec.size, teamId, unitType);
   }
 }
 
@@ -272,6 +274,166 @@ function createPlasmaTankBody(
   barrel.position.set(0, turretY, barrelCenterZ);
   enableShadows(barrel);
   root.add(barrel);
+
+  return root;
+}
+
+/**
+ * SAU (self-propelled artillery) visual: a hover artillery tank.
+ *
+ * Ported from the finalized concept: a hovering platform + layered hull with a
+ * rounded bow, a boxy turret, and a long elevated barrel. The model is authored
+ * with its long axis along local +X and its barrel toward +X; the outer root is
+ * yawed -90° so the barrel points +Z (the engine's forward axis, matching the
+ * other units and `SauMuzzleFlashCue`'s muzzle offset). `size` scales the whole
+ * assembly (size 3.8 reproduces the concept's 1.3× scale).
+ */
+function createSauBody(
+  size: number,
+  teamId: TeamId,
+  unitType: UnitType
+): THREE.Object3D {
+  const root = new THREE.Group();
+  const model = new THREE.Group();
+  root.add(model);
+
+  const hullMat = createTeamMaterial(teamId, unitType);
+  const hullLoMat = new THREE.MeshStandardMaterial({
+    color: resolveUnitColor(teamId, unitType),
+    roughness: 0.85,
+    metalness: 0.15,
+  });
+  hullLoMat.color.multiplyScalar(0.7);
+  const turretMat = createTeamMaterial(teamId, unitType);
+  const gunMat = new THREE.MeshStandardMaterial({
+    color: 0x35393d,
+    roughness: 0.55,
+    metalness: 0.45,
+  });
+  const darkMat = new THREE.MeshStandardMaterial({
+    color: 0x2a2d30,
+    roughness: 0.7,
+    metalness: 0.3,
+  });
+  const detailMat = new THREE.MeshStandardMaterial({
+    color: resolveUnitColor(teamId, unitType),
+    roughness: 0.8,
+    metalness: 0.1,
+  });
+  detailMat.color.multiplyScalar(0.85);
+  const platformMat = new THREE.MeshStandardMaterial({
+    color: 0x2b3022,
+    roughness: 0.6,
+    metalness: 0.35,
+  });
+
+  const HOVER_Y = 1.15;
+
+  const add = (
+    geometry: THREE.BufferGeometry,
+    material: THREE.Material,
+    x: number,
+    y: number,
+    z: number,
+    castShadow = true
+  ): THREE.Mesh => {
+    const mesh = new THREE.Mesh(geometry, material);
+    mesh.position.set(x, y, z);
+    if (castShadow) mesh.castShadow = true;
+    model.add(mesh);
+    return mesh;
+  };
+
+  // Hover platform + skirt.
+  add(new THREE.BoxGeometry(4.5, 0.34, 2.05), platformMat, -0.1, 0.66, 0);
+  add(new THREE.BoxGeometry(4.5, 0.2, 2.05), darkMat, -0.1, HOVER_Y - 0.4, 0, false);
+
+  // Hull stack.
+  add(new THREE.BoxGeometry(4.4, 1.0, 1.95), hullLoMat, -0.1, HOVER_Y, 0);
+  const bow = add(
+    new THREE.CylinderGeometry(0.5, 0.5, 1.95, 24),
+    hullLoMat,
+    2.1,
+    HOVER_Y,
+    0
+  );
+  bow.rotation.x = Math.PI / 2;
+  add(new THREE.BoxGeometry(4.1, 0.55, 1.78), hullMat, -0.1, HOVER_Y + 0.62, 0);
+  add(new THREE.BoxGeometry(0.9, 0.6, 1.6), detailMat, -2.05, HOVER_Y + 0.6, 0);
+
+  // Turret.
+  add(new THREE.BoxGeometry(2.4, 0.78, 1.8), turretMat, -0.25, HOVER_Y + 1.27, 0);
+  add(new THREE.BoxGeometry(2.0, 0.12, 1.45), detailMat, -0.25, HOVER_Y + 1.7, 0);
+  const cupola = add(
+    new THREE.CylinderGeometry(0.3, 0.32, 0.34, 16),
+    detailMat,
+    0,
+    HOVER_Y + 1.92,
+    -0.45
+  );
+  cupola.castShadow = true;
+  add(
+    new THREE.CylinderGeometry(0.23, 0.23, 0.08, 16),
+    darkMat,
+    -0.95,
+    HOVER_Y + 1.74,
+    0.45,
+    false
+  );
+  add(new THREE.BoxGeometry(0.5, 0.62, 1.0), gunMat, 1.0, HOVER_Y + 1.22, 0);
+
+  // Barrel assembly (elevated, along +X local).
+  const barrelGroup = new THREE.Group();
+  barrelGroup.position.set(1.1, HOVER_Y + 1.22, 0);
+  barrelGroup.rotation.z = 0.28;
+  model.add(barrelGroup);
+  const barrel = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.14, 0.15, 5.6, 24),
+    gunMat
+  );
+  barrel.rotation.z = -Math.PI / 2;
+  barrel.position.x = 2.8;
+  barrel.castShadow = true;
+  barrelGroup.add(barrel);
+  const fume = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.22, 0.22, 0.55, 20),
+    darkMat
+  );
+  fume.rotation.z = -Math.PI / 2;
+  fume.position.x = 4.0;
+  barrelGroup.add(fume);
+  const muzzle = new THREE.Mesh(
+    new THREE.CylinderGeometry(0.2, 0.17, 0.55, 20),
+    darkMat
+  );
+  muzzle.rotation.z = -Math.PI / 2;
+  muzzle.position.x = 5.5;
+  barrelGroup.add(muzzle);
+
+  // Antenna + side exhaust.
+  const antenna = add(
+    new THREE.CylinderGeometry(0.022, 0.022, 1.7, 6),
+    darkMat,
+    -1.35,
+    HOVER_Y + 2.45,
+    0.55
+  );
+  antenna.castShadow = true;
+  const exhaust = add(
+    new THREE.CylinderGeometry(0.13, 0.13, 0.95, 12),
+    darkMat,
+    -2.4,
+    HOVER_Y + 0.5,
+    0.5,
+    false
+  );
+  exhaust.rotation.z = Math.PI / 2;
+
+  // Lower the assembly so its mass centers near the group origin, then yaw so
+  // the barrel faces +Z and scale to the requested size (3.8 → concept 1.3×).
+  model.position.y = -HOVER_Y;
+  root.rotation.y = -Math.PI / 2;
+  root.scale.setScalar(size * 0.342);
 
   return root;
 }

--- a/abilities-playground/tests/SauArtillery.test.ts
+++ b/abilities-playground/tests/SauArtillery.test.ts
@@ -1,0 +1,367 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  Entity,
+  EntityManager,
+  EventBus,
+  SoAComponent,
+  SystemContext,
+} from '@phalanx-engine/ecs';
+import type { GameWorld } from '@phalanx-engine/ecs';
+import { FP, FPVector3 } from '@phalanx-engine/math';
+import {
+  TransformComponent,
+  TRANSFORM_COMPONENT_TYPE,
+} from '@phalanx-engine/physics';
+import {
+  ComponentType,
+  StatsComponent,
+  TeamComponent,
+  ArtilleryShellComponent,
+  ShrapnelPayloadComponent,
+} from '../src/components';
+import { ArtilleryShellSystem } from '../src/systems/ArtilleryShellSystem';
+import {
+  ShrapnelLandingSystem,
+  computeGroundLanding,
+} from '../src/systems/ShrapnelLandingSystem';
+import { sauArtillery } from '../src/hooks/SauArtillery';
+import { GameRandom } from '../src/core/GameRandom';
+import {
+  SAU_SHRAPNEL_COUNT,
+  SAU_MIN_ENGAGEMENT_RANGE,
+} from '../src/config/abilityDefinitions';
+import {
+  SAU_SHRAPNEL_CONE,
+  SAU_SHRAPNEL_SPEED,
+} from '../src/config/constants';
+
+function makeManager(): EntityManager {
+  const entityManager = new EntityManager();
+  entityManager.registerComponentTypes([
+    TRANSFORM_COMPONENT_TYPE,
+    ComponentType.Team,
+    ComponentType.UnitStats,
+    ComponentType.ArtilleryShell,
+    ComponentType.ShrapnelPayload,
+  ]);
+  SoAComponent.useEntityManager(entityManager);
+  return entityManager;
+}
+
+function addTransformUnit(
+  entityManager: EntityManager,
+  pos: { x: number; y: number; z: number },
+  teamId: 0 | 1
+): Entity {
+  const entity = new Entity();
+  entity.addComponent(
+    new TransformComponent(
+      entity.id,
+      FPVector3.FromFloat(pos.x, pos.y, pos.z)
+    )
+  );
+  entity.addComponent(new TeamComponent(teamId));
+  entityManager.addEntity(entity);
+  entityManager.onComponentAdded(entity, TRANSFORM_COMPONENT_TYPE);
+  entityManager.onComponentAdded(entity, ComponentType.Team);
+  return entity;
+}
+
+describe('computeGroundLanding (FP safety + landing point)', () => {
+  it('returns null when the segment does not cross the ground plane', () => {
+    // Both endpoints above ground.
+    expect(
+      computeGroundLanding(
+        FP.FromFloat(0),
+        FP.FromFloat(5),
+        FP.FromFloat(0),
+        FP.FromFloat(0),
+        FP.FromFloat(2),
+        FP.FromFloat(0)
+      )
+    ).toBeNull();
+    // Ascending (below → above) is not a downward crossing.
+    expect(
+      computeGroundLanding(
+        FP.FromFloat(0),
+        FP.FromFloat(-1),
+        FP.FromFloat(0),
+        FP.FromFloat(0),
+        FP.FromFloat(3),
+        FP.FromFloat(0)
+      )
+    ).toBeNull();
+  });
+
+  it('interpolates the exact crossing point without dividing by zero', () => {
+    // prevY=5 → curY=-1 over dx=2..2 dz=3..3 crosses at t=5/6.
+    const landing = computeGroundLanding(
+      FP.FromFloat(2),
+      FP.FromFloat(5),
+      FP.FromFloat(3),
+      FP.FromFloat(2),
+      FP.FromFloat(-1),
+      FP.FromFloat(3)
+    );
+    expect(landing).not.toBeNull();
+    expect(FP.ToFloat(landing!.x)).toBeCloseTo(2, 5);
+    expect(FP.ToFloat(landing!.y)).toBeCloseTo(0, 5);
+    expect(FP.ToFloat(landing!.z)).toBeCloseTo(3, 5);
+  });
+
+  it('never throws across many crossing configurations (FP.Div guard)', () => {
+    for (let i = 1; i <= 50; i++) {
+      const prevY = FP.FromFloat(i * 0.13);
+      const curY = FP.FromFloat(-i * 0.07);
+      expect(() =>
+        computeGroundLanding(
+          FP.FromFloat(i),
+          prevY,
+          FP.FromFloat(-i),
+          FP.FromFloat(i + 1),
+          curY,
+          FP.FromFloat(-i - 1)
+        )
+      ).not.toThrow();
+    }
+  });
+});
+
+describe('sauArtillery hook', () => {
+  let entityManager: EntityManager;
+  let spawn: ReturnType<typeof vi.fn>;
+  let world: GameWorld;
+
+  beforeEach(() => {
+    entityManager = makeManager();
+    spawn = vi.fn(() => ({ id: 9999 }));
+    world = {
+      entityManager,
+      eventBus: new EventBus(),
+      pools: { spawn },
+    } as unknown as GameWorld;
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function fireAt(target: Entity, caster: Entity): void {
+    sauArtillery(
+      {
+        tick: 100,
+        casterEntityId: caster.id,
+        resolvedTargets: [target.id],
+      } as never,
+      world
+    );
+  }
+
+  it('snapshots the impact point independent of later target movement', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const target = addTransformUnit(entityManager, { x: 0, y: 0, z: 50 }, 1);
+
+    fireAt(target, caster);
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const args = spawn.mock.calls[0][1] as {
+      impactPoint: { x: number; y: number; z: number };
+    };
+    const snapshotZ = FP.ToFloat(args.impactPoint.z);
+    expect(snapshotZ).toBeCloseTo(50, 3);
+
+    // Move the target far away; the already-snapshotted impact must not change.
+    const targetTransform = target.getComponent<TransformComponent>(
+      ComponentType.Transform
+    )!;
+    targetTransform.fpPosition = FPVector3.FromFloat(0, 0, 999);
+    expect(FP.ToFloat(args.impactPoint.z)).toBeCloseTo(snapshotZ, 3);
+  });
+
+  it('refuses to fire on enemies inside the minimum engagement range', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const near = addTransformUnit(
+      entityManager,
+      { x: 0, y: 0, z: SAU_MIN_ENGAGEMENT_RANGE - 5 },
+      1
+    );
+    fireAt(near, caster);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('fires on enemies beyond the minimum engagement range', () => {
+    const caster = addTransformUnit(entityManager, { x: 0, y: 0, z: 0 }, 0);
+    const far = addTransformUnit(
+      entityManager,
+      { x: 0, y: 0, z: SAU_MIN_ENGAGEMENT_RANGE + 20 },
+      1
+    );
+    fireAt(far, caster);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ArtilleryShellSystem shrapnel determinism', () => {
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function runDetonation(seed: number): Array<[number, number, number]> {
+    GameRandom.initialize(seed);
+    const entityManager = makeManager();
+    const context = new SystemContext(new EventBus(), entityManager);
+    const impulses: Array<[number, number, number]> = [];
+    let nextId = 5000;
+    context.physics = {
+      spatialGrid: { queryRadius: () => [] as number[] },
+      getEntityPosition: () => undefined,
+      applyImpulse3D: (_id: number, vx: number, vy: number, vz: number) => {
+        impulses.push([FP.ToRaw(vx), FP.ToRaw(vy), FP.ToRaw(vz)]);
+      },
+    } as never;
+    context.abilities = { applyEffect: vi.fn() } as never;
+    context.pools = {
+      spawn: () => ({ id: nextId++ }),
+      despawn: vi.fn(),
+    } as never;
+
+    const shellEntity = new Entity();
+    const shell = new ArtilleryShellComponent();
+    shell.sourceEntityId = 1;
+    shell.teamId = 0;
+    shell.detonateTick = 0;
+    shell.primaryRadius = FP._0;
+    shell.secondaryRadius = FP.FromFloat(5);
+    shell.shrapnelConfig = {
+      count: SAU_SHRAPNEL_COUNT,
+      cone: FP.FromFloat(SAU_SHRAPNEL_CONE),
+      speed: FP.FromFloat(SAU_SHRAPNEL_SPEED),
+    };
+    shellEntity.addComponent(shell);
+    entityManager.addEntity(shellEntity);
+    entityManager.onComponentAdded(shellEntity, ComponentType.ArtilleryShell);
+
+    const system = new ArtilleryShellSystem();
+    system.init(context);
+    system.processTick(0);
+    return impulses;
+  }
+
+  it('spawns SAU_SHRAPNEL_COUNT fragments', () => {
+    const impulses = runDetonation(42);
+    expect(impulses).toHaveLength(SAU_SHRAPNEL_COUNT);
+  });
+
+  it('produces identical impulses for the same seed', () => {
+    const a = runDetonation(1234);
+    const b = runDetonation(1234);
+    expect(b).toEqual(a);
+  });
+});
+
+describe('ShrapnelLandingSystem secondary blast', () => {
+  let entityManager: EntityManager;
+  let context: SystemContext;
+  let applyEffect: ReturnType<typeof vi.fn>;
+  let queryRadius: ReturnType<typeof vi.fn>;
+  let despawn: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    entityManager = makeManager();
+    context = new SystemContext(new EventBus(), entityManager);
+    applyEffect = vi.fn();
+    despawn = vi.fn();
+    queryRadius = vi.fn();
+    context.abilities = { applyEffect } as never;
+    context.pools = { despawn, spawn: vi.fn() } as never;
+  });
+
+  afterEach(() => {
+    SoAComponent.resetContext();
+  });
+
+  function addShrapnel(sourceEntityId: number): Entity {
+    const entity = new Entity();
+    // Current position is below ground (crossed this tick).
+    entity.addComponent(
+      new TransformComponent(entity.id, FPVector3.FromFloat(2, -1, 3))
+    );
+    const payload = new ShrapnelPayloadComponent();
+    payload.sourceEntityId = sourceEntityId;
+    payload.teamId = 0;
+    payload.secondaryEffectId = 'Effect.Damage.SAU.Secondary';
+    payload.secondaryRadius = FP.FromFloat(5);
+    payload.prevPosX = FP.FromFloat(2);
+    payload.prevPosY = FP.FromFloat(5);
+    payload.prevPosZ = FP.FromFloat(3);
+    entity.addComponent(payload);
+    entityManager.addEntity(entity);
+    entityManager.onComponentAdded(entity, TRANSFORM_COMPONENT_TYPE);
+    entityManager.onComponentAdded(entity, ComponentType.ShrapnelPayload);
+    return entity;
+  }
+
+  function addVictim(): Entity {
+    const entity = new Entity();
+    const stats = new StatsComponent({ stopRange: 1 });
+    stats.alive = true;
+    entity.addComponent(stats);
+    entity.addComponent(new TeamComponent(1));
+    entityManager.addEntity(entity);
+    entityManager.onComponentAdded(entity, ComponentType.UnitStats);
+    entityManager.onComponentAdded(entity, ComponentType.Team);
+    return entity;
+  }
+
+  it('applies the secondary effect at the exact ground landing point', () => {
+    const victim = addVictim();
+    queryRadius.mockReturnValue([victim.id]);
+    context.physics = {
+      spatialGrid: { queryRadius },
+      getEntityPosition: () => ({ x: FP.FromFloat(2), z: FP.FromFloat(3) }),
+    } as never;
+
+    const shrapnel = addShrapnel(1);
+    const system = new ShrapnelLandingSystem();
+    system.init(context);
+    system.processTick(0);
+
+    // Queried around the interpolated landing point (≈ x=2, z=3).
+    expect(queryRadius).toHaveBeenCalledTimes(1);
+    const [qx, qz] = queryRadius.mock.calls[0];
+    expect(FP.ToFloat(qx)).toBeCloseTo(2, 3);
+    expect(FP.ToFloat(qz)).toBeCloseTo(3, 3);
+
+    expect(applyEffect).toHaveBeenCalledWith(
+      victim.id,
+      'Effect.Damage.SAU.Secondary',
+      1
+    );
+    const payload = shrapnel.getComponent<ShrapnelPayloadComponent>(
+      ComponentType.ShrapnelPayload
+    )!;
+    expect(payload.landed).toBe(true);
+    expect(despawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('resolves the secondary even when the firing unit has already died', () => {
+    const victim = addVictim();
+    queryRadius.mockReturnValue([victim.id]);
+    context.physics = {
+      spatialGrid: { queryRadius },
+      getEntityPosition: () => ({ x: FP.FromFloat(2), z: FP.FromFloat(3) }),
+    } as never;
+
+    // Source id 777 has no live entity in the manager (caster is gone).
+    addShrapnel(777);
+    const system = new ShrapnelLandingSystem();
+    system.init(context);
+    system.processTick(0);
+
+    expect(applyEffect).toHaveBeenCalledWith(
+      victim.id,
+      'Effect.Damage.SAU.Secondary',
+      777
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Game-side Stage 2 of the САУ (self-propelled artillery) unit, built entirely within `abilities-playground` on top of the Stage-1 physics primitives from `feat/physics-gravity` (GravitySystem, `applyImpulse3D`, 3-axis integration, `useGravity`).

The SAU fires a **delayed-detonation artillery shell** (logic-only, no visible flying projectile). On the detonation tick it applies a primary AoE at a **snapshotted impact point** and sprays **N deterministic, gravity-affected shrapnel fragments** along a seeded cone. Each fragment resolves a secondary AoE at its **exact ground-landing point** (swept prev→cur crossing).

## Changes
- **Entities:** `ArtilleryShellEntity` (pooled, logic-only marker — no body/mesh), `ShrapnelEntity` (pooled, gravity-affected physics body, protected by the collision filter rather than `ignorePhysics`).
- **Components:** `ArtilleryShellComponent`, `ShrapnelPayloadComponent`.
- **Systems:** `ArtilleryShellSystem`, `ShrapnelLandingSystem`. Documented order: `AttackSystem → abilities (Hook.SAU.Fire) → ArtilleryShellSystem → GravitySystem → physicsSystem → ShrapnelLandingSystem`.
- **Ability / effects / cues:** `Ability.SAU.Artillery` (+ cooldown), primary & secondary damage effects, and presentation-only cues (muzzle flash, impact, secondary impact, falling-shadow warning).
- **Unit + visual:** `UnitType 'sau'` with mesh (`createSauBody`), palette colors, and a UI palette button.
- **Wiring:** `SimulationContainer` registers pools (`artilleryShell`, `shrapnel`), global gravity, systems in documented order, the hook, cues, and `resetBattle` cleanup; collision filter excludes shrapnel↔unit and shrapnel↔shrapnel pairs.
- **Gravity scope (v1):** global world gravity; only shrapnel bodies opt in via `useGravity`.
- **Ground landing:** ground-plane crossing only; the lerp denominator is guarded against divide-by-zero (`FP.Div` throws). `computeGroundLanding` carries a `TODO(v2)` extension point for building-AABB raycasts.

## Test plan
- [x] `corepack pnpm --filter abilities-playground exec vitest run` — 53 passed (10 new SAU tests)
- [x] `corepack pnpm -r build` — passes
- SAU test coverage: impact-point snapshot independent of target movement; RNG determinism (same seed → identical impulses); secondary AoE at the correct ground landing point; secondary resolves even after the firing unit dies; min-engagement-range gating; FP divide-by-zero safety across many crossing configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)